### PR TITLE
docs: warn that uninstalling leaves the hosts file as last written

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ An ad-hoc build verifies the packaging structure, but the XPC channel intentiona
 
 Use “Deactivate and Remove Helper…” in the app first (unregisters the daemon), then delete `Hostflip.app`. `brew uninstall --zap --cask hostflip` also clears application data.
 
+Note that `/etc/hosts` keeps whatever hostflip last wrote — uninstalling does not rewrite it, and entries from profiles that were active stay in effect. If you want only your baseline hosts applied, turn off the master switch (which restores Base Hosts) **before** removing the helper; once the helper is gone, hostflip can no longer write the file. Your pre-hostflip hosts file is preserved as `hosts.orig` in `~/Library/Application Support/hostflip` until that folder is zapped.
+
 ## License
 
 [MIT](LICENSE)

--- a/Sources/Hostflip/HelperMaintenanceView.swift
+++ b/Sources/Hostflip/HelperMaintenanceView.swift
@@ -168,7 +168,7 @@ struct HelperMaintenanceView: View {
                 Task { await maintenanceStore.removeHelper() }
             }
         } message: {
-            Text("hostflip will remove its privileged helper. Your profiles and base hosts will stay in the workspace. The helper will be requested again on your next switch.")
+            Text("hostflip will remove its privileged helper. Your profiles and base hosts will stay in the workspace. The helper will be requested again on your next switch.\n\nThe system hosts file keeps its current content — entries from active profiles stay in effect. To leave only Base Hosts applied (e.g. before uninstalling), turn off the master switch first.")
         }
     }
 


### PR DESCRIPTION
Uninstalling deliberately does not rewrite `/etc/hosts` (once the helper is unregistered the app has no privilege to write it, so a restore could only ever happen before removal). Make that explicit instead:

- The "Deactivate and Remove Helper" confirmation now states that the hosts file keeps its current content and points at the master switch for restoring Base Hosts first.
- README's Uninstall section explains the same, plus where the pre-hostflip `hosts.orig` backup lives and that zap removes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)