### PR TITLE
fix: stop toolbar and editor flicker on profile edits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,3 +63,6 @@ fastlane/test_output
 
 # hostflip packaging output (scripts/build-app.sh)
 build/
+
+# macOS
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -45,6 +45,23 @@ The first time you actually switch something, macOS asks you to approve the help
 
 Technical deep-dives live in [`docs/`](docs/): signed-build verification, helper re-registration behavior, DNS flush measurements, and the release pipeline, all with reproducible steps.
 
+## FAQ
+
+**I switched profiles, but my browser still resolves the old address.**
+
+The system side is already complete — every write ends with a full DNS flush (`dscacheutil -flushcache` plus a `HUP` to `mDNSResponder`). What ignores it is the browser itself, in two layers: browsers keep a private DNS cache (roughly a minute), and — the bigger one — they keep established HTTP/2 and HTTP/3 connections alive for minutes. A reload rides an existing connection to the old address without resolving anything, which is why the behavior looks random and why restarting the browser "fixes" it. No hosts switcher can reach inside another process to clear these.
+
+To pick up a switch without restarting the browser:
+
+- **Chrome / Edge**: open `chrome://net-internals/#dns` (`edge://net-internals/#dns`) and click **Clear host cache**; then — the step that actually matters — `chrome://net-internals/#sockets` → **Flush socket pools**. A fresh incognito window also works: it gets its own DNS cache and connection pool (a plain new window shares them).
+- **Firefox**: `about:networking#dns` → Clear DNS Cache. There is no UI for the connection pool, so a private window is the practical route.
+- **Safari**: exposes neither; restart it or wait for idle connections to time out.
+- DevTools' "Disable cache" does not help — it only affects the HTTP cache, not DNS or connection reuse.
+
+To confirm the switch itself took effect, ask the system resolver directly: `dscacheutil -q host -a name your.host.name`. If that returns the new address, hostflip did its job and what you're seeing is browser-side.
+
+One adjacent trap: with DNS-over-HTTPS enabled (Chrome's "Secure DNS", Firefox's TRR), some configurations bypass `/etc/hosts` entirely. That shows up as hosts entries *never* working — different from needing a browser restart.
+
 ## Updating
 
 - Homebrew: `brew upgrade --cask hostflip`

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -10,6 +10,11 @@ import SwiftUI
 struct HostsEditor: NSViewRepresentable {
     @Binding var text: String
     var isEditable = true
+    /// Identity of the document being shown. A persistent editor instance switches documents in
+    /// place (the detail pane reuses one NSScrollView so switching never re-creates the text
+    /// system, which would flash a zero-sized editor for a frame); a change of identity resets
+    /// the per-document view state: undo stack, selection, scroll position, and the find bar.
+    var documentID: AnyHashable = "single-document"
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = NSTextView.scrollableTextView()
@@ -57,23 +62,47 @@ struct HostsEditor: NSViewRepresentable {
         let textView = scrollView.documentView as! NSTextView
         textView.isEditable = isEditable
         textView.allowsUndo = isEditable
+        let documentChanged = context.coordinator.documentID != documentID
+        if documentChanged {
+            context.coordinator.documentID = documentID
+            // The undo stack belongs to the previous document; replaying it into this one
+            // would splice the old document's text in.
+            context.coordinator.textUndoManager.removeAllActions()
+            // TextFinder highlights reference the previous content; drop the bar with them.
+            if scrollView.isFindBarVisible {
+                scrollView.isFindBarVisible = false
+            }
+        }
         if textView.string != text { // guard against the delegate write-back loop
             textView.string = text
             Self.highlight(textView)
             scrollView.verticalRulerView?.needsDisplay = true
         }
+        if documentChanged {
+            textView.setSelectedRange(NSRange(location: 0, length: 0))
+            textView.scroll(.zero)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
-        Coordinator(text: $text)
+        Coordinator(text: $text, documentID: documentID)
     }
 
     @MainActor
     final class Coordinator: NSObject, NSTextViewDelegate {
         var text: Binding<String>
+        var documentID: AnyHashable
+        /// Dedicated undo manager so clearing it on a document switch cannot touch
+        /// undo state registered elsewhere in the window (e.g. the name field).
+        let textUndoManager = UndoManager()
 
-        init(text: Binding<String>) {
+        init(text: Binding<String>, documentID: AnyHashable) {
             self.text = text
+            self.documentID = documentID
+        }
+
+        func undoManager(for view: NSTextView) -> UndoManager? {
+            textUndoManager
         }
 
         func textDidChange(_ notification: Notification) {

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -300,24 +300,9 @@ struct MainWindowView: View {
             ToolbarItem(placement: .automatic) {
                 HelperToolbarControl(store: store, maintenanceStore: maintenanceStore)
             }
-
-            ToolbarItem(placement: .automatic) {
-                Toggle("Enable hostflip", isOn: Binding(
-                    get: { !store.isPaused },
-                    set: { store.setPaused(!$0) }
-                ))
-                .labelsHidden()
-                .toggleStyle(.switch)
-                .controlSize(.small)
-                .disabled(store.model == nil || store.isSwitching || store.hasHostsDrift)
-                .help(store.isPaused ? "Resume hostflip" : "Pause hostflip")
-                .accessibilityLabel("Enable hostflip")
-                .padding(.trailing, 8)
-            }
-            .hidingSharedBackgroundWhenAvailable()
         }
         .background {
-            NativeToolbarFlexibleSpace(trailingItemCount: 1)
+            TitlebarSwitchAccessory(store: store)
         }
         .confirmationDialog(
             "Delete “\(profilePendingDeletion?.name ?? "")”?",
@@ -1512,116 +1497,6 @@ private struct ProfileEditorPane: View {
             await Task.yield()
             nameFieldFocused = true
             nameFocusConsumed()
-        }
-    }
-}
-
-/// SwiftUI has no trailing Toolbar placement on macOS; inserting a native flexible-space into
-/// the existing NSToolbar keeps the last group of items pinned to the right edge of the title bar.
-private struct NativeToolbarFlexibleSpace: NSViewRepresentable {
-    let trailingItemCount: Int
-
-    func makeNSView(context: Context) -> ToolbarFlexibleSpaceInstallerView {
-        let view = ToolbarFlexibleSpaceInstallerView()
-        view.trailingItemCount = trailingItemCount
-        return view
-    }
-
-    func updateNSView(_ nsView: ToolbarFlexibleSpaceInstallerView, context: Context) {
-        nsView.trailingItemCount = trailingItemCount
-        nsView.scheduleInstallation()
-    }
-}
-
-private final class ToolbarFlexibleSpaceInstallerView: NSView {
-    var trailingItemCount = 1
-    private weak var observedToolbar: NSToolbar?
-    private var isInstalling = false
-
-    override func viewDidMoveToWindow() {
-        super.viewDidMoveToWindow()
-        guard window != nil else {
-            stopObservingToolbar()
-            return
-        }
-        scheduleInstallation()
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
-    }
-
-    func scheduleInstallation() {
-        DispatchQueue.main.async { [weak self] in
-            self?.installSpace()
-        }
-    }
-
-    @objc private func toolbarItemsDidChange(_: Notification) {
-        guard !isInstalling else { return }
-        scheduleInstallation()
-    }
-
-    private func installSpace() {
-        guard let toolbar = window?.toolbar else { return }
-        observe(toolbar)
-
-        let existingIndex = toolbar.items.firstIndex(where: {
-            $0.itemIdentifier == .flexibleSpace
-        })
-        let itemCountWithoutSpace = toolbar.items.count - (existingIndex == nil ? 0 : 1)
-        let insertionIndex = max(itemCountWithoutSpace - trailingItemCount, 0)
-        guard existingIndex != insertionIndex else { return }
-
-        isInstalling = true
-        defer { isInstalling = false }
-        if let existingIndex {
-            toolbar.removeItem(at: existingIndex)
-        }
-        toolbar.insertItem(withItemIdentifier: .flexibleSpace, at: insertionIndex)
-    }
-
-    private func observe(_ toolbar: NSToolbar) {
-        guard observedToolbar !== toolbar else { return }
-        stopObservingToolbar()
-        observedToolbar = toolbar
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(toolbarItemsDidChange(_:)),
-            name: NSToolbar.willAddItemNotification,
-            object: toolbar
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(toolbarItemsDidChange(_:)),
-            name: NSToolbar.didRemoveItemNotification,
-            object: toolbar
-        )
-    }
-
-    private func stopObservingToolbar() {
-        guard let observedToolbar else { return }
-        NotificationCenter.default.removeObserver(
-            self,
-            name: NSToolbar.willAddItemNotification,
-            object: observedToolbar
-        )
-        NotificationCenter.default.removeObserver(
-            self,
-            name: NSToolbar.didRemoveItemNotification,
-            object: observedToolbar
-        )
-        self.observedToolbar = nil
-    }
-}
-
-private extension ToolbarContent {
-    @ToolbarContentBuilder
-    func hidingSharedBackgroundWhenAvailable() -> some ToolbarContent {
-        if #available(macOS 26.0, *) {
-            sharedBackgroundVisibility(.hidden)
-        } else {
-            self
         }
     }
 }

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -901,10 +901,14 @@ struct MainWindowView: View {
                 description: Text(loadError)
             )
         } else {
+            let editedProfile: Profile? = {
+                if case .profile(let profileID) = selection { return store.profile(profileID) }
+                return nil
+            }()
             VStack(spacing: 0) {
                 MainWindowStateBanner(store: store, presentation: presentation)
-                if case .profile(let profileID) = selection, let profile = store.profile(profileID) {
-                    ProfileEditorPane(
+                if let profile = editedProfile {
+                    ProfileEditorHeader(
                         store: store,
                         profile: profile,
                         presentation: presentation,
@@ -916,12 +920,35 @@ struct MainWindowView: View {
                         },
                         requestDeletion: { profilePendingDeletion = profile }
                     )
-                    .id(profile.id) // Rebuild the pane when the profile changes so the name draft never leaks across profiles
+                    .id(profile.id) // Rebuild the header when the profile changes so the name draft never leaks across profiles
                 } else {
-                    BaseHostsViewerPane(store: store)
+                    BaseHostsHeader()
                 }
+                Divider()
+                sharedEditor(for: editedProfile)
             }
         }
+    }
+
+    /// One persistent editor below the switching headers: a document switch (including the first
+    /// profile created from Base Hosts) swaps content in place instead of re-creating the
+    /// NSScrollView, whose zero-sized first frame could flash before SwiftUI sizes it.
+    private func sharedEditor(for profile: Profile?) -> some View {
+        let profileID = profile?.id
+        return HostsEditor(
+            text: Binding(
+                get: {
+                    if let profileID { return store.profile(profileID)?.content ?? "" }
+                    return store.baseHostsContent
+                },
+                set: { newValue in
+                    guard let profileID else { return }
+                    store.updateProfileContent(profileID, content: newValue)
+                }
+            ),
+            isEditable: profileID != nil,
+            documentID: profileID.map { AnyHashable($0) } ?? AnyHashable("base-hosts")
+        )
     }
 }
 
@@ -1344,43 +1371,34 @@ private struct SystemHostsViewerPane: View {
     }
 }
 
-/// Read-only Base Hosts pane: the content can only be updated, in a controlled way, through the drift reconciliation flow.
-private struct BaseHostsViewerPane: View {
-    let store: WorkspaceStore
-
+/// Read-only Base Hosts header: the content below can only be updated, in a controlled way, through the drift reconciliation flow.
+private struct BaseHostsHeader: View {
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    Text("Base Hosts")
-                        .font(.headline)
-                    Text("Protected · Read Only")
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                Label("Always Active", systemImage: "lock.fill")
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text("Base Hosts")
+                    .font(.headline)
+                Text("Protected · Read Only")
                     .font(.caption)
                     .foregroundStyle(.secondary)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 3)
-                    .background(.primary.opacity(0.06), in: Capsule())
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            Divider()
-            HostsEditor(
-                text: Binding(get: { store.baseHostsContent }, set: { _ in }),
-                isEditable: false
-            )
+            Spacer()
+            Label("Always Active", systemImage: "lock.fill")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background(.primary.opacity(0.06), in: Capsule())
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
     }
 }
 
-/// Profile editor pane: the header holds the renamable profile name, an ownership caption, and
-/// the "make active" pill; the body is the highlighting editor. Renames apply on commit or focus
-/// loss, never rewriting the profile file per keystroke.
-private struct ProfileEditorPane: View {
+/// Profile editor header: holds the renamable profile name, an ownership caption, and the
+/// "make active" pill; the highlighting editor below it is shared across documents. Renames
+/// apply on commit or focus loss, never rewriting the profile file per keystroke.
+private struct ProfileEditorHeader: View {
     let store: WorkspaceStore
     let profile: Profile
     let presentation: MainWindowPresentation
@@ -1408,49 +1426,42 @@ private struct ProfileEditorPane: View {
     }
 
     var body: some View {
-        VStack(spacing: 0) {
-            HStack(spacing: 10) {
-                VStack(alignment: .leading, spacing: 2) {
-                    TextField("Profile Name", text: $draftName)
-                        .textFieldStyle(.plain)
-                        .font(.headline)
-                        .focused($nameFieldFocused)
-                        .onSubmit(commitRename)
-                        .onChange(of: nameFieldFocused) {
-                            if !nameFieldFocused { commitRename() }
-                        }
-                        .onExitCommand {
-                            draftName = profile.name
-                            nameFieldFocused = false
-                        }
-                    Text(locationDescription)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                }
-                Spacer()
-                SaveErrorText(store: store)
-                if store.isSwitching {
-                    ProgressView()
-                        .controlSize(.small)
-                }
-                activePill
-                Button {
-                    requestDeletion()
-                } label: {
-                    Image(systemName: "trash")
-                }
-                .buttonStyle(.borderless)
-                .disabled(store.isSwitching)
-                .help("Delete Profile")
+        HStack(spacing: 10) {
+            VStack(alignment: .leading, spacing: 2) {
+                TextField("Profile Name", text: $draftName)
+                    .textFieldStyle(.plain)
+                    .font(.headline)
+                    .focused($nameFieldFocused)
+                    .onSubmit(commitRename)
+                    .onChange(of: nameFieldFocused) {
+                        if !nameFieldFocused { commitRename() }
+                    }
+                    .onExitCommand {
+                        draftName = profile.name
+                        nameFieldFocused = false
+                    }
+                Text(locationDescription)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
             }
-            .padding(.horizontal, 16)
-            .padding(.vertical, 10)
-            Divider()
-            HostsEditor(text: Binding(
-                get: { store.profile(profile.id)?.content ?? "" },
-                set: { store.updateProfileContent(profile.id, content: $0) }
-            ))
+            Spacer()
+            SaveErrorText(store: store)
+            if store.isSwitching {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            activePill
+            Button {
+                requestDeletion()
+            } label: {
+                Image(systemName: "trash")
+            }
+            .buttonStyle(.borderless)
+            .disabled(store.isSwitching)
+            .help("Delete Profile")
         }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 10)
         .onAppear { focusNameIfRequested() }
         .onChange(of: focusName) { focusNameIfRequested() }
     }

--- a/Sources/Hostflip/TitlebarSwitchAccessory.swift
+++ b/Sources/Hostflip/TitlebarSwitchAccessory.swift
@@ -1,0 +1,72 @@
+import AppKit
+import SwiftUI
+
+/// SwiftUI has no trailing Toolbar placement on macOS (ToolbarSpacer needs macOS 26), and any
+/// item living in the SwiftUI-managed NSToolbar shifts while SwiftUI rebuilds its items. A
+/// titlebar accessory pinned to the trailing edge sits outside the toolbar entirely, so the
+/// switch never moves no matter how often the toolbar is rebuilt.
+struct TitlebarSwitchAccessory: NSViewRepresentable {
+    let store: WorkspaceStore
+
+    func makeNSView(context: Context) -> TitlebarSwitchInstallerView {
+        TitlebarSwitchInstallerView(store: store)
+    }
+
+    func updateNSView(_ nsView: TitlebarSwitchInstallerView, context: Context) {}
+}
+
+final class TitlebarSwitchInstallerView: NSView {
+    private let store: WorkspaceStore
+    private var accessory: NSTitlebarAccessoryViewController?
+
+    init(store: WorkspaceStore) {
+        self.store = store
+        super.init(frame: .zero)
+    }
+
+    @available(*, unavailable)
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) is not supported")
+    }
+
+    override func viewDidMoveToWindow() {
+        super.viewDidMoveToWindow()
+        if let accessory, accessory.view.window !== window {
+            accessory.removeFromParent()
+            self.accessory = nil
+        }
+        guard let window, accessory == nil else { return }
+
+        let controller = NSTitlebarAccessoryViewController()
+        controller.layoutAttribute = .trailing
+        let hostingView = NSHostingView(rootView: TitlebarSwitchToggle(store: store))
+        hostingView.setFrameSize(hostingView.fittingSize)
+        controller.view = hostingView
+        window.addTitlebarAccessoryViewController(controller)
+        accessory = controller
+    }
+}
+
+private struct TitlebarSwitchToggle: View {
+    let store: WorkspaceStore
+
+    var body: some View {
+        Toggle("Enable hostflip", isOn: Binding(
+            get: { !store.isPaused },
+            set: { enabled in
+                // Same split as activationControlsDisabled/Dimmed: the sub-second
+                // in-flight switch only guards clicks — disabling on it would flash
+                // the control dim on every profile toggle.
+                guard !store.isSwitching else { return }
+                store.setPaused(!enabled)
+            }
+        ))
+        .labelsHidden()
+        .toggleStyle(.switch)
+        .controlSize(.small)
+        .disabled(store.model == nil || store.hasHostsDrift)
+        .help(store.isPaused ? "Resume hostflip" : "Pause hostflip")
+        .accessibilityLabel("Enable hostflip")
+        .padding(.trailing, 8)
+    }
+}


### PR DESCRIPTION
- **fix**: the trailing pause switch now lives in a titlebar accessory, so SwiftUI toolbar rebuilds no longer shift it left and back on every profile create or edit; the in-flight switch window only guards clicks instead of dim-flashing the control
- **fix**: the detail pane keeps one persistent hosts editor and switches documents in place, eliminating the small-then-full flash of the editor on the first profile created after launch; a document switch resets undo, selection, scroll, and the find bar
- **docs**: FAQ entry on why browsers lag behind a hosts switch (private DNS cache plus connection reuse) with per-browser recovery steps
- **chore**: ignore .DS_Store