### PR TITLE
build: bump version to 0.1.6

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.5</string>
+	<string>0.1.6</string>
 	<key>CFBundleVersion</key>
-	<string>6</string>
+	<string>7</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -13,5 +13,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.1.5"
+    public static let version = "0.1.6"
 }


### PR DESCRIPTION
Release prep for v0.1.6: menu bar state readability improvements (badges, ordering, paused/drift icon states) and the UI flicker fixes.