### PR TITLE
feat: add settings helper tab and improve helper status refresh

### DIFF
--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -3,6 +3,8 @@ import Sparkle
 import SwiftUI
 
 struct ApplicationSettingsView: View {
+    let store: WorkspaceStore
+    let maintenanceStore: MaintenanceStore
     let dockIconStore: DockIconVisibilityStore
     let launchAtLoginStore: LaunchAtLoginStore
     let updater: SPUUpdater
@@ -36,17 +38,28 @@ struct ApplicationSettingsView: View {
                     .foregroundStyle(.secondary)
             }
             .padding(20)
+            .frame(width: 460, height: 190)
             .tabItem {
                 Label("General", systemImage: "gearshape")
             }
 
+            // Second home of helper management alongside the toolbar popover (#41):
+            // Settings is where users expect to find privileged-component removal,
+            // e.g. before uninstalling. The extra height leaves room for feedback.
+            HelperMaintenanceSection(store: store, maintenanceStore: maintenanceStore)
+                .padding(20)
+                .frame(width: 460, height: 230, alignment: .topLeading)
+                .tabItem {
+                    Label("Helper", systemImage: "gearshape.2")
+                }
+
             UpdatesSettingsView(updater: updater)
                 .padding(20)
+                .frame(width: 460, height: 190)
                 .tabItem {
                     Label("Updates", systemImage: "arrow.triangle.2.circlepath")
                 }
         }
-        .frame(width: 460, height: 190)
     }
 }
 

--- a/Sources/Hostflip/HelperMaintenanceView.swift
+++ b/Sources/Hostflip/HelperMaintenanceView.swift
@@ -125,6 +125,7 @@ struct HelperMaintenanceView: View {
                         Text(feedbackPresentation.title)
                             .fontWeight(.semibold)
                         Text(feedbackPresentation.message)
+                            .fixedSize(horizontal: false, vertical: true)
                     }
                 } icon: {
                     Image(

--- a/Sources/Hostflip/HelperMaintenanceView.swift
+++ b/Sources/Hostflip/HelperMaintenanceView.swift
@@ -67,7 +67,6 @@ struct HelperMaintenanceView: View {
     let maintenanceStore: MaintenanceStore
     let onDismiss: (() -> Void)?
     @Environment(\.dismiss) private var dismiss
-    @State private var isConfirmingRemoval = false
 
     init(
         store: WorkspaceStore,
@@ -80,11 +79,43 @@ struct HelperMaintenanceView: View {
     }
 
     var body: some View {
-        let helperPresentation = HelperStatusPresentation(maintenanceStore.helperStatus)
         VStack(alignment: .leading, spacing: 14) {
             Text("Maintenance")
                 .font(.headline)
 
+            HelperMaintenanceSection(
+                store: store,
+                maintenanceStore: maintenanceStore,
+                beforeOpeningSystemSettings: { close() }
+            )
+        }
+        .padding(16)
+        .frame(width: 380)
+    }
+
+    private func close() {
+        if let onDismiss {
+            onDismiss()
+        } else {
+            dismiss()
+        }
+    }
+}
+
+/// Shared body of the helper management UI: status, approval shortcut, removal with
+/// confirmation, and operation feedback. Hosted by the toolbar popover and by
+/// Settings > Helper (#41); both hand it the same MaintenanceStore instance, so the
+/// two entry points can never disagree.
+struct HelperMaintenanceSection: View {
+    let store: WorkspaceStore
+    let maintenanceStore: MaintenanceStore
+    /// Runs before jumping to System Settings; the popover closes itself here.
+    var beforeOpeningSystemSettings: () -> Void = {}
+    @State private var isConfirmingRemoval = false
+
+    var body: some View {
+        let helperPresentation = HelperStatusPresentation(maintenanceStore.helperStatus)
+        VStack(alignment: .leading, spacing: 14) {
             VStack(alignment: .leading, spacing: 8) {
                 Label("Background Helper", systemImage: "gearshape.2")
                     .font(.subheadline.weight(.semibold))
@@ -98,7 +129,7 @@ struct HelperMaintenanceView: View {
                     HStack {
                         if helperPresentation.canOpenApprovalSettings {
                             Button("Open System Settings…") {
-                                close()
+                                beforeOpeningSystemSettings()
                                 store.openApprovalSettings()
                             }
                         }
@@ -138,8 +169,6 @@ struct HelperMaintenanceView: View {
                 .foregroundStyle(feedbackPresentation.isFailure ? .red : .green)
             }
         }
-        .padding(16)
-        .frame(width: 380)
         .task { await maintenanceStore.refreshHelperStatus() }
         .confirmationDialog(
             "Deactivate and Remove Helper?",
@@ -159,13 +188,5 @@ struct HelperMaintenanceView: View {
             return "Retry Remove Helper…"
         }
         return "Deactivate and Remove Helper…"
-    }
-
-    private func close() {
-        if let onDismiss {
-            onDismiss()
-        } else {
-            dismiss()
-        }
     }
 }

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -67,6 +67,8 @@ struct HostflipApp: App {
 
         Settings {
             ApplicationSettingsView(
+                store: store,
+                maintenanceStore: maintenanceStore,
                 dockIconStore: dockIconStore,
                 launchAtLoginStore: launchAtLoginStore,
                 updater: updaterController.updater

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -175,7 +175,6 @@ struct MainWindowView: View {
 
     let store: WorkspaceStore
     let maintenanceStore: MaintenanceStore
-    @Environment(\.scenePhase) private var scenePhase
     @State private var selection: SidebarItem? = .baseHosts
     /// The profile pending deletion confirmation; a non-nil value shows the confirmation dialog.
     @State private var profilePendingDeletion: Profile?
@@ -265,8 +264,13 @@ struct MainWindowView: View {
                 selection = .baseHosts
             }
         }
-        .onChange(of: scenePhase) {
-            guard scenePhase == .active else { return }
+        // App activation, not scenePhase: on macOS the phase only flips when every
+        // window closes, so returning from System Settings never triggered it.
+        // SMAppService posts no status-change notification; re-reading on activation
+        // is the DTS-recommended way to catch toggles made in System Settings.
+        .onReceive(
+            NotificationCenter.default.publisher(for: NSApplication.didBecomeActiveNotification)
+        ) { _ in
             store.refreshSystemHosts()
             Task { await maintenanceStore.refreshHelperStatus() }
         }

--- a/Sources/Hostflip/MaintenanceStore.swift
+++ b/Sources/Hostflip/MaintenanceStore.swift
@@ -36,17 +36,49 @@ final class MaintenanceStore {
 
     private let loadHelperStatus: @Sendable () async -> DaemonRegistrationStatus
     private let unregisterHelper: @Sendable () async throws -> Void
+    private let wait: @Sendable (Duration) async -> Void
+    @ObservationIgnored private var approvalPollTask: Task<Void, Never>?
 
+    /// The wait closure is an injection seam so tests can skip the real poll interval.
     init(
         helperStatus: @escaping @Sendable () async -> DaemonRegistrationStatus,
-        unregisterHelper: @escaping @Sendable () async throws -> Void
+        unregisterHelper: @escaping @Sendable () async throws -> Void,
+        wait: @escaping @Sendable (Duration) async -> Void = { try? await Task.sleep(for: $0) }
     ) {
         loadHelperStatus = helperStatus
         self.unregisterHelper = unregisterHelper
+        self.wait = wait
     }
 
     func refreshHelperStatus() async {
         helperStatus = await loadHelperStatus()
+        updateApprovalPolling()
+    }
+
+    /// SMAppService offers no status-change notification, so while approval is pending
+    /// the store polls: the toggle flipped in System Settings unblocks the UI without
+    /// the user having to switch back to the app first. The loop is bounded — it only
+    /// runs while the status stays `requiresApproval` and stops itself on any other
+    /// answer.
+    private func updateApprovalPolling() {
+        guard helperStatus == .requiresApproval else {
+            approvalPollTask?.cancel()
+            approvalPollTask = nil
+            return
+        }
+        guard approvalPollTask == nil else { return }
+        approvalPollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                guard let self else { return }
+                await self.wait(.seconds(2))
+                if Task.isCancelled { return }
+                self.helperStatus = await self.loadHelperStatus()
+                if self.helperStatus != .requiresApproval {
+                    self.approvalPollTask = nil
+                    return
+                }
+            }
+        }
     }
 
     func removeHelper() async {
@@ -65,6 +97,7 @@ final class MaintenanceStore {
                 "Could not remove the helper. Try again. Your profiles were not changed. \(error.localizedDescription)"
             )
         }
+        updateApprovalPolling()
     }
 
 }

--- a/Tests/HostflipTests/MaintenanceStoreTests.swift
+++ b/Tests/HostflipTests/MaintenanceStoreTests.swift
@@ -76,11 +76,86 @@ final class MaintenanceStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testApprovalPollingReflectsExternalApprovalWithoutManualRefresh() async {
+        let helper = HelperMaintenanceStub(status: .requiresApproval)
+        let gate = PollGate()
+        let store = MaintenanceStore(
+            helperStatus: { await helper.currentStatus() },
+            unregisterHelper: { try await helper.unregister() },
+            wait: { _ in await gate.waitForTick() }
+        )
+
+        await store.refreshHelperStatus()
+        XCTAssertEqual(store.helperStatus, .requiresApproval)
+
+        // Approve externally (the System Settings toggle), then release one poll cycle.
+        await helper.setStatus(.enabled)
+        await gate.tick()
+        await waitUntil { store.helperStatus == .enabled }
+        XCTAssertEqual(store.helperStatus, .enabled)
+    }
+
+    @MainActor
+    func testApprovalPollingStopsOnceStatusSettles() async {
+        let helper = HelperMaintenanceStub(status: .requiresApproval)
+        let gate = PollGate()
+        let store = MaintenanceStore(
+            helperStatus: { await helper.currentStatus() },
+            unregisterHelper: { try await helper.unregister() },
+            wait: { _ in await gate.waitForTick() }
+        )
+
+        await store.refreshHelperStatus()
+        await helper.setStatus(.enabled)
+        await gate.tick()
+        await waitUntil { store.helperStatus == .enabled }
+
+        // A settled poll loop must not pick this up: no cycle should still be waiting.
+        await helper.setStatus(.requiresApproval)
+        await gate.tick()
+        for _ in 0 ..< 50 { await Task.yield() }
+        XCTAssertEqual(store.helperStatus, .enabled, "轮询应在批准后停止")
+    }
+
+    /// Yields until the condition holds (the poll task needs a few actor hops to land).
+    @MainActor
+    private func waitUntil(_ condition: () -> Bool) async {
+        for _ in 0 ..< 1000 {
+            if condition() { return }
+            await Task.yield()
+        }
+        XCTFail("等待条件超时")
+    }
+
+    @MainActor
     private func makeStore(helper: HelperMaintenanceStub) -> MaintenanceStore {
         MaintenanceStore(
             helperStatus: { await helper.currentStatus() },
             unregisterHelper: { try await helper.unregister() }
         )
+    }
+}
+
+/// Deterministic stand-in for the poll interval: each waitForTick() suspends until
+/// the test releases it with tick().
+private actor PollGate {
+    private var waiters: [CheckedContinuation<Void, Never>] = []
+    private var pendingTicks = 0
+
+    func waitForTick() async {
+        if pendingTicks > 0 {
+            pendingTicks -= 1
+            return
+        }
+        await withCheckedContinuation { waiters.append($0) }
+    }
+
+    func tick() {
+        if waiters.isEmpty {
+            pendingTicks += 1
+        } else {
+            waiters.removeFirst().resume()
+        }
     }
 }
 


### PR DESCRIPTION
## Changes

- **Settings > Helper tab**: the helper-management block (status, approval shortcut, deactivate-and-remove flow) previously lived only in the toolbar popover. It is now extracted into a shared `HelperMaintenanceSection` hosted by both the popover and a new Settings tab, sharing one `MaintenanceStore` so the two entry points always agree. Settings is where users expect to find privileged-component removal, e.g. before uninstalling.
- **Helper status refresh**: `SMAppService` posts no status-change notification, and on macOS `scenePhase` only flips when every window closes — so approval toggles made in System Settings were not reflected until relaunch. The status is now re-read on `NSApplication.didBecomeActiveNotification`, and while approval is pending the store polls every 2 seconds so approving in System Settings unblocks the UI without switching back to the app. Covered by two new deterministic tests with an injected poll-interval gate.
- **Popover feedback wrapping**: long feedback messages (e.g. the helper-removed confirmation) no longer truncate to a single ellipsized line.