### PR TITLE
fix: render drift diff rows correctly in the review sheet

### DIFF
--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -1091,7 +1091,9 @@ private struct HostsDriftReviewSheet: View {
                         }
 
                         ScrollView([.horizontal, .vertical]) {
-                            LazyVStack(alignment: .leading, spacing: 0) {
+                            // A lazy stack collapses to a near-zero width proposal inside a
+                            // horizontal-axis ScrollView, wrapping every row character by character.
+                            VStack(alignment: .leading, spacing: 0) {
                                 ForEach(Array(comparison.diffRows.enumerated()), id: \.offset) { _, row in
                                     diffRow(row)
                                 }
@@ -1203,6 +1205,7 @@ private struct HostsDriftReviewSheet: View {
                 .frame(width: 12)
             Text(row.text.isEmpty ? " " : row.text)
                 .foregroundStyle(.primary)
+                .fixedSize(horizontal: true, vertical: false)
         }
         .font(.system(.body, design: .monospaced))
         .padding(.horizontal, 10)

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -1090,16 +1090,25 @@ private struct HostsDriftReviewSheet: View {
                             Spacer()
                         }
 
-                        ScrollView([.horizontal, .vertical]) {
-                            // A lazy stack collapses to a near-zero width proposal inside a
-                            // horizontal-axis ScrollView, wrapping every row character by character.
-                            VStack(alignment: .leading, spacing: 0) {
-                                ForEach(Array(comparison.diffRows.enumerated()), id: \.offset) { _, row in
-                                    diffRow(row)
+                        GeometryReader { viewport in
+                            ScrollView([.horizontal, .vertical]) {
+                                // A lazy stack collapses to a near-zero width proposal inside a
+                                // horizontal-axis ScrollView, wrapping every row character by character.
+                                VStack(alignment: .leading, spacing: 0) {
+                                    ForEach(Array(comparison.diffRows.enumerated()), id: \.offset) { _, row in
+                                        diffRow(row)
+                                    }
                                 }
+                                // A two-axis ScrollView centers undersized content; proposing at
+                                // least the viewport pins the rows top-leading and stripes them
+                                // across the full width.
+                                .frame(
+                                    minWidth: viewport.size.width,
+                                    minHeight: viewport.size.height,
+                                    alignment: .topLeading
+                                )
+                                .textSelection(.enabled)
                             }
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .textSelection(.enabled)
                         }
                         .background(.background.secondary, in: RoundedRectangle(cornerRadius: 8))
 


### PR DESCRIPTION
The drift review sheet rendered diff rows wrapped character by character: a lazy stack inside the two-axis ScrollView collapses to a near-zero width proposal. The scroll view also centered content smaller than the viewport, floating the diff block in the middle of the viewer.

Use a plain VStack (row counts are small), pin row text to its ideal single-line width, and propose at least the viewport size so rows sit top-leading and stripe the full width.