### PR TITLE
docs: add brew trust step to Homebrew install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Editing `/etc/hosts` by hand — or typing your password every time a hosts mana
 **Homebrew**
 
     brew tap heronapp/tap
+    brew trust heronapp/tap   # newer Homebrew requires trusting third-party taps once
     brew install --cask hostflip
 
 **Direct download**


### PR DESCRIPTION
Newer Homebrew refuses to install casks from untrusted third-party taps until `brew trust` is run once. Verified during the v0.1.0 install check on a machine running current Homebrew.

🤖 Generated with [Claude Code](https://claude.com/claude-code)