### PR TITLE
fix: correct fresh-install helper status and prepare v0.1.1

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -4,10 +4,10 @@
 <dict>
 	<key>CFBundleExecutable</key>
 	<string>Hostflip</string>
-	<key>CFBundleIdentifier</key>
-	<string>com.heronapp.hostflip</string>
 	<key>CFBundleIconFile</key>
 	<string>Hostflip.icns</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.heronapp.hostflip</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.0</string>
+	<string>0.1.1</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>2</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/Hostflip/HelperMaintenanceView.swift
+++ b/Sources/Hostflip/HelperMaintenanceView.swift
@@ -1,7 +1,7 @@
 import HostflipXPC
 import SwiftUI
 
-private struct HelperStatusPresentation {
+struct HelperStatusPresentation {
     let title: String
     let description: String
     let color: Color
@@ -22,16 +22,16 @@ private struct HelperStatusPresentation {
             color = .orange
             canRemove = true
             canOpenApprovalSettings = true
-        case .notRegistered:
+        case .notRegistered, .notFound:
+            // SMAppService reports .notFound for a daemon that was never
+            // registered (docs/helper-reregistration-verification.md step 1), so
+            // both states are the pristine "not installed yet" condition —
+            // registration is lazily triggered by the first switch (ADR-0002).
+            // A genuinely broken install (wrong location, policy block) surfaces
+            // through switch feedback, not through this passive light.
             title = "Helper Not Installed"
             description = "Switch a profile to install the helper. macOS may ask you to approve it."
             color = .secondary
-            canRemove = false
-            canOpenApprovalSettings = false
-        case .notFound:
-            title = "Helper Unavailable"
-            description = "The helper is unavailable. Move hostflip to Applications or reinstall the app."
-            color = .red
             canRemove = false
             canOpenApprovalSettings = false
         case nil:

--- a/Sources/Hostflip/MainWindowPresentation.swift
+++ b/Sources/Hostflip/MainWindowPresentation.swift
@@ -16,7 +16,6 @@ struct MainWindowPresentation: Equatable {
     let profilesAreEffective: Bool
     let activationControlsDisabled: Bool
     let showsEmptyState: Bool
-    let showsSwitchSuccess: Bool
 
     init(
         isPaused: Bool,
@@ -43,6 +42,5 @@ struct MainWindowPresentation: Equatable {
         self.profilesAreEffective = !isPaused
         self.activationControlsDisabled = isPaused || hasHostsDrift || isSwitching
         self.showsEmptyState = profileCount == 0
-        self.showsSwitchSuccess = switchFeedback == .merged && !hasHostsDrift
     }
 }

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -275,14 +275,6 @@ struct MainWindowView: View {
                 HelperToolbarControl(store: store, maintenanceStore: maintenanceStore)
             }
 
-            if presentation.showsSwitchSuccess {
-                ToolbarItem(placement: .automatic) {
-                    Label("Hosts Updated", systemImage: "checkmark.circle.fill")
-                        .font(.caption)
-                        .foregroundStyle(.green)
-                }
-            }
-
             ToolbarItem(placement: .automatic) {
                 Toggle("Enable hostflip", isOn: Binding(
                     get: { !store.isPaused },
@@ -299,9 +291,7 @@ struct MainWindowView: View {
             .hidingSharedBackgroundWhenAvailable()
         }
         .background {
-            NativeToolbarFlexibleSpace(
-                trailingItemCount: presentation.showsSwitchSuccess ? 2 : 1
-            )
+            NativeToolbarFlexibleSpace(trailingItemCount: 1)
         }
         .confirmationDialog(
             "Delete “\(profilePendingDeletion?.name ?? "")”?",

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -13,5 +13,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.1.0"
+    public static let version = "0.1.1"
 }

--- a/Tests/HostflipTests/HelperStatusPresentationTests.swift
+++ b/Tests/HostflipTests/HelperStatusPresentationTests.swift
@@ -1,0 +1,39 @@
+import SwiftUI
+import XCTest
+@testable import Hostflip
+@testable import HostflipXPC
+
+/// The passive helper status light. SMAppService reports `.notFound` for a
+/// daemon that has simply never been registered (see
+/// docs/helper-reregistration-verification.md step 1), so a fresh install must
+/// present it as "not installed yet", never as a broken state — genuine
+/// unavailability surfaces through switch feedback when a switch is attempted.
+final class HelperStatusPresentationTests: XCTestCase {
+    func testNeverRegisteredPresentsAsNotInstalledNotAsFailure() {
+        let presentation = HelperStatusPresentation(.notFound)
+        XCTAssertEqual(presentation.title, "Helper Not Installed")
+        XCTAssertNotEqual(presentation.color, .red)
+        XCTAssertFalse(presentation.description.localizedCaseInsensitiveContains("reinstall"))
+        XCTAssertFalse(presentation.canRemove)
+    }
+
+    func testNotRegisteredPresentsTheSamePristineGuidance() {
+        let notFound = HelperStatusPresentation(.notFound)
+        let notRegistered = HelperStatusPresentation(.notRegistered)
+        XCTAssertEqual(notRegistered.title, notFound.title)
+        XCTAssertEqual(notRegistered.description, notFound.description)
+    }
+
+    func testEnabledPresentsAsReadyAndRemovable() {
+        let presentation = HelperStatusPresentation(.enabled)
+        XCTAssertEqual(presentation.title, "Helper Ready")
+        XCTAssertTrue(presentation.canRemove)
+    }
+
+    func testRequiresApprovalIsActionableIntoSystemSettings() {
+        let presentation = HelperStatusPresentation(.requiresApproval)
+        XCTAssertEqual(presentation.title, "Helper Approval Required")
+        XCTAssertTrue(presentation.canOpenApprovalSettings)
+        XCTAssertTrue(presentation.canRemove)
+    }
+}

--- a/Tests/HostflipTests/MainWindowPresentationTests.swift
+++ b/Tests/HostflipTests/MainWindowPresentationTests.swift
@@ -34,7 +34,6 @@ final class MainWindowPresentationTests: XCTestCase {
         XCTAssertEqual(presentation.banner, .hostsDrift)
         XCTAssertTrue(presentation.profilesAreEffective)
         XCTAssertTrue(presentation.activationControlsDisabled)
-        XCTAssertFalse(presentation.showsSwitchSuccess)
     }
 
     func testApprovalRequiredIsActionableWithoutDisablingLocalEditing() {
@@ -84,7 +83,7 @@ final class MainWindowPresentationTests: XCTestCase {
         XCTAssertEqual(presentation.banner, .switchFeedback(feedback))
     }
 
-    func testSuccessfulSwitchUsesTransientToolbarFeedbackInsteadOfAFullWidthBanner() {
+    func testSuccessfulSwitchDoesNotUseAWarningBanner() {
         let presentation = MainWindowPresentation(
             isPaused: false,
             hasHostsDrift: false,
@@ -96,7 +95,6 @@ final class MainWindowPresentationTests: XCTestCase {
         )
 
         XCTAssertNil(presentation.banner)
-        XCTAssertTrue(presentation.showsSwitchSuccess)
     }
 
     func testBaseHostsReplacementUsesDedicatedBannerInsteadOfHostsUpdatedFeedback() {
@@ -111,7 +109,6 @@ final class MainWindowPresentationTests: XCTestCase {
         )
 
         XCTAssertEqual(presentation.banner, .switchFeedback(.baseHostsReplaced))
-        XCTAssertFalse(presentation.showsSwitchSuccess)
     }
 
     func testBackgroundSyncErrorUsesBannerAheadOfPausedState() {


### PR DESCRIPTION
Two fixes surfaced by clean-machine install verification, plus the version bump:

- **Never-registered helper presented as a failure**: SMAppService reports `.notFound` for a daemon that has simply never been registered, but the passive status light rendered it as a red "Helper Unavailable" with reinstall guidance on every fresh install. It now presents as neutral "Helper Not Installed" (registration is lazily triggered by the first switch); genuine breakage still surfaces through switch feedback. Pinned by new `HelperStatusPresentationTests`.
- **Redundant toolbar success indicator removed**: switch success already has menu bar toast feedback.
- Version 0.1.1 (build 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)