### PR TITLE
feat: add import/export of profiles and groups

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -21,7 +21,7 @@ Where standalone profiles live; profiles can move between groups and the standal
 _Avoid_: ungrouped area, root directory
 
 **Base Hosts**:
-The protected baseline imported from the system hosts on first run; always applied, shown read-only, cannot be deleted, and only updated through the controlled drift-reconciliation flow.
+The protected baseline captured from the system hosts on first run; always applied, shown read-only, cannot be deleted, and only updated through the controlled drift-reconciliation flow.
 _Avoid_: system hosts (reserve that term for the real /etc/hosts file)
 
 **System Hosts**:
@@ -49,9 +49,17 @@ Whether hostflip registers itself as a login item to start automatically at logi
 _Avoid_: auto-start, boot launch
 
 **Workspace**:
-hostflip's persistence directory; holds Base Hosts, the profile files, the manifest, and the original backup from first import (hosts.orig).
+hostflip's persistence directory; holds Base Hosts, the profile files, the manifest, and the original backup from first capture (hosts.orig).
 _Avoid_: data directory, config directory
 
 **Drift**:
 The state where the current system hosts content differs from what hostflip last confirmed; means there are unreconciled external modifications.
 _Avoid_: external change, conflict
+
+**Export**:
+A portable snapshot of every profile and the group structure; excludes Base Hosts and all active state.
+_Avoid_: backup, dump
+
+**Import**:
+Appending external content to the workspace as new, inactive profiles and groups; never changes existing content or the system hosts.
+_Avoid_: restore, load

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -61,6 +61,9 @@ struct HostflipApp: App {
                 }
         }
         .defaultSize(width: 820, height: 560)
+        .commands {
+            ImportExportCommands(store: store)
+        }
 
         Settings {
             ApplicationSettingsView(

--- a/Sources/Hostflip/ImportExportCommands.swift
+++ b/Sources/Hostflip/ImportExportCommands.swift
@@ -1,0 +1,68 @@
+import AppKit
+import SwiftUI
+import UniformTypeIdentifiers
+
+/// File menu Import…/Export… (#40, ADR-0008): manual entry points using the standard panels.
+struct ImportExportCommands: Commands {
+    let store: WorkspaceStore
+
+    var body: some Commands {
+        CommandGroup(replacing: .importExport) {
+            Button("Import…") {
+                runImportPanel()
+            }
+            .disabled(store.model == nil)
+
+            Button("Export…") {
+                runExportPanel()
+            }
+            .disabled(store.model == nil)
+        }
+    }
+
+    /// One panel for both formats: the reader tells export files and plain hosts text apart.
+    @MainActor
+    private func runImportPanel() {
+        let panel = NSOpenPanel()
+        panel.allowsMultipleSelection = true
+        panel.canChooseDirectories = false
+        NSApp.activate()
+        guard panel.runModal() == .OK, !panel.urls.isEmpty else { return }
+        if case .failed(let message) = store.importFiles(at: panel.urls) {
+            presentError(title: "Import Failed", message: message)
+        }
+    }
+
+    @MainActor
+    private func runExportPanel() {
+        let panel = NSSavePanel()
+        panel.allowedContentTypes = [.json]
+        panel.canCreateDirectories = true
+        panel.nameFieldStringValue = defaultExportFileName()
+        NSApp.activate()
+        guard panel.runModal() == .OK, let url = panel.url else { return }
+        do {
+            guard let data = try store.exportSnapshotData() else { return }
+            try data.write(to: url, options: .atomic)
+        } catch {
+            presentError(title: "Export Failed", message: "Nothing was exported: \(error)")
+        }
+    }
+
+    private func defaultExportFileName() -> String {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "yyyy-MM-dd"
+        return "hostflip-\(formatter.string(from: .now)).json"
+    }
+
+    @MainActor
+    private func presentError(title: String, message: String) {
+        let alert = NSAlert()
+        alert.messageText = title
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: "OK")
+        alert.runModal()
+    }
+}

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -53,6 +53,12 @@ enum HostsReconciliationChoice {
     case later
 }
 
+/// Result of one import (#40): either every file was applied, or none was.
+enum ImportOutcome: Equatable {
+    case imported
+    case failed(String)
+}
+
 /// Domain state for the main window (#20/#21/#22): opens the workspace, shows hosts, manages profiles and groups.
 /// Saving does not go through the helper — every edit is written to disk synchronously, leaving no
 /// window for loss; when already approved, a debounced follow-up merge runs separately
@@ -139,7 +145,7 @@ final class WorkspaceStore {
         self.readSystemHosts = readSystemHosts
     }
 
-    /// Idempotent open: the first call imports or restores the workspace; later calls reuse the in-memory model.
+    /// Idempotent open: the first call captures or restores the workspace; later calls reuse the in-memory model.
     func loadIfNeeded() {
         guard model == nil, loadError == nil else { return }
         do {
@@ -685,6 +691,74 @@ final class WorkspaceStore {
         guard refreshed != hostsDriftComparison else { return }
         hostsDriftComparison = refreshed
         hostsDriftGeneration &+= 1
+    }
+
+    // MARK: - Import / Export (#40, ADR-0008)
+
+    /// Every file is parsed and validated before anything is applied, so one bad file means zero
+    /// change. Imported content lands inactive, making this a purely local edit: it must not go
+    /// through applyEdit, whose follow-up merge would touch the system hosts. The in-memory model
+    /// is committed only after the workspace save succeeds.
+    func importFiles(at urls: [URL]) -> ImportOutcome {
+        guard var updated = model else {
+            return .failed("Nothing was imported: the workspace is not loaded.")
+        }
+        do {
+            let contents = try urls.map { url in
+                do {
+                    return try ImportReader.read(
+                        data: Data(contentsOf: url),
+                        fileName: url.lastPathComponent
+                    )
+                } catch {
+                    throw ImportFileFailure(fileName: url.lastPathComponent, underlying: error)
+                }
+            }
+            for content in contents {
+                switch content {
+                case .snapshot(let snapshot):
+                    try updated.importSnapshot(snapshot)
+                case .plainText(let name, let text):
+                    try updated.addProfile(id: Profile.ID(UUID().uuidString), name: name, content: text)
+                }
+            }
+            try workspace.save(updated)
+            model = updated
+            return .imported
+        } catch {
+            return .failed(Self.importFailureMessage(for: error))
+        }
+    }
+
+    /// A portable snapshot of every profile and the group structure; Base Hosts and active state
+    /// stay on this machine. Nil until the workspace has loaded.
+    func exportSnapshotData() throws -> Data? {
+        guard let model else { return nil }
+        return try ExportSnapshot(of: model).encoded()
+    }
+
+    private struct ImportFileFailure: Error {
+        let fileName: String
+        let underlying: any Error
+    }
+
+    private static func importFailureMessage(for error: any Error) -> String {
+        guard let failure = error as? ImportFileFailure else {
+            return "Nothing was imported: \(error)"
+        }
+        let reason = switch failure.underlying as? ImportError {
+        case .unsupportedVersion(let version):
+            "this file was created by a newer version of hostflip (format version \(version))"
+        case .malformedSnapshot:
+            "this file is JSON but not a valid hostflip export"
+        case .blankName:
+            "the export contains a profile or group with an empty name"
+        case .invalidTextEncoding:
+            "this file is not UTF-8 text"
+        case nil:
+            "\(failure.underlying)"
+        }
+        return "Nothing was imported. \(failure.fileName): \(reason)."
     }
 
     // MARK: - Persisting and follow-up merging

--- a/Sources/HostflipCore/ImportExport.swift
+++ b/Sources/HostflipCore/ImportExport.swift
@@ -1,0 +1,154 @@
+import Foundation
+
+/// A portable snapshot of every profile and the group structure (ADR-0008). It deliberately has no
+/// fields for Base Hosts, active state, or IDs: Base Hosts is machine-specific, and import always
+/// mints fresh IDs, so an export carries names and contents only.
+public struct ExportSnapshot: Equatable, Sendable {
+    public struct Profile: Equatable, Sendable, Codable {
+        public var name: String
+        public var content: String
+
+        public init(name: String, content: String) {
+            self.name = name
+            self.content = content
+        }
+    }
+
+    public struct Group: Equatable, Sendable, Codable {
+        public var name: String
+        public var profiles: [Profile]
+
+        public init(name: String, profiles: [Profile]) {
+            self.name = name
+            self.profiles = profiles
+        }
+    }
+
+    public var standaloneProfiles: [Profile]
+    public var groups: [Group]
+
+    public init(standaloneProfiles: [Profile], groups: [Group]) {
+        self.standaloneProfiles = standaloneProfiles
+        self.groups = groups
+    }
+
+    public init(of model: ActivationModel) {
+        standaloneProfiles = model.standaloneProfiles.map {
+            Profile(name: $0.name, content: $0.content)
+        }
+        groups = model.groups.map { group in
+            Group(name: group.name, profiles: group.profiles.map {
+                Profile(name: $0.name, content: $0.content)
+            })
+        }
+    }
+
+    /// The on-disk export format is versioned from day one; the snapshot structure is a DTO
+    /// independent of the workspace manifest, so the two evolve separately.
+    static let currentVersion = 1
+
+    public func encoded() throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        return try encoder.encode(SnapshotFile(
+            version: Self.currentVersion,
+            standaloneProfiles: standaloneProfiles,
+            groups: groups
+        ))
+    }
+}
+
+/// The serialized form of an export file: the snapshot plus the format version.
+private struct SnapshotFile: Codable {
+    var version: Int
+    var standaloneProfiles: [ExportSnapshot.Profile]
+    var groups: [ExportSnapshot.Group]
+}
+
+public enum ImportError: Error, Equatable, Sendable {
+    /// The file was written by a newer hostflip; refuse rather than guess at the format.
+    case unsupportedVersion(Int)
+    /// The file is JSON but not a valid export snapshot; JSON is never swallowed as plain hosts text.
+    case malformedSnapshot
+    /// A profile or group name in the snapshot is empty or whitespace-only.
+    case blankName
+    /// A plain text file that is not valid UTF-8.
+    case invalidTextEncoding
+}
+
+/// One file selected for import, classified by content.
+public enum ImportedContent: Equatable, Sendable {
+    case snapshot(ExportSnapshot)
+    /// Plain hosts text; lands as one standalone profile named after the file.
+    case plainText(name: String, content: String)
+}
+
+public enum ImportReader {
+    /// Classifies a file: JSON must be a valid versioned snapshot (never falls through to plain
+    /// text); anything else is plain hosts text named after the file (extension stripped).
+    public static func read(data: Data, fileName: String) throws -> ImportedContent {
+        if (try? JSONSerialization.jsonObject(with: data)) != nil {
+            return .snapshot(try decodeSnapshot(data))
+        }
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw ImportError.invalidTextEncoding
+        }
+        return .plainText(name: profileName(fromFileName: fileName), content: content)
+    }
+
+    private static func decodeSnapshot(_ data: Data) throws -> ExportSnapshot {
+        // The version is probed before full decoding so a future format still reports
+        // unsupportedVersion instead of malformedSnapshot.
+        struct VersionProbe: Codable {
+            var version: Int
+        }
+        guard let probe = try? JSONDecoder().decode(VersionProbe.self, from: data),
+              probe.version >= 1
+        else {
+            throw ImportError.malformedSnapshot
+        }
+        guard probe.version <= ExportSnapshot.currentVersion else {
+            throw ImportError.unsupportedVersion(probe.version)
+        }
+        guard let file = try? JSONDecoder().decode(SnapshotFile.self, from: data) else {
+            throw ImportError.malformedSnapshot
+        }
+
+        let names = file.standaloneProfiles.map(\.name)
+            + file.groups.flatMap { [$0.name] + $0.profiles.map(\.name) }
+        guard names.allSatisfy({ !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }) else {
+            throw ImportError.blankName
+        }
+        return ExportSnapshot(standaloneProfiles: file.standaloneProfiles, groups: file.groups)
+    }
+
+    private static func profileName(fromFileName fileName: String) -> String {
+        let stem = (fileName as NSString).deletingPathExtension
+        let isBlank = stem.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        return isBlank ? "Untitled" : stem
+    }
+}
+
+extension ActivationModel {
+    /// Appends the snapshot as new, inactive profiles and groups after the existing ones (ADR-0008).
+    /// Every object gets a fresh ID; names are kept verbatim, so same-named objects coexist rather
+    /// than merge — file-name collisions are the persistence layer's concern, not the model's.
+    public mutating func importSnapshot(
+        _ snapshot: ExportSnapshot,
+        makeProfileID: () -> Profile.ID = { Profile.ID(UUID().uuidString) },
+        makeGroupID: () -> Group.ID = { Group.ID(UUID().uuidString) }
+    ) throws {
+        for profile in snapshot.standaloneProfiles {
+            try addProfile(id: makeProfileID(), name: profile.name, content: profile.content)
+        }
+        for group in snapshot.groups {
+            let groupID = makeGroupID()
+            try addGroup(id: groupID, name: group.name)
+            for profile in group.profiles {
+                let profileID = makeProfileID()
+                try addProfile(id: profileID, name: profile.name, content: profile.content)
+                try moveProfile(profileID, toGroup: groupID)
+            }
+        }
+    }
+}

--- a/Sources/HostflipCore/ImportExport.swift
+++ b/Sources/HostflipCore/ImportExport.swift
@@ -84,10 +84,11 @@ public enum ImportedContent: Equatable, Sendable {
 }
 
 public enum ImportReader {
-    /// Classifies a file: JSON must be a valid versioned snapshot (never falls through to plain
-    /// text); anything else is plain hosts text named after the file (extension stripped).
+    /// Classifies a file: JSON — including top-level scalars like `42` or `null` — must be a valid
+    /// versioned snapshot (never falls through to plain text); anything else is plain hosts text
+    /// named after the file (extension stripped).
     public static func read(data: Data, fileName: String) throws -> ImportedContent {
-        if (try? JSONSerialization.jsonObject(with: data)) != nil {
+        if (try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)) != nil {
             return .snapshot(try decodeSnapshot(data))
         }
         guard let content = String(data: data, encoding: .utf8) else {

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -3,15 +3,15 @@ import Foundation
 /// hostflip's persistent workspace (defaults to `~/Library/Application Support/hostflip/`).
 ///
 /// Directory layout (see the ticket #4 resolution):
-/// - `hosts.orig`: pristine backup of the system hosts taken at first import; kept forever, never rewritten
+/// - `hosts.orig`: pristine backup of the system hosts taken at first capture; kept forever, never rewritten
 /// - `base.hosts`: Base Hosts content, updatable in a controlled way by the drift reconciliation flow
 /// - `profiles/*.hosts`: each profile's content; file name = profile name (sanitized + conflict suffix)
 /// - `manifest.json`: group structure, active state, ordering
 public enum WorkspaceError: Error, Equatable, Sendable {
     /// The workspace has residual content (base.hosts or profile files) but no manifest;
-    /// it must not be overwritten as a first-run import and needs manual intervention.
+    /// it must not be overwritten as a first-run capture and needs manual intervention.
     case residualContentWithoutManifest
-    /// The workspace has not completed first import; domain state cannot be saved and the last-written hash cannot be read or written.
+    /// The workspace has not completed first capture; domain state cannot be saved and the last-written hash cannot be read or written.
     case notInitialized
 }
 
@@ -28,7 +28,7 @@ public struct Workspace: Sendable {
         self.rootDirectory = rootDirectory
     }
 
-    /// Opens the workspace: an empty workspace imports the system hosts as Base Hosts; an initialized
+    /// Opens the workspace: an empty workspace captures the system hosts as Base Hosts; an initialized
     /// workspace restores from existing data and no longer reads the system hosts.
     public func open(systemHosts: () throws -> String) throws -> ActivationModel {
         if FileManager.default.fileExists(atPath: manifestURL.path) {
@@ -37,10 +37,10 @@ public struct Workspace: Sendable {
         guard !hasResidualContent else {
             throw WorkspaceError.residualContentWithoutManifest
         }
-        return try importSystemHosts(systemHosts)
+        return try captureSystemHosts(systemHosts)
     }
 
-    /// hosts.orig alone is treated as an interrupted first import and safe to re-import;
+    /// hosts.orig alone is treated as an interrupted first capture and safe to capture again;
     /// base.hosts or profile files, however, are unreproducible user content.
     private var hasResidualContent: Bool {
         if FileManager.default.fileExists(atPath: baseHostsURL.path) {
@@ -53,9 +53,9 @@ public struct Workspace: Sendable {
         return profileFiles.contains { $0.pathExtension == "hosts" }
     }
 
-    // MARK: - First import
+    // MARK: - First capture
 
-    private func importSystemHosts(_ systemHosts: () throws -> String) throws -> ActivationModel {
+    private func captureSystemHosts(_ systemHosts: () throws -> String) throws -> ActivationModel {
         let content = try systemHosts()
 
         try FileManager.default.createDirectory(at: profilesDirectory, withIntermediateDirectories: true)
@@ -75,7 +75,7 @@ public struct Workspace: Sendable {
         do {
             try Data(content.utf8).write(to: originalBackupURL, options: .withoutOverwriting)
         } catch let error as CocoaError where error.code == .fileWriteFileExists {
-            // Backup already exists (an interrupted first import or concurrent initialization)
+            // Backup already exists (an interrupted first capture or concurrent initialization)
         }
     }
 
@@ -159,7 +159,7 @@ public struct Workspace: Sendable {
     }
 
     /// The hash the system hosts should currently have. After a successful merge write, the daemon-confirmed value wins;
-    /// before any write it falls back to the read-only pristine snapshot from first import, so even the first write has a verifiable baseline.
+    /// before any write it falls back to the read-only pristine snapshot from first capture, so even the first write has a verifiable baseline.
     public func expectedSystemHostsHash() throws -> String {
         if let lastWrittenHash = try requireManifest().lastWrittenHash {
             return lastWrittenHash
@@ -176,7 +176,7 @@ public struct Workspace: Sendable {
         }
     }
 
-    /// Reading or writing the last-written hash requires the manifest to exist (guaranteed once open has completed first import).
+    /// Reading or writing the last-written hash requires the manifest to exist (guaranteed once open has completed first capture).
     private func requireManifest() throws -> Manifest {
         guard FileManager.default.fileExists(atPath: manifestURL.path) else {
             throw WorkspaceError.notInitialized

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -132,14 +132,18 @@ public struct Workspace: Sendable {
             )
             try writeManifest(manifest)
 
-            // Stale profile files are cleaned up only after the manifest is persisted: if any step fails midway,
-            // every file the on-disk manifest references still exists, keeping the workspace loadable.
+            // Stale profile files are cleaned up only after the manifest is persisted — and best-effort:
+            // the manifest write is the commit point, so a cleanup failure must not turn an already
+            // committed save into a thrown one (callers that commit in-memory state only on success
+            // would diverge from disk). An unremoved stale file is unreferenced and retried next save.
             let expectedFileNames = Set(fileNames.values.map { $0.lowercased() })
-            for url in try FileManager.default.contentsOfDirectory(
+            let leftovers = (try? FileManager.default.contentsOfDirectory(
                 at: profilesDirectory,
                 includingPropertiesForKeys: nil
-            ) where url.pathExtension == "hosts" && !expectedFileNames.contains(url.lastPathComponent.lowercased()) {
-                try FileManager.default.removeItem(at: url)
+            )) ?? []
+            for url in leftovers
+            where url.pathExtension == "hosts" && !expectedFileNames.contains(url.lastPathComponent.lowercased()) {
+                try? FileManager.default.removeItem(at: url)
             }
         }
     }

--- a/Tests/HostflipCoreTests/ImportExportTests.swift
+++ b/Tests/HostflipCoreTests/ImportExportTests.swift
@@ -95,6 +95,17 @@ final class ImportExportTests: XCTestCase {
         }
     }
 
+    func testTopLevelJSONScalarIsRejectedRatherThanTreatedAsPlainText() {
+        for scalar in ["42", "null", #""hello""#] {
+            XCTAssertThrowsError(
+                try ImportReader.read(data: Data(scalar.utf8), fileName: "scalar.json"),
+                scalar
+            ) { error in
+                XCTAssertEqual(error as? ImportError, .malformedSnapshot, scalar)
+            }
+        }
+    }
+
     func testBlankNameInSnapshotIsRejected() {
         let data = Data(
             #"{"version": 1, "standaloneProfiles": [{"name": "  ", "content": "x"}], "groups": []}"#.utf8

--- a/Tests/HostflipCoreTests/ImportExportTests.swift
+++ b/Tests/HostflipCoreTests/ImportExportTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import HostflipCore
+import XCTest
+
+final class ImportExportTests: XCTestCase {
+    /// A workspace with base hosts, a standalone profile, and a group with one active member.
+    private func makeModel() throws -> ActivationModel {
+        try ActivationModel(
+            baseHosts: BaseHosts(content: "127.0.0.1 localhost\n"),
+            standaloneProfiles: [
+                Profile(id: .init("s1"), name: "Ad Block", content: "0.0.0.0 ads.example\n")
+            ],
+            groups: [
+                Group(id: .init("g1"), name: "Staging", profiles: [
+                    Profile(id: .init("p1"), name: "API", content: "10.0.0.1 api.example\n"),
+                    Profile(id: .init("p2"), name: "Web", content: "10.0.0.2 web.example\n"),
+                ])
+            ],
+            activeProfileIDs: [.init("p1")]
+        )
+    }
+
+    // MARK: - Export
+
+    func testSnapshotCapturesProfilesAndGroupStructure() throws {
+        let snapshot = ExportSnapshot(of: try makeModel())
+
+        XCTAssertEqual(snapshot, ExportSnapshot(
+            standaloneProfiles: [.init(name: "Ad Block", content: "0.0.0.0 ads.example\n")],
+            groups: [.init(name: "Staging", profiles: [
+                .init(name: "API", content: "10.0.0.1 api.example\n"),
+                .init(name: "Web", content: "10.0.0.2 web.example\n"),
+            ])]
+        ))
+    }
+
+    func testEncodedSnapshotIsVersionedJSONCarryingOnlyNamesAndContents() throws {
+        let data = try ExportSnapshot(of: makeModel()).encoded()
+
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        XCTAssertEqual(object["version"] as? Int, 1)
+        XCTAssertEqual(Set(object.keys), ["version", "standaloneProfiles", "groups"])
+        let groups = try XCTUnwrap(object["groups"] as? [[String: Any]])
+        XCTAssertEqual(Set(groups[0].keys), ["name", "profiles"])
+        let profile = try XCTUnwrap((groups[0]["profiles"] as? [[String: Any]])?.first)
+        XCTAssertEqual(Set(profile.keys), ["name", "content"])
+    }
+
+    // MARK: - Reading import files
+
+    func testReadingAnExportedFileRoundTripsTheSnapshot() throws {
+        let snapshot = ExportSnapshot(of: try makeModel())
+
+        let read = try ImportReader.read(data: snapshot.encoded(), fileName: "hostflip-2026-08-12.json")
+
+        XCTAssertEqual(read, .snapshot(snapshot))
+    }
+
+    func testPlainTextFileBecomesAProfileNamedAfterTheFile() throws {
+        let read = try ImportReader.read(
+            data: Data("10.0.0.3 db.example\n".utf8),
+            fileName: "Staging DB.hosts"
+        )
+
+        XCTAssertEqual(read, .plainText(name: "Staging DB", content: "10.0.0.3 db.example\n"))
+    }
+
+    func testSnapshotFromANewerVersionIsRejected() {
+        let data = Data(#"{"version": 2, "standaloneProfiles": [], "groups": []}"#.utf8)
+
+        XCTAssertThrowsError(try ImportReader.read(data: data, fileName: "future.json")) { error in
+            XCTAssertEqual(error as? ImportError, .unsupportedVersion(2))
+        }
+    }
+
+    func testSnapshotWithNonPositiveVersionIsMalformedNotNewer() {
+        let data = Data(#"{"version": 0, "standaloneProfiles": [], "groups": []}"#.utf8)
+
+        XCTAssertThrowsError(try ImportReader.read(data: data, fileName: "zero.json")) { error in
+            XCTAssertEqual(error as? ImportError, .malformedSnapshot)
+        }
+    }
+
+    func testWhitespaceOnlyFileNameStemFallsBackToUntitled() throws {
+        let read = try ImportReader.read(data: Data("# empty\n".utf8), fileName: "   .hosts")
+
+        XCTAssertEqual(read, .plainText(name: "Untitled", content: "# empty\n"))
+    }
+
+    func testJSONWithWrongShapeIsRejectedRatherThanTreatedAsPlainText() {
+        let data = Data(#"{"hosts": "127.0.0.1 localhost"}"#.utf8)
+
+        XCTAssertThrowsError(try ImportReader.read(data: data, fileName: "weird.json")) { error in
+            XCTAssertEqual(error as? ImportError, .malformedSnapshot)
+        }
+    }
+
+    func testBlankNameInSnapshotIsRejected() {
+        let data = Data(
+            #"{"version": 1, "standaloneProfiles": [{"name": "  ", "content": "x"}], "groups": []}"#.utf8
+        )
+
+        XCTAssertThrowsError(try ImportReader.read(data: data, fileName: "blank.json")) { error in
+            XCTAssertEqual(error as? ImportError, .blankName)
+        }
+    }
+
+    func testNonUTF8PlainTextIsRejected() {
+        XCTAssertThrowsError(try ImportReader.read(data: Data([0xFF, 0xFE]), fileName: "binary")) { error in
+            XCTAssertEqual(error as? ImportError, .invalidTextEncoding)
+        }
+    }
+
+    // MARK: - Importing a snapshot into a model
+
+    func testImportAppendsInactiveProfilesAndGroupsWithFreshIDs() throws {
+        var model = try makeModel()
+        let snapshot = ExportSnapshot(of: model)
+        var minted = 0
+
+        try model.importSnapshot(
+            snapshot,
+            makeProfileID: { minted += 1; return .init("new-p\(minted)") },
+            makeGroupID: { .init("new-g") }
+        )
+
+        XCTAssertEqual(model.standaloneProfiles.map(\.name), ["Ad Block", "Ad Block"])
+        XCTAssertEqual(model.standaloneProfiles.map(\.id.rawValue), ["s1", "new-p1"])
+        XCTAssertEqual(model.groups.map(\.name), ["Staging", "Staging"])
+        XCTAssertEqual(model.groups.map(\.id.rawValue), ["g1", "new-g"])
+        XCTAssertEqual(model.groups[1].profiles.map(\.name), ["API", "Web"])
+        XCTAssertEqual(model.groups[1].profiles.map(\.content), [
+            "10.0.0.1 api.example\n", "10.0.0.2 web.example\n",
+        ])
+        // Existing content and active state stay untouched; every imported profile is inactive.
+        XCTAssertEqual(model.groups[0].profiles.map(\.id.rawValue), ["p1", "p2"])
+        XCTAssertEqual(model.activeProfileIDs, [.init("p1")])
+        XCTAssertFalse(model.isPaused)
+    }
+
+    func testImportWithDefaultIDMintingProducesUniqueIDs() throws {
+        var model = try makeModel()
+        let snapshot = ExportSnapshot(of: model)
+
+        try model.importSnapshot(snapshot)
+        try model.importSnapshot(snapshot)
+
+        let allIDs = (model.standaloneProfiles + model.groups.flatMap(\.profiles)).map(\.id)
+        XCTAssertEqual(Set(allIDs).count, allIDs.count)
+        XCTAssertEqual(allIDs.count, 9)
+    }
+}

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -1238,6 +1238,127 @@ final class WorkspaceStoreTests: XCTestCase {
         }
     }
 
+    // MARK: - Import / Export (#40)
+
+    @MainActor
+    func testImportAppendsFilesAsInactiveContentWithoutMerging() throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        let snapshot = ExportSnapshot(
+            standaloneProfiles: [.init(name: "Ad Block", content: "0.0.0.0 ads.example\n")],
+            groups: [.init(name: "Staging", profiles: [
+                .init(name: "API", content: "10.0.0.1 api.example\n")
+            ])]
+        )
+        let urls = [
+            try writeImportFile(named: "team.json", snapshot.encoded()),
+            try writeImportFile(named: "Team DB.hosts", Data("10.0.0.3 db.example\n".utf8)),
+        ]
+
+        let outcome = store.importFiles(at: urls)
+
+        XCTAssertEqual(outcome, .imported)
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["Ad Block", "Team DB"])
+        XCTAssertEqual(store.groups.map(\.name), ["Staging"])
+        XCTAssertEqual(store.groups.first?.profiles.map(\.name), ["API"])
+        XCTAssertEqual(store.model?.activeProfileIDs, [])
+
+        // Local-only: no follow-up merge is scheduled and nothing reaches the coordinator.
+        XCTAssertNil(store.followUpMergeTask)
+        XCTAssertTrue(stub.authorizedMerges.isEmpty)
+        XCTAssertTrue(stub.performedSwitches.isEmpty)
+
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.name), ["Ad Block", "Team DB"])
+        XCTAssertEqual(reloaded.groups.map(\.name), ["Staging"])
+        XCTAssertEqual(reloaded.activeProfileIDs, [])
+    }
+
+    @MainActor
+    func testImportOfSameNamedProfilesKeepsBothWithoutMerging() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        _ = store.createStandaloneProfile()
+        let snapshot = ExportSnapshot(
+            standaloneProfiles: [.init(name: "New Profile", content: "0.0.0.0 ads.example\n")],
+            groups: []
+        )
+
+        let outcome = store.importFiles(at: [
+            try writeImportFile(named: "dup.json", snapshot.encoded())
+        ])
+
+        XCTAssertEqual(outcome, .imported)
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["New Profile", "New Profile"])
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.name), ["New Profile", "New Profile"])
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.content).sorted(), [
+            "# Add hosts entries here\n", "0.0.0.0 ads.example\n",
+        ])
+    }
+
+    @MainActor
+    func testImportAppliesNothingWhenAnyFileIsInvalid() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let valid = ExportSnapshot(
+            standaloneProfiles: [.init(name: "Ad Block", content: "0.0.0.0 ads.example\n")],
+            groups: []
+        )
+        let urls = [
+            try writeImportFile(named: "good.json", valid.encoded()),
+            try writeImportFile(named: "bad.json", Data(#"{"nope": 1}"#.utf8)),
+        ]
+
+        let outcome = store.importFiles(at: urls)
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("导入应整体失败，实际结果：\(outcome)")
+        }
+        XCTAssertTrue(message.contains("bad.json"), message)
+        XCTAssertTrue(store.standaloneProfiles.isEmpty)
+        XCTAssertTrue(try reloadModel().standaloneProfiles.isEmpty)
+    }
+
+    @MainActor
+    func testImportCommitsNothingInMemoryWhenSaveFails() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let url = try writeImportFile(named: "team.json", ExportSnapshot(
+            standaloneProfiles: [.init(name: "Ad Block", content: "0.0.0.0 ads.example\n")],
+            groups: []
+        ).encoded())
+        // Removing hosts.orig makes Workspace.save throw notInitialized after parsing succeeds.
+        try FileManager.default.removeItem(at: rootDirectory.appendingPathComponent("hosts.orig"))
+
+        let outcome = store.importFiles(at: [url])
+
+        guard case .failed = outcome else {
+            return XCTFail("保存失败时导入应失败，实际结果：\(outcome)")
+        }
+        XCTAssertTrue(store.standaloneProfiles.isEmpty)
+        XCTAssertNil(store.followUpMergeTask)
+    }
+
+    @MainActor
+    func testExportedDataRoundTripsAsASnapshotOfCurrentProfiles() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        _ = store.createStandaloneProfile()
+
+        let data = try XCTUnwrap(store.exportSnapshotData())
+
+        let read = try ImportReader.read(data: data, fileName: "export.json")
+        XCTAssertEqual(read, .snapshot(ExportSnapshot(
+            standaloneProfiles: [.init(name: "New Profile", content: "# Add hosts entries here\n")],
+            groups: []
+        )))
+    }
+
+    private func writeImportFile(named name: String, _ data: Data) throws -> URL {
+        let directory = rootDirectory.appendingPathComponent("import-files", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let url = directory.appendingPathComponent(name)
+        try data.write(to: url)
+        return url
+    }
+
     // MARK: - Helpers
 
     @MainActor


### PR DESCRIPTION
Adds manual import/export of profiles and groups via the File menu.

- **Export…** writes a versioned JSON snapshot (`version: 1`) of every profile and the group structure — names and contents only: no Base Hosts, no active state, no IDs. Default file name carries the date; a workspace with only Base Hosts still exports a valid empty snapshot.
- **Import…** appends export files or plain hosts text as new, inactive profiles and groups. One panel for both: JSON (including top-level scalars) must be a valid snapshot — files from a newer format version are refused, and malformed JSON is never swallowed as plain text. Anything else imports as one standalone profile named after the file; multi-select is supported.
- The whole batch is parsed and validated before anything is applied — one bad file means zero change — and the in-memory model is committed only after the workspace save succeeds. Import never schedules a merge and never touches the system hosts.
- First-run wording moves from "import" to "capture" so *Import* now refers only to this feature (see the glossary in CONTEXT.md).