### PR TITLE
feat: sidebar alignment fix and in-group profile creation

### DIFF
--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -537,6 +537,12 @@ struct MainWindowView: View {
         profilePendingNameFocus = profileID
     }
 
+    private func createProfile(in groupID: HostflipCore.Group.ID) {
+        guard let profileID = store.createProfile(in: groupID) else { return }
+        selection = .profile(profileID)
+        profilePendingNameFocus = profileID
+    }
+
 
     private func createGroup() {
         guard let groupID = store.createGroup(),
@@ -638,6 +644,10 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private func groupActionButtons(_ group: HostflipCore.Group, index: Int) -> some View {
+        Button("New Profile") {
+            createProfile(in: group.id)
+        }
+        Divider()
         Button("Rename Group…") {
             beginRenaming(group)
         }

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -514,7 +514,6 @@ struct MainWindowView: View {
                         .fill(Color.primary.opacity(0.06))
                 }
             }
-            .padding(.leading, groupID == nil ? 0 : 14)
             .tag(SidebarItem.profile(profile.id))
             .modifier(sidebarDropTarget(.profileRow(profile.id, groupID: groupID, index: index)))
             .overlay(alignment: .top) {
@@ -537,6 +536,7 @@ struct MainWindowView: View {
         selection = .profile(profileID)
         profilePendingNameFocus = profileID
     }
+
 
     private func createGroup() {
         guard let groupID = store.createGroup(),
@@ -614,7 +614,10 @@ struct MainWindowView: View {
                     .fill(Color.primary.opacity(0.06))
             }
         }
-        .padding(.horizontal, 6)
+        // Counter the inner breathing-room padding so the title text left-aligns
+        // with the plain "Standalone Profiles" header; the hover box extends left.
+        .padding(.leading, -6)
+        .padding(.trailing, 6)
         .modifier(sidebarDropTarget(
             .groupHeader(group.id, index: index, memberCount: group.profiles.count)
         ))

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -223,6 +223,20 @@ final class WorkspaceStore {
         return profileID
     }
 
+    /// Same as createStandaloneProfile, but the new profile lands directly in the
+    /// group — a single edit, so one manifest write covers the add and the move.
+    @discardableResult
+    func createProfile(in groupID: Group.ID) -> Profile.ID? {
+        guard model != nil else { return nil }
+        let profileID = Profile.ID(UUID().uuidString)
+        let name = defaultProfileName()
+        applyEdit {
+            try $0.addProfile(id: profileID, name: name, content: "# Add hosts entries here\n")
+            try $0.moveProfile(profileID, toGroup: groupID)
+        }
+        return profileID
+    }
+
     func renameProfile(_ profileID: Profile.ID, to name: String) {
         guard let profile = profile(profileID),
               let normalized = normalizedRenameName(name, currentName: profile.name) else { return }

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -123,6 +123,21 @@ final class WorkspaceStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testCreateProfileInGroupLandsInGroupAndPersists() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let groupID = try XCTUnwrap(store.createGroup())
+
+        let profileID = try XCTUnwrap(store.createProfile(in: groupID))
+
+        XCTAssertEqual(store.standaloneProfiles, [])
+        XCTAssertEqual(store.groups.first?.profiles.map(\.id), [profileID])
+        XCTAssertFalse(store.isActive(profileID))
+
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.groups.first?.profiles.map(\.id), [profileID])
+    }
+
+    @MainActor
     func testCreateStandaloneProfileAvoidsDuplicateDefaultNames() throws {
         let store = makeStore(coordinator: SwitchCoordinatingStub())
 


### PR DESCRIPTION
Two commits:

- **fix: align sidebar group headers with the standalone header** — group header titles were pushed right by two layers of breathing-room padding; a negative leading offset restores a single alignment line. The extra indent on grouped profile rows goes too, since standalone rows never had one and section grouping already conveys membership.
- **feat: create a profile directly inside a group** — the group actions menu gains a New Profile entry: the profile is added and moved into the group in a single edit (one manifest write), then selected with its name focused for renaming, matching the standalone creation flow.

Verified: full test suite green (including a new persistence test for in-group creation); manually exercised in the signed build.