### PR TITLE
feat: add the hostflip cli companion binary

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -40,6 +40,10 @@ _Avoid_: apply, sync
 The state after the master switch is turned off; only Base Hosts is written to the system hosts file, while every profile's active state is preserved.
 _Avoid_: disabled, deactivated
 
+**Resume**:
+The act of turning the master switch back on, ending the Paused state; every preserved active profile re-enters the merge.
+_Avoid_: unpause, re-enable
+
 **Dock Icon Visibility Policy**:
 Controls how the app's Dock icon is shown — "When Main Window Is Open", "Always", or "Never"; does not affect the always-visible menu bar entry.
 _Avoid_: menu-bar-only mode, menu bar switch

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,11 @@ let package = Package(
     products: [
         .library(name: "HostflipCore", targets: ["HostflipCore"]),
         .library(name: "HostflipXPC", targets: ["HostflipXPC"]),
-        .executable(name: "Hostflip", targets: ["Hostflip"]),
+        // The app product is named HostflipApp (not Hostflip) so its build artifact cannot
+        // collide with the `hostflip` CLI binary on case-insensitive APFS; the bundle still
+        // ships the binary as Contents/MacOS/Hostflip (renamed by scripts/build-app.sh).
+        .executable(name: "HostflipApp", targets: ["Hostflip"]),
+        .executable(name: "hostflip", targets: ["HostflipCLI"]),
         .executable(name: "hostflipd", targets: ["hostflipd"]),
     ],
     dependencies: [
@@ -27,8 +31,10 @@ let package = Package(
                 .product(name: "Sparkle", package: "Sparkle"),
             ]
         ),
+        .executableTarget(name: "HostflipCLI", dependencies: ["HostflipCore", "HostflipXPC"]),
         .executableTarget(name: "hostflipd", dependencies: ["HostflipCore", "HostflipXPC"]),
         .testTarget(name: "HostflipCoreTests", dependencies: ["HostflipCore"]),
+        .testTarget(name: "HostflipCLITests", dependencies: ["HostflipCLI", "HostflipCore"]),
         .testTarget(name: "HostflipXPCTests", dependencies: ["HostflipCore", "HostflipXPC"]),
         .testTarget(name: "HostflipTests", dependencies: ["Hostflip", "HostflipCore", "HostflipXPC"]),
     ]

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ Editing `/etc/hosts` by hand — or typing your password every time a hosts mana
 
 ## Install
 
+Requires macOS 14 or later on Apple silicon.
+
 **Homebrew**
 
     brew tap heronapp/tap
@@ -40,8 +42,6 @@ Grab the notarized DMG from [Releases](https://github.com/heronapp/hostflip/rele
     sudo mkdir -p /usr/local/bin
     sudo ln -sf /Applications/Hostflip.app/Contents/Helpers/hostflip /usr/local/bin/hostflip
 
-Requires macOS 14 or later on Apple silicon.
-
 ## How it works
 
 hostflip owns the whole `/etc/hosts` file and rewrites it atomically: Base Hosts first, then every active profile, each section clearly labeled. Writes go through a minimal root daemon whose XPC interface accepts exactly one operation — replace the hosts file with merged content — with code-signing verification on both sides of the connection. The daemon flushes the DNS cache after every write.
@@ -49,6 +49,18 @@ hostflip owns the whole `/etc/hosts` file and rewrites it atomically: Base Hosts
 The first time you actually switch something, macOS asks you to approve the helper in System Settings. That's the only prompt you will ever see.
 
 Technical deep-dives live in [`docs/`](docs/): signed-build verification, helper re-registration behavior, DNS flush measurements, and the release pipeline, all with reproducible steps.
+
+## Command line
+
+The bundle ships with a `hostflip` CLI ([Install](#install) covers how it gets on your PATH). It works on the same workspace and daemon as the app, so both can be used side by side:
+
+    hostflip status                  # pause state, active profiles, hosts drift
+    hostflip list                    # group structure, every profile with its ID
+    hostflip activate staging/api    # switch, by name or group/profile path
+    hostflip cat staging/api         # print a profile's content as stored
+    hostflip write staging/api --file ./hosts.snippet
+
+Profile names are not unique — IDs are; pass `--id` when a name is ambiguous. For scripting and agents, `--json` puts a result object on stdout and structured errors with stable string codes on stderr, and exit codes are meaningful — in particular `3` means the system hosts drifted and hostflip won't write until you reconcile in the app. `hostflip --help` lists the full command surface.
 
 ## FAQ
 

--- a/README.md
+++ b/README.md
@@ -31,9 +31,14 @@ Editing `/etc/hosts` by hand — or typing your password every time a hosts mana
     brew trust heronapp/tap   # newer Homebrew requires trusting third-party taps once
     brew install --cask hostflip
 
+This installs the app and puts the bundled `hostflip` command-line tool on your PATH.
+
 **Direct download**
 
-Grab the notarized DMG from [Releases](https://github.com/heronapp/hostflip/releases/latest) and drag `Hostflip.app` into `/Applications`.
+Grab the notarized DMG from [Releases](https://github.com/heronapp/hostflip/releases/latest) and drag `Hostflip.app` into `/Applications`. To use the `hostflip` command-line tool, symlink it out of the bundle:
+
+    sudo mkdir -p /usr/local/bin
+    sudo ln -sf /Applications/Hostflip.app/Contents/Helpers/hostflip /usr/local/bin/hostflip
 
 Requires macOS 14 or later on Apple silicon.
 

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -53,6 +53,13 @@ struct ApplicationSettingsView: View {
                     Label("Helper", systemImage: "gearshape.2")
                 }
 
+            CLIInstallSection()
+                .padding(20)
+                .frame(width: 460, height: 250, alignment: .topLeading)
+                .tabItem {
+                    Label("Command Line", systemImage: "terminal")
+                }
+
             UpdatesSettingsView(updater: updater)
                 .padding(20)
                 .frame(width: 460, height: 190)

--- a/Sources/Hostflip/CLIInstallView.swift
+++ b/Sources/Hostflip/CLIInstallView.swift
@@ -1,0 +1,129 @@
+import AppKit
+import SwiftUI
+
+/// What `/usr/local/bin/hostflip` currently is, probed before presenting.
+enum CLIInstallLinkState: Equatable {
+    case absent
+    case linked(destination: String)
+    case occupiedByFile
+}
+
+enum CLIInstallProbe {
+    /// Reads the link without traversing it: `attributesOfItem` reports the
+    /// symlink itself, so a broken link still counts as linked, not absent.
+    static func linkState(at path: String) -> CLIInstallLinkState {
+        let fileManager = FileManager.default
+        guard let attributes = try? fileManager.attributesOfItem(atPath: path) else {
+            return .absent
+        }
+        guard attributes[.type] as? FileAttributeType == .typeSymbolicLink,
+              let destination = try? fileManager.destinationOfSymbolicLink(atPath: path) else {
+            return .occupiedByFile
+        }
+        return .linked(destination: destination)
+    }
+}
+
+struct CLIInstallPresentation {
+    static let linkPath = "/usr/local/bin/hostflip"
+
+    let command: String
+    let statusTitle: String
+    let statusColor: Color
+
+    init(cliPath: String, linkState: CLIInstallLinkState) {
+        command = """
+            sudo mkdir -p /usr/local/bin
+            sudo ln -sf \(Self.shellQuoted(cliPath)) \(Self.linkPath)
+            """
+        switch linkState {
+        case .absent:
+            statusTitle = "Not linked yet"
+            statusColor = .secondary
+        case .linked(let destination) where destination == cliPath:
+            statusTitle = "Linked at \(Self.linkPath)"
+            statusColor = .green
+        case .linked(let destination):
+            statusTitle = "Links elsewhere: \(destination)"
+            statusColor = .orange
+        case .occupiedByFile:
+            statusTitle = "Something else occupies \(Self.linkPath)"
+            statusColor = .orange
+        }
+    }
+
+    /// Quotes only when needed so the common /Applications path matches the
+    /// README's install one-liner character for character.
+    private static func shellQuoted(_ path: String) -> String {
+        let safe = CharacterSet(
+            charactersIn: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789/._-"
+        )
+        if path.unicodeScalars.allSatisfy(safe.contains) && !path.isEmpty {
+            return path
+        }
+        return "'" + path.replacingOccurrences(of: "'", with: "'\\''") + "'"
+    }
+}
+
+/// Settings > Command Line: the discoverable home of the CLI install command
+/// (#58). It presents and copies the command instead of creating the link:
+/// that needs root, and privileged work stays out of the app — the daemon's
+/// XPC surface deliberately has exactly one operation (ADR-0009), so the user
+/// runs the command in Terminal themselves. Homebrew installs never need it;
+/// the cask links the CLI into the Homebrew bin directory on install.
+struct CLIInstallSection: View {
+    @State private var linkState: CLIInstallLinkState = .absent
+    @State private var isShowingCopied = false
+
+    private let cliPath = Bundle.main.bundleURL
+        .appendingPathComponent("Contents/Helpers/hostflip").path
+
+    var body: some View {
+        let presentation = CLIInstallPresentation(cliPath: cliPath, linkState: linkState)
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 8) {
+                Label("Command-Line Tool", systemImage: "terminal")
+                    .font(.subheadline.weight(.semibold))
+                Text(
+                    "The bundled hostflip command drives the same profiles and helper as the app. Homebrew puts it on your PATH automatically; for a direct download, run this once in Terminal:"
+                )
+                .font(.callout)
+                .foregroundStyle(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+            }
+
+            Text(presentation.command)
+                .font(.system(.callout, design: .monospaced))
+                .textSelection(.enabled)
+                .lineLimit(nil)
+                .padding(10)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
+
+            HStack {
+                HStack(spacing: 5) {
+                    Image(systemName: "circle.fill")
+                        .font(.system(size: 7))
+                        .foregroundStyle(presentation.statusColor)
+                    Text(presentation.statusTitle)
+                        .font(.caption)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
+                }
+                Spacer()
+                Button(isShowingCopied ? "Copied" : "Copy Command") {
+                    let pasteboard = NSPasteboard.general
+                    pasteboard.clearContents()
+                    pasteboard.setString(presentation.command, forType: .string)
+                    isShowingCopied = true
+                    Task {
+                        try? await Task.sleep(for: .seconds(1.5))
+                        isShowingCopied = false
+                    }
+                }
+                .disabled(isShowingCopied)
+            }
+        }
+        .task { linkState = CLIInstallProbe.linkState(at: CLIInstallPresentation.linkPath) }
+    }
+}

--- a/Sources/Hostflip/HostflipMain.swift
+++ b/Sources/Hostflip/HostflipMain.swift
@@ -15,7 +15,7 @@ enum HostflipMain {
         case "--print-requirement":
             do {
                 // The requirement the app enforces when connecting to the daemon (same Team ID + daemon identifier)
-                print(try SigningIdentity.peerRequirement(identifier: ChannelIdentity.daemonIdentifier))
+                print(try SigningIdentity.peerRequirement(identifiers: [ChannelIdentity.daemonIdentifier]))
             } catch {
                 fail("Cannot construct peer requirement: \(error)")
             }

--- a/Sources/Hostflip/HostsDriftMonitor.swift
+++ b/Sources/Hostflip/HostsDriftMonitor.swift
@@ -22,11 +22,19 @@ final class HostsDriftMonitor:
     @unchecked Sendable {
     private let workspace: Workspace
     private let hostsURL: URL
+    /// A newly detected drift verdict waits out this confirmation window before it is reported:
+    /// an external writer's hosts write is visible before that writer records the new baseline
+    /// into the manifest (write first, record only after the daemon confirms), so a fresh
+    /// mismatch may be that gap rather than tampering. Only the report is deferred, never the
+    /// clearing — genuine drift still reports, just this much later, and a settled external
+    /// write dissolves instead of flashing the drift banner.
+    private let newDriftConfirmationDelay: DispatchTimeInterval
     private let queue = DispatchQueue(label: "com.heronapp.hostflip.hosts-drift-monitor")
 
     private var source: DispatchSourceFileSystemObject?
     private var isStarted = false
     private var retryScheduled = false
+    private var driftConfirmationScheduled = false
     private var pendingTargetWriteHashes: [String: Int] = [:]
     /// The latest target hash the daemon has confirmed but the manifest may not yet have successfully recorded.
     private var confirmedTargetHash: String?
@@ -36,10 +44,12 @@ final class HostsDriftMonitor:
 
     init(
         workspace: Workspace,
-        hostsURL: URL = URL(fileURLWithPath: "/etc/hosts")
+        hostsURL: URL = URL(fileURLWithPath: "/etc/hosts"),
+        newDriftConfirmationDelay: DispatchTimeInterval = .milliseconds(250)
     ) {
         self.workspace = workspace
         self.hostsURL = hostsURL
+        self.newDriftConfirmationDelay = newDriftConfirmationDelay
     }
 
     /// Idempotent start: arms the watcher first and then checks immediately, so no modification slips between the initial check and the watch.
@@ -183,7 +193,7 @@ final class HostsDriftMonitor:
         }
     }
 
-    private func checkNow() {
+    private func checkNow(deferringNewDrift: Bool = true) {
         let actualHash = (try? Data(contentsOf: hostsURL)).map(MergedHosts.hash(of:))
         let persistedHash = try? workspace.expectedSystemHostsHash()
         let expectedHash = confirmedTargetHash ?? persistedHash
@@ -197,6 +207,14 @@ final class HostsDriftMonitor:
             hasDrift = true
         }
 
+        // A drift verdict that would newly show the banner first waits out the confirmation
+        // window; the deferred re-evaluation reads fresh state, so a baseline that has caught
+        // up by then dissolves the verdict unreported. Nothing is recorded as reported here.
+        if deferringNewDrift, hasDrift, lastReportedDrift != true {
+            scheduleDriftConfirmation()
+            return
+        }
+
         // Drift-free self-writes also need a notification so the read-only System Hosts page can update in real time.
         let shouldReport = hasDrift != lastReportedDrift
             || actualHash != lastReportedActualHash
@@ -206,6 +224,16 @@ final class HostsDriftMonitor:
         guard let onChange else { return }
         Task { @MainActor in
             onChange(hasDrift)
+        }
+    }
+
+    private func scheduleDriftConfirmation() {
+        guard !driftConfirmationScheduled else { return }
+        driftConfirmationScheduled = true
+        queue.asyncAfter(deadline: .now() + newDriftConfirmationDelay) { [self] in
+            driftConfirmationScheduled = false
+            guard isStarted else { return }
+            checkNow(deferringNewDrift: false)
         }
     }
 }

--- a/Sources/Hostflip/HostsDriftMonitor.swift
+++ b/Sources/Hostflip/HostsDriftMonitor.swift
@@ -5,6 +5,11 @@ import HostflipXPC
 
 protocol HostsDriftMonitoring: Sendable {
     func start(onChange: @escaping @MainActor @Sendable (Bool) -> Void)
+    /// Re-evaluates drift from the on-disk state, reporting through the start callback if the
+    /// verdict changed. An external writer's hosts file event can reach the monitor before that
+    /// writer records the new baseline into the manifest — its change notification arrives after
+    /// the record, so a recheck then clears the stale verdict (ADR-0010 ③).
+    func recheck()
 }
 
 /// Watches the system hosts while the app is resident. All file descriptors and state are
@@ -47,6 +52,12 @@ final class HostsDriftMonitor:
             }
             isStarted = true
             armSource()
+            checkNow()
+        }
+    }
+
+    func recheck() {
+        queue.async { [self] in
             checkNow()
         }
     }

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -232,6 +232,10 @@ final class WorkspaceStore {
     /// edits in memory, and an in-flight switch or reconciliation commits through its own
     /// reload-and-replay — those paths reconcile with external changes at save time instead.
     func refreshFromExternalChange() {
+        // Always re-evaluate drift, even when the model refresh below is skipped: the writer's
+        // hosts file event may have outrun its manifest record, and this notification (posted
+        // after the record) is what clears the resulting stale drift verdict.
+        driftMonitor?.recheck()
         guard model != nil, saveError == nil, !isSwitching, !isReconciling else { return }
         guard let latest = try? workspace.openReadOnly() else { return }
         model = latest

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -106,6 +106,16 @@ final class WorkspaceStore {
     /// workspace persistence is not yet confirmed, keep blocking new writes even if the
     /// monitor briefly reports no drift.
     private var reconciliationNeedsAttention = false
+    /// DistributedNotificationCenter observer token for external workspace-change signals
+    /// (ADR-0010 ③); registered by the production initializer only. Not observation state, and
+    /// nonisolated(unsafe) because the nonisolated deinit reads it — it is written only once.
+    @ObservationIgnored nonisolated(unsafe) private var externalChangeObserver: (any NSObjectProtocol)?
+
+    deinit {
+        if let externalChangeObserver {
+            DistributedNotificationCenter.default().removeObserver(externalChangeObserver)
+        }
+    }
 
     convenience init(registrar: DaemonRegistrar) {
         let workspace = Workspace(rootDirectory: Workspace.defaultRootDirectory)
@@ -126,6 +136,7 @@ final class WorkspaceStore {
             driftMonitor: driftMonitor,
             readSystemHosts: { try Data(contentsOf: hostsURL) }
         )
+        observeExternalWorkspaceChanges()
     }
 
     /// Injection seam: tests substitute a temporary workspace + a coordinator stub for real XPC.
@@ -197,6 +208,35 @@ final class WorkspaceStore {
         } catch {
             systemHostsContent = nil
             systemHostsReadError = "Cannot read /etc/hosts: \(error)"
+        }
+    }
+
+    /// Subscribes to the external writers' change signal (ADR-0010 ③), filtered to this
+    /// workspace. Production wiring only: tests drive refreshFromExternalChange directly.
+    private func observeExternalWorkspaceChanges() {
+        let refresh: @MainActor @Sendable () -> Void = { [weak self] in
+            self?.refreshFromExternalChange()
+        }
+        externalChangeObserver = DistributedNotificationCenter.default().addObserver(
+            forName: Workspace.changeNotification,
+            object: workspace.changeNotificationObject,
+            queue: .main
+        ) { _ in
+            MainActor.assumeIsolated(refresh)
+        }
+    }
+
+    /// Re-reads the workspace after an external writer announced a change (ADR-0010 ③) and
+    /// refreshes the display; the notification is untrusted, so receipt only ever triggers this
+    /// re-read. Skipped whenever local state may diverge from disk — a failed save keeps unsaved
+    /// edits in memory, and an in-flight switch or reconciliation commits through its own
+    /// reload-and-replay — those paths reconcile with external changes at save time instead.
+    func refreshFromExternalChange() {
+        guard model != nil, saveError == nil, !isSwitching, !isReconciling else { return }
+        guard let latest = try? workspace.openReadOnly() else { return }
+        model = latest
+        if hasHostsDrift {
+            refreshHostsDriftComparison()
         }
     }
 
@@ -468,27 +508,25 @@ final class WorkspaceStore {
         return preview
     }
 
-    /// The merge has succeeded: replay this change on the latest model and persist it. The system
-    /// hosts is already updated at this point, so a save failure only affects the manifest — the
-    /// feedback is still a successful switch, with the save error reported separately.
+    /// The merge has succeeded: commit this change by replaying it on the latest persisted state —
+    /// neither edits saved while the switch was in flight nor an external writer's changes are
+    /// rolled back (ADR-0010 ②). The system hosts is already updated at this point, so a save
+    /// failure only affects the manifest — the feedback is still a successful switch, with the
+    /// save error reported separately.
     /// A follow-up merge is scheduled at the end: if in-flight edits were queued ahead of this
     /// switch, it converges the latest content into the system hosts; when the content matches,
     /// the daemon short-circuits idempotently and no extra write happens.
     private func commitSwitched(_ change: (inout ActivationModel) throws -> Void) {
         defer { scheduleFollowUpMerge() }
-        guard var current = model else { return }
         do {
-            try change(&current)
-        } catch {
-            // Replay conflict (e.g. the profile was deleted mid-flight): do not commit; the follow-up merge converges the system hosts back to the current model
-            return
-        }
-        model = current
-        do {
-            try workspace.save(current)
-            saveError = nil
+            guard case .saved = try persistByReplaying(change) else {
+                // Replay conflict (e.g. the profile was deleted mid-flight): do not commit; the
+                // follow-up merge converges the system hosts back to the current model
+                return
+            }
             backgroundSyncError = nil
         } catch {
+            // The change stays committed in memory (persistByReplaying); only the disk write failed
             saveError = "Save failed: \(error)"
         }
         switchFeedback = .merged
@@ -514,17 +552,23 @@ final class WorkspaceStore {
               var updated = model else { return }
         let reviewedGeneration = hostsDriftGeneration
 
+        // The reviewed change in replayable form: replayed on the latest persisted state at commit
+        // time (ADR-0010 ②), so profile and active-state changes made while the reconcile is in
+        // flight are not rolled back. The base content is deliberately the snapshot value computed
+        // at review time — it is exactly what this reconcile writes into the system hosts, and the
+        // CLI (the only external writer) has no command that edits Base Hosts.
+        let change: (inout ActivationModel) -> Void
         switch choice {
         case .addDriftLinesToBaseHosts:
-            updated.baseHosts.content = comparison.appendingDriftAdditions(
-                to: updated.baseHosts.content
-            )
+            let reviewedBase = comparison.appendingDriftAdditions(to: updated.baseHosts.content)
+            change = { $0.baseHosts.content = reviewedBase }
         case .overwriteDriftWithActiveState:
-            break
+            change = { _ in }
         case .later:
             reconciliationTask = nil
             return
         }
+        change(&updated)
 
         followUpMergeTask?.cancel()
         isReconciling = true
@@ -540,7 +584,7 @@ final class WorkspaceStore {
                 switch outcome.guidance(targetHash: updated.mergedHosts.hash) {
                 case .merged:
                     guard reconciliationSnapshotIsCurrent(reviewedGeneration),
-                          persistReconciledModel(updated) else { return }
+                          persistReconciledModel(applying: change) else { return }
                     hasHostsDrift = false
                     hostsDriftComparison = nil
                     reconciliationError = nil
@@ -556,7 +600,7 @@ final class WorkspaceStore {
                     // user's choice about the drifted content must be saved now, or the next
                     // normal write would overwrite the preserved lines.
                     guard reconciliationSnapshotIsCurrent(reviewedGeneration),
-                          persistReconciledModel(updated, writtenHash: failure.writtenHash)
+                          persistReconciledModel(applying: change, writtenHash: failure.writtenHash)
                     else { return }
                     hasHostsDrift = false
                     hostsDriftComparison = nil
@@ -604,7 +648,7 @@ final class WorkspaceStore {
     func useSystemHostsAsBase() {
         guard useSystemHostsAsBaseUnavailableReason == nil,
               let comparison = hostsDriftComparison,
-              var updated = model else { return }
+              model != nil else { return }
 
         followUpMergeTask?.cancel()
         followUpMergeTask = nil
@@ -625,9 +669,13 @@ final class WorkspaceStore {
                 return
             }
 
-            updated.baseHosts.content = latestContent
-            try workspace.save(updated, acceptingSystemHostsHash: latestHash)
-            model = updated
+            guard case .saved = try persistByReplaying(
+                { $0.baseHosts.content = latestContent },
+                acceptingSystemHostsHash: latestHash
+            ) else {
+                assertionFailure("a non-throwing base replacement cannot conflict")
+                return
+            }
             systemHostsContent = latestContent
             systemHostsReadError = nil
             reconciliationNeedsAttention = false
@@ -657,12 +705,14 @@ final class WorkspaceStore {
     }
 
     private func persistReconciledModel(
-        _ updated: ActivationModel,
+        applying change: (inout ActivationModel) -> Void,
         writtenHash: String? = nil
     ) -> Bool {
-        model = updated
         do {
-            try workspace.save(updated)
+            guard case .saved = try persistByReplaying(change) else {
+                assertionFailure("a non-throwing reconciliation change cannot conflict")
+                return false
+            }
             if let writtenHash {
                 try workspace.recordLastWrittenHash(writtenHash)
             }
@@ -671,6 +721,7 @@ final class WorkspaceStore {
             backgroundSyncError = nil
             return true
         } catch {
+            // The change stays committed in memory (persistByReplaying); only the disk write failed
             saveError = "Save failed: \(error)"
             reconciliationNeedsAttention = true
             hasHostsDrift = true
@@ -700,7 +751,7 @@ final class WorkspaceStore {
     /// through applyEdit, whose follow-up merge would touch the system hosts. The in-memory model
     /// is committed only after the workspace save succeeds.
     func importFiles(at urls: [URL]) -> ImportOutcome {
-        guard var updated = model else {
+        guard model != nil else {
             return .failed("Nothing was imported: the workspace is not loaded.")
         }
         do {
@@ -714,16 +765,35 @@ final class WorkspaceStore {
                     throw ImportFileFailure(fileName: url.lastPathComponent, underlying: error)
                 }
             }
-            for content in contents {
-                switch content {
-                case .snapshot(let snapshot):
-                    try updated.importSnapshot(snapshot)
-                case .plainText(let name, let text):
-                    try updated.addProfile(id: Profile.ID(UUID().uuidString), name: name, content: text)
+            let applyImports: (inout ActivationModel) throws -> Void = { updated in
+                for content in contents {
+                    switch content {
+                    case .snapshot(let snapshot):
+                        try updated.importSnapshot(snapshot)
+                    case .plainText(let name, let text):
+                        try updated.addProfile(id: Profile.ID(UUID().uuidString), name: name, content: text)
+                    }
                 }
             }
-            try workspace.save(updated)
-            model = updated
+            // Imports commit only when the save succeeds, so this path stays off persistByReplaying,
+            // whose disk-failure fallback would keep the imported content in memory.
+            if saveError == nil {
+                switch try workspace.save(applying: applyImports) {
+                case .saved(let saved):
+                    model = saved
+                case .conflict(let latest, let reason):
+                    model = latest
+                    throw reason
+                }
+            } else {
+                guard var updated = model else {
+                    return .failed("Nothing was imported: the workspace is not loaded.")
+                }
+                try applyImports(&updated)
+                try workspace.save(updated)
+                model = updated
+                saveError = nil
+            }
             return .imported
         } catch {
             return .failed(Self.importFailureMessage(for: error))
@@ -763,31 +833,80 @@ final class WorkspaceStore {
 
     // MARK: - Persisting and follow-up merging
 
-    /// Shared path for edit-type changes: mutate the in-memory model → save to disk synchronously → schedule a follow-up merge.
+    /// Shared path for edit-type changes: persist the edit synchronously by replaying it on the
+    /// latest state (persistByReplaying) → schedule a follow-up merge.
     private func applyEdit(_ edit: (inout ActivationModel) throws -> Void) {
-        guard var updated = model else { return }
+        guard model != nil else { return }
         // Every new edit first cancels the old follow-up merge: its content is stale. This must
         // happen before saving — if the save fails and returns early, a late success from the old
         // task must not clear this save error
         followUpMergeTask?.cancel()
-        do {
-            try edit(&updated)
-        } catch {
-            assertionFailure("Failed to apply the edit to the current model: \(error)")
-            return
-        }
-        model = updated
-        if hasHostsDrift {
-            refreshHostsDriftComparison()
+        // The comparison derives from the model; recompute it once the model reaches its final
+        // state on every exit path (a failed save keeps the edit in memory)
+        defer {
+            if hasHostsDrift {
+                refreshHostsDriftComparison()
+            }
         }
         do {
-            try workspace.save(updated)
-            saveError = nil
+            guard case .saved = try persistByReplaying(edit) else {
+                // The edit's target no longer exists on disk (an external writer removed it):
+                // the edit is dropped and the model now shows the latest state
+                return
+            }
         } catch {
             saveError = "Save failed: \(error)"
             return
         }
         scheduleFollowUpMerge()
+    }
+
+    /// ADR-0010 ② for every GUI save: replays `change` on the latest on-disk state under the
+    /// manifest lock, so changes an external writer made since the last load survive the save.
+    /// Two deliberate departures:
+    /// - Degraded mode: while an earlier save failure keeps unsaved edits in the in-memory model
+    ///   (saveError != nil), the replay target is that model and it is written whole, so the
+    ///   unsaved edits self-heal on the next successful save instead of being dropped by a reload.
+    /// - Disk failure: the change is still committed to the in-memory model — the user's edit must
+    ///   not vanish while the disk is unwritable — before rethrowing for the caller to report.
+    /// On .saved the in-memory model equals the persisted state; on .conflict nothing was written
+    /// and the in-memory model shows the latest on-disk state, which lacks the change's target.
+    private func persistByReplaying(
+        _ change: (inout ActivationModel) throws -> Void,
+        acceptingSystemHostsHash acceptedHash: String? = nil
+    ) throws -> Workspace.ReplayedSaveOutcome {
+        if saveError != nil {
+            guard var current = model else { throw WorkspaceError.notInitialized }
+            try change(&current)
+            model = current
+            if let acceptedHash {
+                try workspace.save(current, acceptingSystemHostsHash: acceptedHash)
+            } else {
+                try workspace.save(current)
+            }
+            saveError = nil
+            return .saved(current)
+        }
+        let outcome: Workspace.ReplayedSaveOutcome
+        do {
+            if let acceptedHash {
+                outcome = try workspace.save(applying: change, acceptingSystemHostsHash: acceptedHash)
+            } else {
+                outcome = try workspace.save(applying: change)
+            }
+        } catch {
+            if var current = model, (try? change(&current)) != nil {
+                model = current
+            }
+            throw error
+        }
+        switch outcome {
+        case .saved(let saved):
+            model = saved
+        case .conflict(let latest, _):
+            model = latest
+        }
+        return outcome
     }
 
     /// Converges with one merge 800ms after typing stops; stale schedules were already cancelled

--- a/Sources/HostflipCLI/CLI.swift
+++ b/Sources/HostflipCLI/CLI.swift
@@ -203,6 +203,12 @@ enum CLI {
                 message: "no profile matches '\(reference)'",
                 exitCode: .notFound
             )
+        case ProfileResolver.Failure.idPassedAsName(let reference):
+            return CLIError(
+                code: "profile-not-found",
+                message: "'\(reference)' is a profile ID, not a profile name; use --id \(reference)",
+                exitCode: .notFound
+            )
         case ProfileResolver.Failure.ambiguous(let reference, let candidates):
             return CLIError(
                 code: "profile-ambiguous",

--- a/Sources/HostflipCLI/CLI.swift
+++ b/Sources/HostflipCLI/CLI.swift
@@ -12,6 +12,9 @@ enum CLI {
           status      Report the pause state, active profiles, and system hosts drift
           list        List the group structure and every profile with its ID
           cat         Print a profile's content exactly as stored
+          create      Create an empty profile: standalone by default, in a group via group/name
+          write       Replace a profile's content from stdin or --file
+          delete      Delete a profile; an active profile leaves the merge first
           activate    Activate a profile and rewrite the system hosts via the daemon
           deactivate  Deactivate a profile and rewrite the system hosts via the daemon
           pause       Rewrite the system hosts with Base Hosts only, keeping active state
@@ -21,9 +24,10 @@ enum CLI {
         name is ambiguous (names are not unique; IDs are — see 'hostflip list').
 
         Options:
-          --id <id>  Address a profile by its unique ID
-          --json     Machine-readable output: result object on stdout, JSON errors on stderr
-          --help     Show this help
+          --id <id>      Address a profile by its unique ID
+          --file <path>  Read the new content for 'write' from a file instead of stdin
+          --json         Machine-readable output: result object on stdout, JSON errors on stderr
+          --help         Show this help
         """
 
     static func run(
@@ -31,7 +35,8 @@ enum CLI {
         workspaceRootDirectory: URL,
         systemHostsURL: URL,
         makeHostsMerger: @Sendable (Workspace) -> any HostsMerging = { DaemonHostsMerger(workspace: $0) },
-        postWorkspaceChanged: @escaping @Sendable (Workspace) -> Void = CLI.postDistributedWorkspaceChange
+        postWorkspaceChanged: @escaping @Sendable (Workspace) -> Void = CLI.postDistributedWorkspaceChange,
+        readStandardInput: @Sendable () throws -> Data = { try FileHandle.standardInput.readToEnd() ?? Data() }
     ) async -> CLIResult {
         // The output mode is decided by scanning the whole argv, not during parsing, so even a
         // usage error earlier in the argument list is rendered in the requested format.
@@ -46,7 +51,8 @@ enum CLI {
                 workspace: Workspace(rootDirectory: workspaceRootDirectory),
                 systemHostsURL: systemHostsURL,
                 makeHostsMerger: makeHostsMerger,
-                postWorkspaceChanged: postWorkspaceChanged
+                postWorkspaceChanged: postWorkspaceChanged,
+                readStandardInput: readStandardInput
             )
             let output: String
             if wantsJSON {
@@ -72,6 +78,7 @@ enum CLI {
     private struct Invocation {
         var wantsHelp = false
         var profileID: String?
+        var filePath: String?
         var commandArguments: [String] = []
     }
 
@@ -89,6 +96,11 @@ enum CLI {
                     throw CLIError.usage("option '--id' requires a value")
                 }
                 invocation.profileID = value
+            case "--file":
+                guard let value = iterator.next() else {
+                    throw CLIError.usage("option '--file' requires a value")
+                }
+                invocation.filePath = value
             case _ where argument.hasPrefix("-"):
                 throw CLIError.usage("unknown option '\(argument)'")
             default:
@@ -105,10 +117,14 @@ enum CLI {
         workspace: Workspace,
         systemHostsURL: URL,
         makeHostsMerger: @Sendable (Workspace) -> any HostsMerging,
-        postWorkspaceChanged: @escaping @Sendable (Workspace) -> Void
+        postWorkspaceChanged: @escaping @Sendable (Workspace) -> Void,
+        readStandardInput: @Sendable () throws -> Data
     ) async throws -> any CommandPayload {
         guard let command = invocation.commandArguments.first else {
             throw CLIError.usage("no command given")
+        }
+        if invocation.filePath != nil, command != "write" {
+            throw CLIError.usage("option '--file' is only valid with 'write'")
         }
         switch command {
         case "status":
@@ -121,6 +137,30 @@ enum CLI {
             return try CatCommand.run(
                 reference: requireProfileReference(in: invocation, command: command),
                 workspace: workspace
+            )
+        case "create":
+            return try CreateCommand.run(
+                target: requireCreateTarget(in: invocation),
+                workspace: workspace,
+                postWorkspaceChanged: postWorkspaceChanged
+            )
+        case "write":
+            return try await WriteCommand.run(
+                reference: requireProfileReference(in: invocation, command: command),
+                filePath: invocation.filePath,
+                readStandardInput: readStandardInput,
+                workspace: workspace,
+                systemHostsURL: systemHostsURL,
+                merger: makeHostsMerger(workspace),
+                postWorkspaceChanged: postWorkspaceChanged
+            )
+        case "delete":
+            return try await DeleteCommand.run(
+                reference: requireProfileReference(in: invocation, command: command),
+                workspace: workspace,
+                systemHostsURL: systemHostsURL,
+                merger: makeHostsMerger(workspace),
+                postWorkspaceChanged: postWorkspaceChanged
             )
         // "on"/"off" are entry aliases only: they always require the profile argument (a bare
         // `off` is a usage error, keeping it unmistakable from `pause`) and never appear in help.
@@ -154,6 +194,23 @@ enum CLI {
         if invocation.profileID != nil {
             throw CLIError.usage("unexpected option '--id'")
         }
+    }
+
+    /// Extracts create's one positional target: a new profile's name, or a group/name path.
+    /// The target names something that does not exist yet, so the --id addressing form has no
+    /// meaning here and is rejected.
+    private static func requireCreateTarget(in invocation: Invocation) throws -> String {
+        if invocation.profileID != nil {
+            throw CLIError.usage("unexpected option '--id'")
+        }
+        let positionals = invocation.commandArguments.dropFirst()
+        if let extra = positionals.dropFirst().first {
+            throw CLIError.usage("unexpected argument '\(extra)'")
+        }
+        guard let target = positionals.first else {
+            throw CLIError.usage("'create' needs a profile name or group/name path")
+        }
+        return target
     }
 
     /// Extracts the one profile reference of a profile-addressed command: exactly one of a

--- a/Sources/HostflipCLI/CLI.swift
+++ b/Sources/HostflipCLI/CLI.swift
@@ -5,15 +5,20 @@ import HostflipCore
 /// show canonical verbs only; any future aliases stay out of both.
 enum CLI {
     static let usageText = """
-        Usage: hostflip [--json] <command>
+        Usage: hostflip [--json] <command> [<profile>]
 
         Commands:
           status  Report the pause state, active profiles, and system hosts drift
           list    List the group structure and every profile with its ID
+          cat     Print a profile's content exactly as stored
+
+        Profiles are addressed by name, by group/profile path, or by --id when the
+        name is ambiguous (names are not unique; IDs are — see 'hostflip list').
 
         Options:
-          --json  Machine-readable output: result object on stdout, JSON errors on stderr
-          --help  Show this help
+          --id <id>  Address a profile by its unique ID
+          --json     Machine-readable output: result object on stdout, JSON errors on stderr
+          --help     Show this help
         """
 
     static func run(
@@ -34,8 +39,15 @@ enum CLI {
                 workspace: Workspace(rootDirectory: workspaceRootDirectory),
                 systemHostsURL: systemHostsURL
             )
-            let output = wantsJSON ? CLIJSON.encode(payload) : payload.humanText
-            return CLIResult(exitCode: .success, standardOutput: output + "\n", standardError: "")
+            let output: String
+            if wantsJSON {
+                output = CLIJSON.encode(payload) + "\n"
+            } else if payload.humanTextIsVerbatim {
+                output = payload.humanText
+            } else {
+                output = payload.humanText + "\n"
+            }
+            return CLIResult(exitCode: .success, standardOutput: output, standardError: "")
         } catch {
             let normalized = normalize(error)
             return CLIResult(
@@ -50,17 +62,24 @@ enum CLI {
 
     private struct Invocation {
         var wantsHelp = false
+        var profileID: String?
         var commandArguments: [String] = []
     }
 
     private static func parse(_ arguments: [String]) throws -> Invocation {
         var invocation = Invocation()
-        for argument in arguments {
+        var iterator = arguments.makeIterator()
+        while let argument = iterator.next() {
             switch argument {
             case "--json":
                 break // Handled by the argv scan in run.
             case "--help", "-h":
                 invocation.wantsHelp = true
+            case "--id":
+                guard let value = iterator.next() else {
+                    throw CLIError.usage("option '--id' requires a value")
+                }
+                invocation.profileID = value
             case _ where argument.hasPrefix("-"):
                 throw CLIError.usage("unknown option '\(argument)'")
             default:
@@ -87,6 +106,11 @@ enum CLI {
         case "list":
             try requireNoArguments(in: invocation)
             return try ListCommand.run(workspace: workspace)
+        case "cat":
+            return try CatCommand.run(
+                reference: requireProfileReference(in: invocation, command: command),
+                workspace: workspace
+            )
         default:
             throw CLIError.usage("unknown command '\(command)'")
         }
@@ -96,6 +120,31 @@ enum CLI {
         if let extra = invocation.commandArguments.dropFirst().first {
             throw CLIError.usage("unexpected argument '\(extra)'")
         }
+        if invocation.profileID != nil {
+            throw CLIError.usage("unexpected option '--id'")
+        }
+    }
+
+    /// Extracts the one profile reference of a profile-addressed command: exactly one of a
+    /// positional name/path or --id.
+    private static func requireProfileReference(
+        in invocation: Invocation,
+        command: String
+    ) throws -> ProfileReference {
+        let positionals = invocation.commandArguments.dropFirst()
+        if let extra = positionals.dropFirst().first {
+            throw CLIError.usage("unexpected argument '\(extra)'")
+        }
+        switch (positionals.first, invocation.profileID) {
+        case (let reference?, nil):
+            return .nameOrPath(reference)
+        case (nil, let id?):
+            return .id(id)
+        case (nil, nil):
+            throw CLIError.usage("'\(command)' needs a profile name, group/profile path, or --id")
+        case (.some, .some):
+            throw CLIError.usage("give a profile name or --id, not both")
+        }
     }
 
     // MARK: - Error rendering
@@ -104,6 +153,19 @@ enum CLI {
         switch error {
         case let error as CLIError:
             return error
+        case ProfileResolver.Failure.notFound(let reference):
+            return CLIError(
+                code: "profile-not-found",
+                message: "no profile matches '\(reference)'",
+                exitCode: .notFound
+            )
+        case ProfileResolver.Failure.ambiguous(let reference, let candidates):
+            return CLIError(
+                code: "profile-ambiguous",
+                message: "'\(reference)' matches multiple profiles; disambiguate with a group/profile path or --id",
+                exitCode: .ambiguous,
+                candidates: candidates
+            )
         case WorkspaceError.notInitialized:
             return CLIError(
                 code: "workspace-not-initialized",
@@ -117,9 +179,16 @@ enum CLI {
 
     private static func render(_ error: CLIError, asJSON: Bool) -> String {
         if asJSON {
-            return CLIJSON.encode(ErrorEnvelope(error: .init(code: error.code, message: error.message)))
+            return CLIJSON.encode(ErrorEnvelope(error: .init(
+                code: error.code,
+                message: error.message,
+                candidates: error.candidates
+            )))
         }
         var text = "hostflip: \(error.message)"
+        if let candidates = error.candidates {
+            text += ":\n" + CLIColumns.render(candidates.map { ("  " + $0.reference, $0.id) })
+        }
         if error.exitCode == .usage {
             text += "\nRun 'hostflip --help' for usage."
         }

--- a/Sources/HostflipCLI/CLI.swift
+++ b/Sources/HostflipCLI/CLI.swift
@@ -1,5 +1,6 @@
 import Foundation
 import HostflipCore
+import HostflipXPC
 
 /// Parses one invocation and dispatches to the command implementations. Help and documentation
 /// show canonical verbs only; any future aliases stay out of both.
@@ -8,9 +9,13 @@ enum CLI {
         Usage: hostflip [--json] <command> [<profile>]
 
         Commands:
-          status  Report the pause state, active profiles, and system hosts drift
-          list    List the group structure and every profile with its ID
-          cat     Print a profile's content exactly as stored
+          status      Report the pause state, active profiles, and system hosts drift
+          list        List the group structure and every profile with its ID
+          cat         Print a profile's content exactly as stored
+          activate    Activate a profile and rewrite the system hosts via the daemon
+          deactivate  Deactivate a profile and rewrite the system hosts via the daemon
+          pause       Rewrite the system hosts with Base Hosts only, keeping active state
+          resume      Rewrite the system hosts with the kept active profiles restored
 
         Profiles are addressed by name, by group/profile path, or by --id when the
         name is ambiguous (names are not unique; IDs are — see 'hostflip list').
@@ -24,8 +29,10 @@ enum CLI {
     static func run(
         arguments: [String],
         workspaceRootDirectory: URL,
-        systemHostsURL: URL
-    ) -> CLIResult {
+        systemHostsURL: URL,
+        makeHostsMerger: @Sendable (Workspace) -> any HostsMerging = { DaemonHostsMerger(workspace: $0) },
+        postWorkspaceChanged: @escaping @Sendable (Workspace) -> Void = CLI.postDistributedWorkspaceChange
+    ) async -> CLIResult {
         // The output mode is decided by scanning the whole argv, not during parsing, so even a
         // usage error earlier in the argument list is rendered in the requested format.
         let wantsJSON = arguments.contains("--json")
@@ -34,10 +41,12 @@ enum CLI {
             if invocation.wantsHelp {
                 return CLIResult(exitCode: .success, standardOutput: usageText + "\n", standardError: "")
             }
-            let payload = try dispatch(
+            let payload = try await dispatch(
                 invocation,
                 workspace: Workspace(rootDirectory: workspaceRootDirectory),
-                systemHostsURL: systemHostsURL
+                systemHostsURL: systemHostsURL,
+                makeHostsMerger: makeHostsMerger,
+                postWorkspaceChanged: postWorkspaceChanged
             )
             let output: String
             if wantsJSON {
@@ -94,8 +103,10 @@ enum CLI {
     private static func dispatch(
         _ invocation: Invocation,
         workspace: Workspace,
-        systemHostsURL: URL
-    ) throws -> any CommandPayload {
+        systemHostsURL: URL,
+        makeHostsMerger: @Sendable (Workspace) -> any HostsMerging,
+        postWorkspaceChanged: @escaping @Sendable (Workspace) -> Void
+    ) async throws -> any CommandPayload {
         guard let command = invocation.commandArguments.first else {
             throw CLIError.usage("no command given")
         }
@@ -110,6 +121,26 @@ enum CLI {
             return try CatCommand.run(
                 reference: requireProfileReference(in: invocation, command: command),
                 workspace: workspace
+            )
+        // "on"/"off" are entry aliases only: they always require the profile argument (a bare
+        // `off` is a usage error, keeping it unmistakable from `pause`) and never appear in help.
+        case "activate", "on", "deactivate", "off":
+            return try await SwitchCommand.setActive(
+                command == "activate" || command == "on",
+                reference: requireProfileReference(in: invocation, command: command),
+                workspace: workspace,
+                systemHostsURL: systemHostsURL,
+                merger: makeHostsMerger(workspace),
+                postWorkspaceChanged: postWorkspaceChanged
+            )
+        case "pause", "resume":
+            try requireNoArguments(in: invocation)
+            return try await SwitchCommand.setPaused(
+                command == "pause",
+                workspace: workspace,
+                systemHostsURL: systemHostsURL,
+                merger: makeHostsMerger(workspace),
+                postWorkspaceChanged: postWorkspaceChanged
             )
         default:
             throw CLIError.usage("unknown command '\(command)'")
@@ -147,6 +178,19 @@ enum CLI {
         }
     }
 
+    // MARK: - Cross-process change notification (ADR-0010 ③)
+
+    /// Tells a running GUI that this process changed the workspace on disk. Display-refresh
+    /// optimization only: delivery is not guaranteed and correctness never depends on it.
+    static func postDistributedWorkspaceChange(for workspace: Workspace) {
+        DistributedNotificationCenter.default().postNotificationName(
+            Workspace.changeNotification,
+            object: workspace.changeNotificationObject,
+            userInfo: nil,
+            deliverImmediately: true
+        )
+    }
+
     // MARK: - Error rendering
 
     private static func normalize(_ error: any Error) -> CLIError {
@@ -172,8 +216,68 @@ enum CLI {
                 message: "workspace not initialized; launch the Hostflip app once to capture the system hosts",
                 exitCode: .failure
             )
+        case let error as DaemonChannelError:
+            return normalize(error)
         default:
             return CLIError(code: "internal-error", message: error.localizedDescription, exitCode: .failure)
+        }
+    }
+
+    /// Maps a daemon channel failure onto the exit-code contract: drift means "stop and hand
+    /// back to a human" (3), an unreachable or restarting daemon is "not ready" (4), everything
+    /// else is a general failure with a string code integrations can key on.
+    private static func normalize(_ error: DaemonChannelError) -> CLIError {
+        switch error {
+        case .mergeRejected(.hostsDrift):
+            return .hostsDrift
+        case .unavailable:
+            return CLIError(
+                code: "daemon-unavailable",
+                message: "the privileged daemon is not available; launch the Hostflip app and perform a switch once to install and approve it",
+                exitCode: .daemonUnavailable
+            )
+        case .interrupted:
+            return CLIError(
+                code: "daemon-unavailable",
+                message: "the privileged daemon was interrupted twice in a row; try again, or relaunch the Hostflip app",
+                exitCode: .daemonUnavailable
+            )
+        case .peerRejected:
+            return CLIError(
+                code: "daemon-unavailable",
+                message: "the daemon's code signature was rejected; reinstall the Hostflip app",
+                exitCode: .daemonUnavailable
+            )
+        case .selfSigningUnavailable:
+            return CLIError(
+                code: "unsigned-build",
+                message: "this hostflip binary is unsigned, so it cannot connect to the daemon; use a signed build",
+                exitCode: .failure
+            )
+        case .protocolViolation, .mergeRejected(.versionMismatch):
+            return CLIError(
+                code: "version-mismatch",
+                message: "the daemon and this hostflip binary are from different versions; finish the upgrade by relaunching the Hostflip app",
+                exitCode: .failure
+            )
+        case .mergeRejected(let reason):
+            return CLIError(
+                code: "merge-rejected",
+                message: "the daemon rejected the merge: \(reason)",
+                exitCode: .failure
+            )
+        case .mergeWriteFailed(let failure):
+            return CLIError(
+                code: "hosts-write-failed",
+                message: "the daemon could not write the system hosts (stage \(failure.stage.rawValue)): \(failure.message)",
+                exitCode: .failure
+            )
+        case .transport(let domain, let code):
+            return CLIError(
+                code: "transport-error",
+                message: "the daemon channel failed (\(domain) \(code)); try again",
+                exitCode: .failure
+            )
         }
     }
 

--- a/Sources/HostflipCLI/CLI.swift
+++ b/Sources/HostflipCLI/CLI.swift
@@ -1,0 +1,128 @@
+import Foundation
+import HostflipCore
+
+/// Parses one invocation and dispatches to the command implementations. Help and documentation
+/// show canonical verbs only; any future aliases stay out of both.
+enum CLI {
+    static let usageText = """
+        Usage: hostflip [--json] <command>
+
+        Commands:
+          status  Report the pause state, active profiles, and system hosts drift
+          list    List the group structure and every profile with its ID
+
+        Options:
+          --json  Machine-readable output: result object on stdout, JSON errors on stderr
+          --help  Show this help
+        """
+
+    static func run(
+        arguments: [String],
+        workspaceRootDirectory: URL,
+        systemHostsURL: URL
+    ) -> CLIResult {
+        // The output mode is decided by scanning the whole argv, not during parsing, so even a
+        // usage error earlier in the argument list is rendered in the requested format.
+        let wantsJSON = arguments.contains("--json")
+        do {
+            let invocation = try parse(arguments)
+            if invocation.wantsHelp {
+                return CLIResult(exitCode: .success, standardOutput: usageText + "\n", standardError: "")
+            }
+            let payload = try dispatch(
+                invocation,
+                workspace: Workspace(rootDirectory: workspaceRootDirectory),
+                systemHostsURL: systemHostsURL
+            )
+            let output = wantsJSON ? CLIJSON.encode(payload) : payload.humanText
+            return CLIResult(exitCode: .success, standardOutput: output + "\n", standardError: "")
+        } catch {
+            let normalized = normalize(error)
+            return CLIResult(
+                exitCode: normalized.exitCode,
+                standardOutput: "",
+                standardError: render(normalized, asJSON: wantsJSON) + "\n"
+            )
+        }
+    }
+
+    // MARK: - Parsing
+
+    private struct Invocation {
+        var wantsHelp = false
+        var commandArguments: [String] = []
+    }
+
+    private static func parse(_ arguments: [String]) throws -> Invocation {
+        var invocation = Invocation()
+        for argument in arguments {
+            switch argument {
+            case "--json":
+                break // Handled by the argv scan in run.
+            case "--help", "-h":
+                invocation.wantsHelp = true
+            case _ where argument.hasPrefix("-"):
+                throw CLIError.usage("unknown option '\(argument)'")
+            default:
+                invocation.commandArguments.append(argument)
+            }
+        }
+        return invocation
+    }
+
+    // MARK: - Dispatch
+
+    private static func dispatch(
+        _ invocation: Invocation,
+        workspace: Workspace,
+        systemHostsURL: URL
+    ) throws -> any CommandPayload {
+        guard let command = invocation.commandArguments.first else {
+            throw CLIError.usage("no command given")
+        }
+        switch command {
+        case "status":
+            try requireNoArguments(in: invocation)
+            return try StatusCommand.run(workspace: workspace, systemHostsURL: systemHostsURL)
+        case "list":
+            try requireNoArguments(in: invocation)
+            return try ListCommand.run(workspace: workspace)
+        default:
+            throw CLIError.usage("unknown command '\(command)'")
+        }
+    }
+
+    private static func requireNoArguments(in invocation: Invocation) throws {
+        if let extra = invocation.commandArguments.dropFirst().first {
+            throw CLIError.usage("unexpected argument '\(extra)'")
+        }
+    }
+
+    // MARK: - Error rendering
+
+    private static func normalize(_ error: any Error) -> CLIError {
+        switch error {
+        case let error as CLIError:
+            return error
+        case WorkspaceError.notInitialized:
+            return CLIError(
+                code: "workspace-not-initialized",
+                message: "workspace not initialized; launch the Hostflip app once to capture the system hosts",
+                exitCode: .failure
+            )
+        default:
+            return CLIError(code: "internal-error", message: error.localizedDescription, exitCode: .failure)
+        }
+    }
+
+    private static func render(_ error: CLIError, asJSON: Bool) -> String {
+        if asJSON {
+            return CLIJSON.encode(ErrorEnvelope(error: .init(code: error.code, message: error.message)))
+        }
+        var text = "hostflip: \(error.message)"
+        if error.exitCode == .usage {
+            text += "\nRun 'hostflip --help' for usage."
+        }
+        return text
+    }
+}

--- a/Sources/HostflipCLI/CLIMain.swift
+++ b/Sources/HostflipCLI/CLIMain.swift
@@ -5,8 +5,8 @@ import HostflipCore
 /// command and its output contract stay testable through CLI.run.
 @main
 enum CLIMain {
-    static func main() {
-        let result = CLI.run(
+    static func main() async {
+        let result = await CLI.run(
             arguments: Array(CommandLine.arguments.dropFirst()),
             workspaceRootDirectory: Workspace.defaultRootDirectory,
             systemHostsURL: URL(fileURLWithPath: "/etc/hosts")

--- a/Sources/HostflipCLI/CLIMain.swift
+++ b/Sources/HostflipCLI/CLIMain.swift
@@ -1,0 +1,22 @@
+import Foundation
+import HostflipCore
+
+/// Entry point of the standalone `hostflip` CLI (ADR-0009): argv/exit glue only, so every
+/// command and its output contract stay testable through CLI.run.
+@main
+enum CLIMain {
+    static func main() {
+        let result = CLI.run(
+            arguments: Array(CommandLine.arguments.dropFirst()),
+            workspaceRootDirectory: Workspace.defaultRootDirectory,
+            systemHostsURL: URL(fileURLWithPath: "/etc/hosts")
+        )
+        if !result.standardOutput.isEmpty {
+            FileHandle.standardOutput.write(Data(result.standardOutput.utf8))
+        }
+        if !result.standardError.isEmpty {
+            FileHandle.standardError.write(Data(result.standardError.utf8))
+        }
+        exit(result.exitCode.rawValue)
+    }
+}

--- a/Sources/HostflipCLI/CLIOutput.swift
+++ b/Sources/HostflipCLI/CLIOutput.swift
@@ -23,6 +23,9 @@ struct CLIError: Error {
     let code: String
     let message: String
     let exitCode: ExitCode
+    /// Present only on ambiguity errors: every profile the reference could mean, feeding both
+    /// the human candidate listing and the JSON envelope's `candidates` field.
+    var candidates: [ProfileResolver.Candidate]? = nil
 
     static func usage(_ message: String) -> CLIError {
         CLIError(code: "usage", message: message, exitCode: .usage)
@@ -40,6 +43,13 @@ struct CLIResult {
 /// A command's result object: encodable verbatim for `--json`, plus a human-readable rendering.
 protocol CommandPayload: Encodable {
     var humanText: String { get }
+    /// Verbatim payloads (cat) own their exact bytes; every other human rendering gets a
+    /// trailing newline appended by the CLI.
+    var humanTextIsVerbatim: Bool { get }
+}
+
+extension CommandPayload {
+    var humanTextIsVerbatim: Bool { false }
 }
 
 /// The `--json` error shape on stderr: `{"error":{"code":…,"message":…}}`. Fields are only ever
@@ -48,9 +58,23 @@ struct ErrorEnvelope: Encodable {
     struct Details: Encodable {
         let code: String
         let message: String
+        /// Present only on ambiguity errors; omitted from the JSON otherwise.
+        let candidates: [ProfileResolver.Candidate]?
     }
 
     let error: Details
+}
+
+enum CLIColumns {
+    /// Renders non-empty (label, trailing) rows as two aligned columns. Padded by hand:
+    /// String.padding(toLength:) counts UTF-16 units and would truncate labels holding
+    /// non-BMP characters, corrupting the trailing column.
+    static func render(_ rows: [(label: String, trailing: String)]) -> String {
+        let width = rows.map(\.label.count).max()! + 2
+        return rows
+            .map { $0.label + String(repeating: " ", count: width - $0.label.count) + $0.trailing }
+            .joined(separator: "\n")
+    }
 }
 
 enum CLIJSON {

--- a/Sources/HostflipCLI/CLIOutput.swift
+++ b/Sources/HostflipCLI/CLIOutput.swift
@@ -30,6 +30,15 @@ struct CLIError: Error {
     static func usage(_ message: String) -> CLIError {
         CLIError(code: "usage", message: message, exitCode: .usage)
     }
+
+    /// The one drift error, shared by the local pre-check and the daemon's rejection so both
+    /// render identically. The CLI only reports drift, it never reconciles (exit code 3 is the
+    /// documented "stop and hand back to a human" signal).
+    static let hostsDrift = CLIError(
+        code: "hosts-drift",
+        message: "the system hosts changed outside hostflip; review and reconcile in the Hostflip app",
+        exitCode: .drift
+    )
 }
 
 /// What one invocation produced. Commands return their streams instead of printing so tests can

--- a/Sources/HostflipCLI/CLIOutput.swift
+++ b/Sources/HostflipCLI/CLIOutput.swift
@@ -1,0 +1,63 @@
+import Foundation
+
+/// Exit codes shared by every CLI command, aligned with the argparse/Go/bash convention.
+/// Codes 3–6 are reserved by the framework for later write/addressing commands; the read-only
+/// commands never emit them, but the numbers are fixed here so integrations can rely on them.
+enum ExitCode: Int32 {
+    case success = 0
+    case failure = 1
+    case usage = 2
+    /// Reserved: a command refused to proceed because the system hosts drifted.
+    case drift = 3
+    /// Reserved: the privileged daemon is not registered or not reachable.
+    case daemonUnavailable = 4
+    /// Reserved: a profile reference matched nothing.
+    case notFound = 5
+    /// Reserved: a profile reference matched more than one candidate.
+    case ambiguous = 6
+}
+
+/// A command failure carrying the machine contract: the stable string `code` is the authoritative
+/// semantic carrier (integrations key on it, never on message text), the message is for humans.
+struct CLIError: Error {
+    let code: String
+    let message: String
+    let exitCode: ExitCode
+
+    static func usage(_ message: String) -> CLIError {
+        CLIError(code: "usage", message: message, exitCode: .usage)
+    }
+}
+
+/// What one invocation produced. Commands return their streams instead of printing so tests can
+/// assert on stdout/stderr separation and exit codes without spawning a process.
+struct CLIResult {
+    let exitCode: ExitCode
+    let standardOutput: String
+    let standardError: String
+}
+
+/// A command's result object: encodable verbatim for `--json`, plus a human-readable rendering.
+protocol CommandPayload: Encodable {
+    var humanText: String { get }
+}
+
+/// The `--json` error shape on stderr: `{"error":{"code":…,"message":…}}`. Fields are only ever
+/// added to this envelope, never removed or renamed.
+struct ErrorEnvelope: Encodable {
+    struct Details: Encodable {
+        let code: String
+        let message: String
+    }
+
+    let error: Details
+}
+
+enum CLIJSON {
+    static func encode(_ value: some Encodable) -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        // Payloads are plain strings, booleans, and arrays thereof; encoding cannot fail.
+        return String(decoding: try! encoder.encode(value), as: UTF8.self)
+    }
+}

--- a/Sources/HostflipCLI/CatCommand.swift
+++ b/Sources/HostflipCLI/CatCommand.swift
@@ -1,0 +1,28 @@
+import Foundation
+import HostflipCore
+
+/// `hostflip cat <profile>`: prints a profile's content to stdout exactly as stored on disk.
+/// The JSON payload also names the resolved profile so scripts can confirm which one matched.
+enum CatCommand {
+    struct Payload: CommandPayload {
+        let id: String
+        let name: String
+        /// The containing group's name; absent for a standalone profile.
+        let group: String?
+        let content: String
+
+        var humanText: String { content }
+        var humanTextIsVerbatim: Bool { true }
+    }
+
+    static func run(reference: ProfileReference, workspace: Workspace) throws -> Payload {
+        let model = try workspace.openReadOnly()
+        let match = try ProfileResolver.resolve(reference, in: model)
+        return Payload(
+            id: match.profile.id.rawValue,
+            name: match.profile.name,
+            group: match.groupName,
+            content: match.profile.content
+        )
+    }
+}

--- a/Sources/HostflipCLI/CreateCommand.swift
+++ b/Sources/HostflipCLI/CreateCommand.swift
@@ -1,0 +1,103 @@
+import Foundation
+import HostflipCore
+
+/// `hostflip create <name>` / `hostflip create <group>/<name>`: adds an inactive profile, so the
+/// system hosts is never touched and no drift gate applies. The CLI does not manage groups: a
+/// path pointing at a group that does not exist is an error, never an implicit group creation.
+/// A namesake in the same location (the standalone area, or the same group) is rejected — a
+/// retried create must fail instead of piling ambiguous namesakes into the addressing space.
+enum CreateCommand {
+    struct Payload: CommandPayload {
+        let id: String
+        let name: String
+        /// The containing group's name; absent for a standalone profile.
+        let group: String?
+
+        var humanText: String {
+            "Created \(group.map { "\($0)/\(name)" } ?? name)."
+        }
+    }
+
+    static func run(
+        target: String,
+        workspace: Workspace,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) throws -> Payload {
+        // The same first-slash path rule the resolver applies to profile references. Either
+        // half coming out empty is a malformed target, not a lookup miss.
+        let groupName: String?
+        let profileName: String
+        if let path = ProfileResolver.splitPath(target) {
+            groupName = path.group
+            profileName = path.name
+            guard !path.group.isEmpty else {
+                throw CLIError.usage("the group name is empty")
+            }
+        } else {
+            groupName = nil
+            profileName = target
+        }
+        guard !profileName.isEmpty else {
+            throw CLIError.usage("the profile name is empty")
+        }
+
+        let profileID = Profile.ID(UUID().uuidString)
+        // Location resolution and the duplicate check run inside the replayed change, i.e. on
+        // the latest on-disk state under the manifest lock: a namesake a peer writer just
+        // created cannot slip past the check.
+        switch try workspace.save(applying: { model in
+            try add(profileName, id: profileID, toGroupNamed: groupName, in: &model)
+        }) {
+        case .saved:
+            postWorkspaceChanged(workspace)
+            return Payload(id: profileID.rawValue, name: profileName, group: groupName)
+        case .conflict(_, let reason):
+            throw reason
+        }
+    }
+
+    /// A new profile starts empty: the CLI's consumers are scripts and agents, so no editor
+    /// placeholder comment is injected (unlike the GUI's create).
+    private static func add(
+        _ name: String,
+        id: Profile.ID,
+        toGroupNamed groupName: String?,
+        in model: inout ActivationModel
+    ) throws {
+        guard let groupName else {
+            guard !model.standaloneProfiles.contains(where: { $0.name == name }) else {
+                throw CLIError(
+                    code: "profile-exists",
+                    message: "a standalone profile named '\(name)' already exists",
+                    exitCode: .failure
+                )
+            }
+            try model.addProfile(id: id, name: name, content: "")
+            return
+        }
+        let candidates = model.groups.filter { $0.name == groupName }
+        guard let group = candidates.first else {
+            throw CLIError(
+                code: "group-not-found",
+                message: "no group matches '\(groupName)'; the CLI does not create groups — create it in the Hostflip app first",
+                exitCode: .notFound
+            )
+        }
+        guard candidates.count == 1 else {
+            throw CLIError(
+                code: "group-ambiguous",
+                message: "'\(groupName)' matches multiple groups; rename them apart in the Hostflip app",
+                exitCode: .ambiguous
+            )
+        }
+        guard !group.profiles.contains(where: { $0.name == name }) else {
+            throw CLIError(
+                code: "profile-exists",
+                message: "'\(groupName)' already has a profile named '\(name)'",
+                exitCode: .failure
+            )
+        }
+        try model.addProfile(id: id, name: name, content: "")
+        try model.moveProfile(id, toGroup: group.id)
+    }
+}

--- a/Sources/HostflipCLI/DeleteCommand.swift
+++ b/Sources/HostflipCLI/DeleteCommand.swift
@@ -1,0 +1,49 @@
+import Foundation
+import HostflipCore
+
+/// `hostflip delete <profile>`: removes a profile from the workspace. Deleting an active
+/// profile mirrors the GUI — it is also an active-state change, so the merge without the
+/// profile must land before the profile is removed (drift gate included); an inactive profile
+/// is a purely local edit that never goes through the daemon.
+enum DeleteCommand {
+    struct Payload: CommandPayload {
+        let id: String
+        let name: String
+        /// The containing group's name; absent for a standalone profile.
+        let group: String?
+
+        var humanText: String {
+            "Deleted \(group.map { "\($0)/\(name)" } ?? name)."
+        }
+    }
+
+    static func run(
+        reference: ProfileReference,
+        workspace: Workspace,
+        systemHostsURL: URL,
+        merger: any HostsMerging,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) async throws -> Payload {
+        let model = try workspace.openReadOnly()
+        let match = try ProfileResolver.resolve(reference, in: model)
+        let profileID = match.profile.id
+        let payload = Payload(id: profileID.rawValue, name: match.profile.name, group: match.groupName)
+
+        if model.activeProfileIDs.contains(profileID) {
+            try MergeCommitFlow.requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
+            try await MergeCommitFlow.run(
+                change: { try $0.deleteProfile(profileID) },
+                on: model,
+                workspace: workspace,
+                systemHostsURL: systemHostsURL,
+                merger: merger,
+                postWorkspaceChanged: postWorkspaceChanged
+            )
+            return payload
+        }
+
+        try LocalEdit.persist({ try $0.deleteProfile(profileID) }, to: workspace)
+        postWorkspaceChanged(workspace)
+        return payload
+    }
+}

--- a/Sources/HostflipCLI/ListCommand.swift
+++ b/Sources/HostflipCLI/ListCommand.swift
@@ -1,0 +1,57 @@
+import Foundation
+import HostflipCore
+
+/// `hostflip list`: the group structure and every profile in manifest order, each with its
+/// globally unique ID — the stable handle for the future `--id` addressing (names are not
+/// unique in any scope).
+enum ListCommand {
+    struct Payload: CommandPayload {
+        struct ProfileEntry: Encodable {
+            let id: String
+            let name: String
+        }
+
+        struct GroupEntry: Encodable {
+            let id: String
+            let name: String
+            let profiles: [ProfileEntry]
+        }
+
+        let standaloneProfiles: [ProfileEntry]
+        let groups: [GroupEntry]
+
+        var humanText: String {
+            var rows: [(label: String, id: String)] = []
+            for profile in standaloneProfiles {
+                rows.append((profile.name, profile.id))
+            }
+            for group in groups {
+                rows.append(("\(group.name)/", group.id))
+                for profile in group.profiles {
+                    rows.append(("  \(profile.name)", profile.id))
+                }
+            }
+            guard !rows.isEmpty else { return "No profiles." }
+            // Pad by hand: String.padding(toLength:) counts UTF-16 units and would truncate
+            // labels holding non-BMP characters, corrupting the ID column.
+            let width = rows.map(\.label.count).max()! + 2
+            return rows
+                .map { $0.label + String(repeating: " ", count: width - $0.label.count) + $0.id }
+                .joined(separator: "\n")
+        }
+    }
+
+    static func run(workspace: Workspace) throws -> Payload {
+        let model = try workspace.openReadOnly()
+        return Payload(
+            standaloneProfiles: model.standaloneProfiles.map { .init(id: $0.id.rawValue, name: $0.name) },
+            groups: model.groups.map { group in
+                .init(
+                    id: group.id.rawValue,
+                    name: group.name,
+                    profiles: group.profiles.map { .init(id: $0.id.rawValue, name: $0.name) }
+                )
+            }
+        )
+    }
+}

--- a/Sources/HostflipCLI/ListCommand.swift
+++ b/Sources/HostflipCLI/ListCommand.swift
@@ -21,7 +21,7 @@ enum ListCommand {
         let groups: [GroupEntry]
 
         var humanText: String {
-            var rows: [(label: String, id: String)] = []
+            var rows: [(label: String, trailing: String)] = []
             for profile in standaloneProfiles {
                 rows.append((profile.name, profile.id))
             }
@@ -32,12 +32,7 @@ enum ListCommand {
                 }
             }
             guard !rows.isEmpty else { return "No profiles." }
-            // Pad by hand: String.padding(toLength:) counts UTF-16 units and would truncate
-            // labels holding non-BMP characters, corrupting the ID column.
-            let width = rows.map(\.label.count).max()! + 2
-            return rows
-                .map { $0.label + String(repeating: " ", count: width - $0.label.count) + $0.id }
-                .joined(separator: "\n")
+            return CLIColumns.render(rows)
         }
     }
 

--- a/Sources/HostflipCLI/LocalEdit.swift
+++ b/Sources/HostflipCLI/LocalEdit.swift
@@ -1,0 +1,21 @@
+import Foundation
+import HostflipCore
+
+/// The commit path of a content change that stays outside the merged system hosts output
+/// (write or delete on an inactive profile): a reload-and-replay save under the manifest
+/// lock (ADR-0010 ②), with a replay conflict (a peer writer removed the target mid-flight)
+/// reported instead of silently dropped.
+enum LocalEdit {
+    static func persist(
+        _ change: (inout ActivationModel) throws -> Void,
+        to workspace: Workspace
+    ) throws {
+        guard case .saved = try workspace.save(applying: change) else {
+            throw CLIError(
+                code: "state-save-conflict",
+                message: "a peer writer changed the workspace so the change could not be saved; check 'hostflip status' and retry",
+                exitCode: .failure
+            )
+        }
+    }
+}

--- a/Sources/HostflipCLI/MergeCommitFlow.swift
+++ b/Sources/HostflipCLI/MergeCommitFlow.swift
@@ -1,0 +1,85 @@
+import Foundation
+import HostflipCore
+import HostflipXPC
+
+/// The shared daemon write path of every command whose change touches the merged system hosts
+/// output: activation switches, and content writes or deletes aimed at an active profile. The
+/// order mirrors the app's switch path — gate on drift, merge the previewed content, and only
+/// then commit, by replaying the change on the latest on-disk state under the manifest lock
+/// (ADR-0010 ②) and notifying any running GUI (ADR-0010 ③).
+enum MergeCommitFlow {
+    /// The CLI only reports drift (exit code 3), it never reconciles; reconciliation needs the
+    /// review flow of the Hostflip app. The daemon re-verifies inside its transaction lock, so
+    /// this pre-check is a fast local gate, not the authority. Callers gate before their
+    /// idempotent no-op check: under drift the actual hosts content is unknown, so even a no-op
+    /// must stop with the drift verdict instead of vouching for a state it cannot see.
+    static func requireNoDrift(workspace: Workspace, systemHostsURL: URL) throws {
+        guard try !SystemHostsDrift.detect(workspace: workspace, systemHostsURL: systemHostsURL) else {
+            throw CLIError.hostsDrift
+        }
+    }
+
+    /// Merges the model-plus-change preview through the daemon, then commits the change by
+    /// replaying it on the latest persisted state and posting the change notification.
+    static func run(
+        change: @escaping @Sendable (inout ActivationModel) throws -> Void,
+        on model: ActivationModel,
+        workspace: Workspace,
+        systemHostsURL: URL,
+        merger: any HostsMerging,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) async throws {
+        var preview = model
+        try change(&preview)
+        let merged = preview.mergedHosts
+        do {
+            _ = try await mergeWithOneRetry(merged, via: merger)
+        } catch let DaemonChannelError.mergeWriteFailed(failure)
+            where failure.writtenHash == merged.hash {
+            // The atomic replacement physically landed and only a later flush stage failed: the
+            // change is a fact, so commit it — recording the baseline hash and the changed
+            // state keeps the very next status from misreporting the write as drift — and
+            // surface only the flush failure.
+            try workspace.recordLastWrittenHash(merged.hash)
+            try persist(change, to: workspace)
+            postWorkspaceChanged(workspace)
+            throw CLIError(
+                code: "dns-flush-failed",
+                message: "the system hosts was updated and the change was saved, but the DNS cache flush failed: \(failure.message)",
+                exitCode: .failure
+            )
+        }
+        try persist(change, to: workspace)
+        postWorkspaceChanged(workspace)
+    }
+
+    /// interrupted means launchd is relaunching the daemon on demand and a single retry
+    /// recovers; both attempts reuse the mergeID (same discipline as SwitchCoordinator).
+    private static func mergeWithOneRetry(
+        _ merged: MergedHosts,
+        via merger: any HostsMerging
+    ) async throws -> String {
+        let mergeID = UUID()
+        do {
+            return try await merger.merge(merged, mergeID: mergeID, isInterruptedRetry: false)
+        } catch let error as DaemonChannelError where error.isRetryable {
+            return try await merger.merge(merged, mergeID: mergeID, isInterruptedRetry: true)
+        }
+    }
+
+    /// Commits the changed state by replaying it on the latest on-disk model (ADR-0010 ②). At
+    /// this point the system hosts is already rewritten, so a replay conflict (a peer deleted
+    /// the profile mid-flight) is reported instead of silently dropped.
+    private static func persist(
+        _ change: (inout ActivationModel) throws -> Void,
+        to workspace: Workspace
+    ) throws {
+        guard case .saved = try workspace.save(applying: change) else {
+            throw CLIError(
+                code: "state-save-conflict",
+                message: "the system hosts was updated, but a peer writer changed the workspace so the change could not be saved; check 'hostflip status'",
+                exitCode: .failure
+            )
+        }
+    }
+}

--- a/Sources/HostflipCLI/ProfileResolver.swift
+++ b/Sources/HostflipCLI/ProfileResolver.swift
@@ -34,6 +34,11 @@ enum ProfileResolver {
 
     enum Failure: Error, Equatable {
         case notFound(reference: String)
+        /// The reference matched no name or path but is exactly some profile's unique ID: the
+        /// caller pasted an ID (e.g. from an ambiguity listing) positionally, and the error
+        /// must point at `--id` instead of a bare not-found. Name matching always wins first —
+        /// names are arbitrary strings, so this fires only when nothing is named that way.
+        case idPassedAsName(reference: String)
         case ambiguous(reference: String, candidates: [Candidate])
     }
 
@@ -60,6 +65,10 @@ enum ProfileResolver {
             }
         }
         guard let match = matches.first else {
+            if case .nameOrPath = reference,
+               entries(in: model).contains(where: { $0.profile.id.rawValue == raw }) {
+                throw Failure.idPassedAsName(reference: raw)
+            }
             throw Failure.notFound(reference: raw)
         }
         guard matches.count == 1 else {

--- a/Sources/HostflipCLI/ProfileResolver.swift
+++ b/Sources/HostflipCLI/ProfileResolver.swift
@@ -51,14 +51,9 @@ enum ProfileResolver {
             matches = entries(in: model).filter { $0.profile.id.rawValue == id }
         case .nameOrPath(let text):
             raw = text
-            // Any slash makes the reference a `group/profile` path, split on the first slash so
-            // member names may contain slashes themselves. A standalone profile or a group whose
-            // own name contains a slash is therefore reachable only through --id.
-            if let slash = text.firstIndex(of: "/") {
-                let groupName = String(text[..<slash])
-                let profileName = String(text[text.index(after: slash)...])
+            if let path = splitPath(text) {
                 matches = entries(in: model).filter {
-                    $0.groupName == groupName && $0.profile.name == profileName
+                    $0.groupName == path.group && $0.profile.name == path.name
                 }
             } else {
                 matches = entries(in: model).filter { $0.profile.name == text }
@@ -77,6 +72,18 @@ enum ProfileResolver {
             })
         }
         return match
+    }
+
+    /// The one path rule, shared with `create`'s target parsing: any slash makes the text a
+    /// `group/profile` path, split on the first slash so member names may contain slashes
+    /// themselves. A standalone profile or a group whose own name contains a slash is
+    /// therefore reachable only through --id. Returns nil for a slashless bare name.
+    static func splitPath(_ text: String) -> (group: String, name: String)? {
+        guard let slash = text.firstIndex(of: "/") else { return nil }
+        return (
+            group: String(text[..<slash]),
+            name: String(text[text.index(after: slash)...])
+        )
     }
 
     /// Every profile in model order — standalone first, then each group's members.

--- a/Sources/HostflipCLI/ProfileResolver.swift
+++ b/Sources/HostflipCLI/ProfileResolver.swift
@@ -1,0 +1,80 @@
+import Foundation
+import HostflipCore
+
+/// One user-facing way to address a profile: a bare name or `group/profile` path exactly as
+/// typed, or the globally unique ID (`--id`) as the last-resort disambiguator.
+enum ProfileReference: Equatable {
+    case nameOrPath(String)
+    case id(String)
+}
+
+/// Resolves a profile reference against the model. Names are not unique in any scope (only the
+/// global ID is), so resolution finds exactly one profile or fails — it never silently picks one.
+enum ProfileResolver {
+    struct Match: Equatable {
+        let profile: Profile
+        /// The containing group's name; nil for a standalone profile.
+        let groupName: String?
+    }
+
+    /// A profile a reference could mean, in the shape the ambiguity contract exposes: the `--json`
+    /// error's `candidates` entries and the human candidate listing are both built from this.
+    struct Candidate: Encodable, Equatable {
+        let id: String
+        let name: String
+        /// The containing group's name; absent for a standalone profile.
+        let group: String?
+
+        /// The reference form shown to humans: `group/name` for a member, the bare name for a
+        /// standalone profile (whose lack of a path prefix is exactly what --id exists for).
+        var reference: String {
+            group.map { "\($0)/\(name)" } ?? name
+        }
+    }
+
+    enum Failure: Error, Equatable {
+        case notFound(reference: String)
+        case ambiguous(reference: String, candidates: [Candidate])
+    }
+
+    static func resolve(_ reference: ProfileReference, in model: ActivationModel) throws -> Match {
+        let raw: String
+        let matches: [Match]
+        switch reference {
+        case .id(let id):
+            raw = id
+            matches = entries(in: model).filter { $0.profile.id.rawValue == id }
+        case .nameOrPath(let text):
+            raw = text
+            // Any slash makes the reference a `group/profile` path, split on the first slash so
+            // member names may contain slashes themselves. A standalone profile or a group whose
+            // own name contains a slash is therefore reachable only through --id.
+            if let slash = text.firstIndex(of: "/") {
+                let groupName = String(text[..<slash])
+                let profileName = String(text[text.index(after: slash)...])
+                matches = entries(in: model).filter {
+                    $0.groupName == groupName && $0.profile.name == profileName
+                }
+            } else {
+                matches = entries(in: model).filter { $0.profile.name == text }
+            }
+        }
+        guard let match = matches.first else {
+            throw Failure.notFound(reference: raw)
+        }
+        guard matches.count == 1 else {
+            throw Failure.ambiguous(reference: raw, candidates: matches.map {
+                Candidate(id: $0.profile.id.rawValue, name: $0.profile.name, group: $0.groupName)
+            })
+        }
+        return match
+    }
+
+    /// Every profile in model order — standalone first, then each group's members.
+    private static func entries(in model: ActivationModel) -> [Match] {
+        model.standaloneProfiles.map { Match(profile: $0, groupName: nil) }
+            + model.groups.flatMap { group in
+                group.profiles.map { Match(profile: $0, groupName: group.name) }
+            }
+    }
+}

--- a/Sources/HostflipCLI/StatusCommand.swift
+++ b/Sources/HostflipCLI/StatusCommand.swift
@@ -1,0 +1,64 @@
+import Foundation
+import HostflipCore
+
+/// `hostflip status`: reports the pause state, the active profiles (preserved even while paused),
+/// and whether the system hosts drifted. Drift uses the same baseline as the app's monitor: the
+/// workspace's expected hash (last confirmed merge write, or the pristine first-capture backup
+/// before any write) against the hash of the actual system hosts bytes. The CLI only reports
+/// drift, it never reconciles.
+enum StatusCommand {
+    struct Payload: CommandPayload {
+        struct ActiveProfile: Encodable {
+            let id: String
+            let name: String
+            /// The containing group's name; absent for a standalone profile.
+            let group: String?
+        }
+
+        let paused: Bool
+        let active: [ActiveProfile]
+        let drift: Bool
+
+        var humanText: String {
+            let references = active.map { profile in
+                profile.group.map { "\($0)/\(profile.name)" } ?? profile.name
+            }
+            return """
+                Status: \(paused ? "paused" : "running")
+                Active: \(references.isEmpty ? "none" : references.joined(separator: ", "))
+                Drift:  \(drift ? "detected (reconcile in the Hostflip app)" : "none")
+                """
+        }
+    }
+
+    static func run(workspace: Workspace, systemHostsURL: URL) throws -> Payload {
+        let model = try workspace.openReadOnly()
+
+        var active: [Payload.ActiveProfile] = []
+        for profile in model.standaloneProfiles where model.activeProfileIDs.contains(profile.id) {
+            active.append(.init(id: profile.id.rawValue, name: profile.name, group: nil))
+        }
+        for group in model.groups {
+            for profile in group.profiles where model.activeProfileIDs.contains(profile.id) {
+                active.append(.init(id: profile.id.rawValue, name: profile.name, group: group.name))
+            }
+        }
+
+        let expectedHash = try workspace.expectedSystemHostsHash()
+        let actualData: Data
+        do {
+            actualData = try Data(contentsOf: systemHostsURL)
+        } catch {
+            throw CLIError(
+                code: "hosts-unreadable",
+                message: "cannot read \(systemHostsURL.path): \(error.localizedDescription)",
+                exitCode: .failure
+            )
+        }
+        return Payload(
+            paused: model.isPaused,
+            active: active,
+            drift: MergedHosts.hash(of: actualData) != expectedHash
+        )
+    }
+}

--- a/Sources/HostflipCLI/StatusCommand.swift
+++ b/Sources/HostflipCLI/StatusCommand.swift
@@ -2,10 +2,8 @@ import Foundation
 import HostflipCore
 
 /// `hostflip status`: reports the pause state, the active profiles (preserved even while paused),
-/// and whether the system hosts drifted. Drift uses the same baseline as the app's monitor: the
-/// workspace's expected hash (last confirmed merge write, or the pristine first-capture backup
-/// before any write) against the hash of the actual system hosts bytes. The CLI only reports
-/// drift, it never reconciles.
+/// and whether the system hosts drifted (SystemHostsDrift holds the comparison baseline). The
+/// CLI only reports drift, it never reconciles.
 enum StatusCommand {
     struct Payload: CommandPayload {
         struct ActiveProfile: Encodable {
@@ -44,21 +42,10 @@ enum StatusCommand {
             }
         }
 
-        let expectedHash = try workspace.expectedSystemHostsHash()
-        let actualData: Data
-        do {
-            actualData = try Data(contentsOf: systemHostsURL)
-        } catch {
-            throw CLIError(
-                code: "hosts-unreadable",
-                message: "cannot read \(systemHostsURL.path): \(error.localizedDescription)",
-                exitCode: .failure
-            )
-        }
         return Payload(
             paused: model.isPaused,
             active: active,
-            drift: MergedHosts.hash(of: actualData) != expectedHash
+            drift: try SystemHostsDrift.detect(workspace: workspace, systemHostsURL: systemHostsURL)
         )
     }
 }

--- a/Sources/HostflipCLI/SwitchCommand.swift
+++ b/Sources/HostflipCLI/SwitchCommand.swift
@@ -27,13 +27,11 @@ struct DaemonHostsMerger: HostsMerging {
     }
 }
 
-/// `hostflip activate/deactivate/pause/resume`: switches active state through the daemon.
-/// The order mirrors the app's switch path: gate on drift, merge the previewed content, and only
-/// then commit — by replaying the change on the latest on-disk state under the manifest lock
-/// (ADR-0010 ②) and notifying any running GUI (ADR-0010 ③). A command whose target state
-/// already holds is an idempotent success that never touches the daemon — but only once the
-/// drift gate has passed: under drift the actual hosts content is unknown, so even a no-op must
-/// stop with the drift verdict instead of vouching for a state it cannot see.
+/// `hostflip activate/deactivate/pause/resume`: switches active state through the daemon via
+/// the shared MergeCommitFlow. A command whose target state already holds is an idempotent
+/// success that never touches the daemon — but only once the drift gate has passed: under
+/// drift the actual hosts content is unknown, so even a no-op must stop with the drift
+/// verdict instead of vouching for a state it cannot see.
 enum SwitchCommand {
     /// The canonical verbs, encoded into `--json` payloads as their raw strings; an alias
     /// invocation (`on` / `off`) still reports the canonical verb.
@@ -91,7 +89,7 @@ enum SwitchCommand {
         let model = try workspace.openReadOnly()
         let match = try ProfileResolver.resolve(reference, in: model)
         let profileID = match.profile.id
-        try requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
+        try MergeCommitFlow.requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
 
         func payload(changed: Bool) -> ProfilePayload {
             ProfilePayload(
@@ -106,7 +104,7 @@ enum SwitchCommand {
         guard model.activeProfileIDs.contains(profileID) != active else {
             return payload(changed: false)
         }
-        try await performSwitch(
+        try await MergeCommitFlow.run(
             // Replayed on the latest on-disk state at commit time; comparing against the target
             // state keeps the replay from flipping by mistake if a peer already switched it.
             change: { model in
@@ -132,11 +130,11 @@ enum SwitchCommand {
         postWorkspaceChanged: @Sendable (Workspace) -> Void
     ) async throws -> PausePayload {
         let model = try workspace.openReadOnly()
-        try requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
+        try MergeCommitFlow.requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
         guard model.isPaused != paused else {
             return PausePayload(action: paused ? .pause : .resume, changed: false)
         }
-        try await performSwitch(
+        try await MergeCommitFlow.run(
             change: { $0.setPaused(paused) },
             on: model,
             workspace: workspace,
@@ -145,78 +143,5 @@ enum SwitchCommand {
             postWorkspaceChanged: postWorkspaceChanged
         )
         return PausePayload(action: paused ? .pause : .resume, changed: true)
-    }
-
-    // MARK: - Shared switch path
-
-    private static func performSwitch(
-        change: @escaping @Sendable (inout ActivationModel) throws -> Void,
-        on model: ActivationModel,
-        workspace: Workspace,
-        systemHostsURL: URL,
-        merger: any HostsMerging,
-        postWorkspaceChanged: @Sendable (Workspace) -> Void
-    ) async throws {
-        var preview = model
-        try change(&preview)
-        let merged = preview.mergedHosts
-        do {
-            _ = try await mergeWithOneRetry(merged, via: merger)
-        } catch let DaemonChannelError.mergeWriteFailed(failure)
-            where failure.writtenHash == merged.hash {
-            // The atomic replacement physically landed and only a later flush stage failed: the
-            // switch is a fact, so commit it — recording the baseline hash and the switched
-            // state keeps the very next status from misreporting the write as drift — and
-            // surface only the flush failure.
-            try workspace.recordLastWrittenHash(merged.hash)
-            try persist(change, to: workspace)
-            postWorkspaceChanged(workspace)
-            throw CLIError(
-                code: "dns-flush-failed",
-                message: "the system hosts was updated and the switch was saved, but the DNS cache flush failed: \(failure.message)",
-                exitCode: .failure
-            )
-        }
-        try persist(change, to: workspace)
-        postWorkspaceChanged(workspace)
-    }
-
-    /// The CLI only reports drift (exit code 3), it never reconciles; reconciliation needs the
-    /// review flow of the Hostflip app. The daemon re-verifies inside its transaction lock, so
-    /// this pre-check is a fast local gate, not the authority.
-    private static func requireNoDrift(workspace: Workspace, systemHostsURL: URL) throws {
-        guard try !SystemHostsDrift.detect(workspace: workspace, systemHostsURL: systemHostsURL) else {
-            throw CLIError.hostsDrift
-        }
-    }
-
-    /// interrupted means launchd is relaunching the daemon on demand and a single retry
-    /// recovers; both attempts reuse the mergeID (same discipline as SwitchCoordinator).
-    private static func mergeWithOneRetry(
-        _ merged: MergedHosts,
-        via merger: any HostsMerging
-    ) async throws -> String {
-        let mergeID = UUID()
-        do {
-            return try await merger.merge(merged, mergeID: mergeID, isInterruptedRetry: false)
-        } catch let error as DaemonChannelError where error.isRetryable {
-            return try await merger.merge(merged, mergeID: mergeID, isInterruptedRetry: true)
-        }
-    }
-
-    /// Commits the switched state by replaying it on the latest on-disk model (ADR-0010 ②). At
-    /// this point the system hosts is already rewritten, so a replay conflict (a peer deleted
-    /// the profile mid-flight) is reported instead of silently dropped.
-    private static func persist(
-        _ change: (inout ActivationModel) throws -> Void,
-        to workspace: Workspace
-    ) throws {
-        guard case .saved = try workspace.save(applying: change) else {
-            throw CLIError(
-                code: "state-save-conflict",
-                message: "the system hosts was updated, but a peer writer changed the workspace so the switched state could not be saved; check 'hostflip status'",
-                exitCode: .failure
-            )
-        }
     }
 }

--- a/Sources/HostflipCLI/SwitchCommand.swift
+++ b/Sources/HostflipCLI/SwitchCommand.swift
@@ -1,0 +1,222 @@
+import Foundation
+import HostflipCore
+import HostflipXPC
+
+/// The daemon-backed system hosts write seam of the activation commands: production merges
+/// through MergeCoordinator + DaemonClient; tests inject scripted stubs.
+protocol HostsMerging: Sendable {
+    /// Sends one merge to the daemon and returns the daemon-confirmed hash. Both attempts of an
+    /// interrupted retry share the mergeID — the daemon verifies the receipt, so it cannot
+    /// mistake a concurrent external write for its own first attempt.
+    func merge(_ merged: MergedHosts, mergeID: UUID, isInterruptedRetry: Bool) async throws -> String
+}
+
+/// Production merger: the same coordination the app uses (confirmed-hash recording into the
+/// manifest only after the daemon's confirmation), minus SMAppService registration — the CLI
+/// never registers the daemon or guides approval; an unready daemon is reported with exit
+/// code 4 and the user is sent to the Hostflip app instead.
+struct DaemonHostsMerger: HostsMerging {
+    private let coordinator: MergeCoordinator
+
+    init(workspace: Workspace) {
+        coordinator = MergeCoordinator(workspace: workspace, client: DaemonClient())
+    }
+
+    func merge(_ merged: MergedHosts, mergeID: UUID, isInterruptedRetry: Bool) async throws -> String {
+        try await coordinator.merge(merged, mergeID: mergeID, isInterruptedRetry: isInterruptedRetry)
+    }
+}
+
+/// `hostflip activate/deactivate/pause/resume`: switches active state through the daemon.
+/// The order mirrors the app's switch path: gate on drift, merge the previewed content, and only
+/// then commit — by replaying the change on the latest on-disk state under the manifest lock
+/// (ADR-0010 ②) and notifying any running GUI (ADR-0010 ③). A command whose target state
+/// already holds is an idempotent success that never touches the daemon — but only once the
+/// drift gate has passed: under drift the actual hosts content is unknown, so even a no-op must
+/// stop with the drift verdict instead of vouching for a state it cannot see.
+enum SwitchCommand {
+    /// The canonical verbs, encoded into `--json` payloads as their raw strings; an alias
+    /// invocation (`on` / `off`) still reports the canonical verb.
+    enum ProfileAction: String, Encodable {
+        case activate, deactivate
+    }
+
+    enum PauseAction: String, Encodable {
+        case pause, resume
+    }
+
+    struct ProfilePayload: CommandPayload {
+        let action: ProfileAction
+        let id: String
+        let name: String
+        /// The containing group's name; absent for a standalone profile.
+        let group: String?
+        /// False when the profile was already in the requested state and nothing was written.
+        let changed: Bool
+
+        var humanText: String {
+            let reference = group.map { "\($0)/\(name)" } ?? name
+            switch (action, changed) {
+            case (.activate, true): return "Activated \(reference)."
+            case (.activate, false): return "\(reference) is already active."
+            case (.deactivate, true): return "Deactivated \(reference)."
+            case (.deactivate, false): return "\(reference) is not active."
+            }
+        }
+    }
+
+    struct PausePayload: CommandPayload {
+        let action: PauseAction
+        /// False when the pause state already held and nothing was written.
+        let changed: Bool
+
+        var humanText: String {
+            switch (action, changed) {
+            case (.pause, true): return "Paused. The system hosts now carries Base Hosts only."
+            case (.pause, false): return "Already paused."
+            case (.resume, true): return "Resumed. The active profiles are back in the system hosts."
+            case (.resume, false): return "Not paused."
+            }
+        }
+    }
+
+    static func setActive(
+        _ active: Bool,
+        reference: ProfileReference,
+        workspace: Workspace,
+        systemHostsURL: URL,
+        merger: any HostsMerging,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) async throws -> ProfilePayload {
+        let model = try workspace.openReadOnly()
+        let match = try ProfileResolver.resolve(reference, in: model)
+        let profileID = match.profile.id
+        try requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
+
+        func payload(changed: Bool) -> ProfilePayload {
+            ProfilePayload(
+                action: active ? .activate : .deactivate,
+                id: profileID.rawValue,
+                name: match.profile.name,
+                group: match.groupName,
+                changed: changed
+            )
+        }
+
+        guard model.activeProfileIDs.contains(profileID) != active else {
+            return payload(changed: false)
+        }
+        try await performSwitch(
+            // Replayed on the latest on-disk state at commit time; comparing against the target
+            // state keeps the replay from flipping by mistake if a peer already switched it.
+            change: { model in
+                guard model.activeProfileIDs.contains(profileID) != active else { return }
+                try model.toggleProfile(profileID)
+            },
+            on: model,
+            workspace: workspace,
+            systemHostsURL: systemHostsURL,
+            merger: merger,
+            postWorkspaceChanged: postWorkspaceChanged
+        )
+        return payload(changed: true)
+    }
+
+    /// While paused only Base Hosts is written, but every profile's active state is kept; on
+    /// resume the kept state rejoins the merge.
+    static func setPaused(
+        _ paused: Bool,
+        workspace: Workspace,
+        systemHostsURL: URL,
+        merger: any HostsMerging,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) async throws -> PausePayload {
+        let model = try workspace.openReadOnly()
+        try requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
+        guard model.isPaused != paused else {
+            return PausePayload(action: paused ? .pause : .resume, changed: false)
+        }
+        try await performSwitch(
+            change: { $0.setPaused(paused) },
+            on: model,
+            workspace: workspace,
+            systemHostsURL: systemHostsURL,
+            merger: merger,
+            postWorkspaceChanged: postWorkspaceChanged
+        )
+        return PausePayload(action: paused ? .pause : .resume, changed: true)
+    }
+
+    // MARK: - Shared switch path
+
+    private static func performSwitch(
+        change: @escaping @Sendable (inout ActivationModel) throws -> Void,
+        on model: ActivationModel,
+        workspace: Workspace,
+        systemHostsURL: URL,
+        merger: any HostsMerging,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) async throws {
+        var preview = model
+        try change(&preview)
+        let merged = preview.mergedHosts
+        do {
+            _ = try await mergeWithOneRetry(merged, via: merger)
+        } catch let DaemonChannelError.mergeWriteFailed(failure)
+            where failure.writtenHash == merged.hash {
+            // The atomic replacement physically landed and only a later flush stage failed: the
+            // switch is a fact, so commit it — recording the baseline hash and the switched
+            // state keeps the very next status from misreporting the write as drift — and
+            // surface only the flush failure.
+            try workspace.recordLastWrittenHash(merged.hash)
+            try persist(change, to: workspace)
+            postWorkspaceChanged(workspace)
+            throw CLIError(
+                code: "dns-flush-failed",
+                message: "the system hosts was updated and the switch was saved, but the DNS cache flush failed: \(failure.message)",
+                exitCode: .failure
+            )
+        }
+        try persist(change, to: workspace)
+        postWorkspaceChanged(workspace)
+    }
+
+    /// The CLI only reports drift (exit code 3), it never reconciles; reconciliation needs the
+    /// review flow of the Hostflip app. The daemon re-verifies inside its transaction lock, so
+    /// this pre-check is a fast local gate, not the authority.
+    private static func requireNoDrift(workspace: Workspace, systemHostsURL: URL) throws {
+        guard try !SystemHostsDrift.detect(workspace: workspace, systemHostsURL: systemHostsURL) else {
+            throw CLIError.hostsDrift
+        }
+    }
+
+    /// interrupted means launchd is relaunching the daemon on demand and a single retry
+    /// recovers; both attempts reuse the mergeID (same discipline as SwitchCoordinator).
+    private static func mergeWithOneRetry(
+        _ merged: MergedHosts,
+        via merger: any HostsMerging
+    ) async throws -> String {
+        let mergeID = UUID()
+        do {
+            return try await merger.merge(merged, mergeID: mergeID, isInterruptedRetry: false)
+        } catch let error as DaemonChannelError where error.isRetryable {
+            return try await merger.merge(merged, mergeID: mergeID, isInterruptedRetry: true)
+        }
+    }
+
+    /// Commits the switched state by replaying it on the latest on-disk model (ADR-0010 ②). At
+    /// this point the system hosts is already rewritten, so a replay conflict (a peer deleted
+    /// the profile mid-flight) is reported instead of silently dropped.
+    private static func persist(
+        _ change: (inout ActivationModel) throws -> Void,
+        to workspace: Workspace
+    ) throws {
+        guard case .saved = try workspace.save(applying: change) else {
+            throw CLIError(
+                code: "state-save-conflict",
+                message: "the system hosts was updated, but a peer writer changed the workspace so the switched state could not be saved; check 'hostflip status'",
+                exitCode: .failure
+            )
+        }
+    }
+}

--- a/Sources/HostflipCLI/SystemHostsDrift.swift
+++ b/Sources/HostflipCLI/SystemHostsDrift.swift
@@ -1,0 +1,22 @@
+import Foundation
+import HostflipCore
+
+/// The shared drift primitive: compares the actual system hosts bytes against the workspace's
+/// expected hash — the same baseline as the app's monitor: the last confirmed merge write, or
+/// the pristine first-capture backup before any write. `status` reports the verdict; the switch
+/// commands gate on it.
+enum SystemHostsDrift {
+    static func detect(workspace: Workspace, systemHostsURL: URL) throws -> Bool {
+        let actualData: Data
+        do {
+            actualData = try Data(contentsOf: systemHostsURL)
+        } catch {
+            throw CLIError(
+                code: "hosts-unreadable",
+                message: "cannot read \(systemHostsURL.path): \(error.localizedDescription)",
+                exitCode: .failure
+            )
+        }
+        return try MergedHosts.hash(of: actualData) != workspace.expectedSystemHostsHash()
+    }
+}

--- a/Sources/HostflipCLI/WriteCommand.swift
+++ b/Sources/HostflipCLI/WriteCommand.swift
@@ -1,0 +1,106 @@
+import Foundation
+import HostflipCore
+
+/// `hostflip write <profile>`: replaces a profile's content whole, from stdin or `--file`.
+/// The new content must pass the structural hosts validation before anything happens; a
+/// rejected write leaves the stored content untouched. Writing an active profile changes the
+/// merged system hosts output, so it takes the shared daemon path (drift gate, merge, then
+/// commit); an inactive profile is a purely local edit that never gates on drift and never
+/// touches the daemon — mirroring the GUI's edit-versus-switch split.
+enum WriteCommand {
+    struct Payload: CommandPayload {
+        let id: String
+        let name: String
+        /// The containing group's name; absent for a standalone profile.
+        let group: String?
+        /// False when the profile already had exactly this content and nothing was written.
+        let changed: Bool
+
+        var humanText: String {
+            let reference = group.map { "\($0)/\(name)" } ?? name
+            return changed ? "Wrote \(reference)." : "\(reference) already has this content."
+        }
+    }
+
+    static func run(
+        reference: ProfileReference,
+        filePath: String?,
+        readStandardInput: @Sendable () throws -> Data,
+        workspace: Workspace,
+        systemHostsURL: URL,
+        merger: any HostsMerging,
+        postWorkspaceChanged: @Sendable (Workspace) -> Void
+    ) async throws -> Payload {
+        let model = try workspace.openReadOnly()
+        let match = try ProfileResolver.resolve(reference, in: model)
+        let profileID = match.profile.id
+        let content = try readContent(filePath: filePath, readStandardInput: readStandardInput)
+        if let line = HostsSyntax.firstIncompleteLine(in: content) {
+            throw CLIError(
+                code: "invalid-hosts-syntax",
+                message: "invalid hosts content: line \(line) has a single field; every entry needs an IP address and at least one hostname",
+                exitCode: .failure
+            )
+        }
+
+        func payload(changed: Bool) -> Payload {
+            Payload(id: profileID.rawValue, name: match.profile.name, group: match.groupName, changed: changed)
+        }
+
+        if model.activeProfileIDs.contains(profileID) {
+            // Same discipline as the switch commands: the drift gate runs before the idempotent
+            // no-op check, because writing an active profile vouches for the hosts content.
+            try MergeCommitFlow.requireNoDrift(workspace: workspace, systemHostsURL: systemHostsURL)
+            guard match.profile.content != content else {
+                return payload(changed: false)
+            }
+            try await MergeCommitFlow.run(
+                change: { try $0.updateProfileContent(profileID, content: content) },
+                on: model,
+                workspace: workspace,
+                systemHostsURL: systemHostsURL,
+                merger: merger,
+                postWorkspaceChanged: postWorkspaceChanged
+            )
+            return payload(changed: true)
+        }
+
+        guard match.profile.content != content else {
+            return payload(changed: false)
+        }
+        try LocalEdit.persist(
+            { try $0.updateProfileContent(profileID, content: content) },
+            to: workspace
+        )
+        postWorkspaceChanged(workspace)
+        return payload(changed: true)
+    }
+
+    private static func readContent(
+        filePath: String?,
+        readStandardInput: () throws -> Data
+    ) throws -> String {
+        let data: Data
+        if let filePath {
+            do {
+                data = try Data(contentsOf: URL(fileURLWithPath: filePath))
+            } catch {
+                throw CLIError(
+                    code: "file-unreadable",
+                    message: "cannot read \(filePath): \(error.localizedDescription)",
+                    exitCode: .failure
+                )
+            }
+        } else {
+            data = try readStandardInput()
+        }
+        guard let content = String(data: data, encoding: .utf8) else {
+            throw CLIError(
+                code: "invalid-encoding",
+                message: "the new content is not valid UTF-8 text",
+                exitCode: .failure
+            )
+        }
+        return content
+    }
+}

--- a/Sources/HostflipCore/HostsSyntax.swift
+++ b/Sources/HostflipCore/HostsSyntax.swift
@@ -56,4 +56,30 @@ public enum HostsSyntax {
         }
         return tokens
     }
+
+    /// Structural validation on the same per-line rules: a hosts entry names an IP address and at
+    /// least one hostname, so a non-comment line with exactly one field cannot be complete. Field
+    /// values stay unvalidated, matching the tokenizer. Returns the 1-based number of the first
+    /// incomplete line; nil when every line is blank, comment-only, or a full entry.
+    public static func firstIncompleteLine(in text: String) -> Int? {
+        let ns = text as NSString
+        var lineNumber = 0
+        var incompleteLine: Int?
+        ns.enumerateSubstrings(
+            in: NSRange(location: 0, length: ns.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, lineRange, _, stop in
+            lineNumber += 1
+            var codeRange = lineRange
+            let hash = ns.range(of: "#", range: lineRange)
+            if hash.location != NSNotFound {
+                codeRange.length = hash.location - lineRange.location
+            }
+            if fieldPattern.numberOfMatches(in: text, options: [], range: codeRange) == 1 {
+                incompleteLine = lineNumber
+                stop.pointee = true
+            }
+        }
+        return incompleteLine
+    }
 }

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -114,49 +114,109 @@ public struct Workspace: Sendable {
             throw WorkspaceError.notInitialized
         }
         try withManifestLock {
-            // Read the old manifest before writing any content files: we must neither discover a corrupt manifest
-            // after leaving half a set of new content behind, nor silently reset the stored hash (#24's comparison primitive) to nil.
-            let priorLastWrittenHash = FileManager.default.fileExists(atPath: manifestURL.path)
-                ? try loadManifest().lastWrittenHash
-                : nil
-            try FileManager.default.createDirectory(at: profilesDirectory, withIntermediateDirectories: true)
-            try write(model.baseHosts.content, to: baseHostsURL)
+            try saveLocked(model, acceptingSystemHostsHash: acceptedHash)
+        }
+    }
 
-            let fileNames = assignFileNames(for: model.standaloneProfiles + model.groups.flatMap(\.profiles))
-            func writeProfileFile(for profile: Profile) throws -> ManifestProfile {
-                let fileName = fileNames[profile.id]!
-                try write(profile.content, to: profilesDirectory.appendingPathComponent(fileName))
-                return ManifestProfile(id: profile.id.rawValue, name: profile.name, file: fileName)
+    /// The save body proper; the caller must hold the manifest lock.
+    private func saveLocked(
+        _ model: ActivationModel,
+        acceptingSystemHostsHash acceptedHash: String?
+    ) throws {
+        // Read the old manifest before writing any content files: we must neither discover a corrupt manifest
+        // after leaving half a set of new content behind, nor silently reset the stored hash (#24's comparison primitive) to nil.
+        let priorLastWrittenHash = FileManager.default.fileExists(atPath: manifestURL.path)
+            ? try loadManifest().lastWrittenHash
+            : nil
+        try FileManager.default.createDirectory(at: profilesDirectory, withIntermediateDirectories: true)
+        try write(model.baseHosts.content, to: baseHostsURL)
+
+        let fileNames = assignFileNames(for: model.standaloneProfiles + model.groups.flatMap(\.profiles))
+        func writeProfileFile(for profile: Profile) throws -> ManifestProfile {
+            let fileName = fileNames[profile.id]!
+            try write(profile.content, to: profilesDirectory.appendingPathComponent(fileName))
+            return ManifestProfile(id: profile.id.rawValue, name: profile.name, file: fileName)
+        }
+
+        let manifest = try Manifest(
+            standaloneProfiles: model.standaloneProfiles.map(writeProfileFile),
+            groups: model.groups.map { group in
+                try ManifestGroup(
+                    id: group.id.rawValue,
+                    name: group.name,
+                    profiles: group.profiles.map(writeProfileFile)
+                )
+            },
+            activeProfileIDs: model.activeProfileIDs.map(\.rawValue).sorted(),
+            isPaused: model.isPaused,
+            lastWrittenHash: acceptedHash ?? priorLastWrittenHash
+        )
+        try writeManifest(manifest)
+
+        // Stale profile files are cleaned up only after the manifest is persisted — and best-effort:
+        // the manifest write is the commit point, so a cleanup failure must not turn an already
+        // committed save into a thrown one (callers that commit in-memory state only on success
+        // would diverge from disk). An unremoved stale file is unreferenced and retried next save.
+        let expectedFileNames = Set(fileNames.values.map { $0.lowercased() })
+        let leftovers = (try? FileManager.default.contentsOfDirectory(
+            at: profilesDirectory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+        for url in leftovers
+        where url.pathExtension == "hosts" && !expectedFileNames.contains(url.lastPathComponent.lowercased()) {
+            try? FileManager.default.removeItem(at: url)
+        }
+    }
+
+    // MARK: - Reload-and-replay saving (ADR-0010 ②)
+
+    /// Outcome of a reload-and-replay save.
+    public enum ReplayedSaveOutcome: Sendable {
+        /// The change was applied to the latest on-disk state and the result persisted.
+        case saved(ActivationModel)
+        /// The change does not apply to the latest on-disk state (e.g. it targets a profile another
+        /// process deleted); nothing was written. Carries the untouched latest state and the error
+        /// the change threw.
+        case conflict(latest: ActivationModel, reason: any Error)
+    }
+
+    /// Saves by replaying `change` on the latest on-disk state instead of overwriting the disk with
+    /// a model loaded earlier: reload, replay, and write all run under the manifest lock, so changes
+    /// another process made since this instance last read the workspace survive the save (ADR-0010 ②).
+    public func save(
+        applying change: (inout ActivationModel) throws -> Void
+    ) throws -> ReplayedSaveOutcome {
+        try save(applying: change, acceptingSystemHostsHash: nil)
+    }
+
+    /// Reload-and-replay variant of `save(_:acceptingSystemHostsHash:)`.
+    public func save(
+        applying change: (inout ActivationModel) throws -> Void,
+        acceptingSystemHostsHash acceptedHash: String
+    ) throws -> ReplayedSaveOutcome {
+        try save(applying: change, acceptingSystemHostsHash: Optional(acceptedHash))
+    }
+
+    private func save(
+        applying change: (inout ActivationModel) throws -> Void,
+        acceptingSystemHostsHash acceptedHash: String?
+    ) throws -> ReplayedSaveOutcome {
+        guard FileManager.default.fileExists(atPath: originalBackupURL.path) else {
+            throw WorkspaceError.notInitialized
+        }
+        return try withManifestLock {
+            guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+                throw WorkspaceError.notInitialized
             }
-
-            let manifest = try Manifest(
-                standaloneProfiles: model.standaloneProfiles.map(writeProfileFile),
-                groups: model.groups.map { group in
-                    try ManifestGroup(
-                        id: group.id.rawValue,
-                        name: group.name,
-                        profiles: group.profiles.map(writeProfileFile)
-                    )
-                },
-                activeProfileIDs: model.activeProfileIDs.map(\.rawValue).sorted(),
-                isPaused: model.isPaused,
-                lastWrittenHash: acceptedHash ?? priorLastWrittenHash
-            )
-            try writeManifest(manifest)
-
-            // Stale profile files are cleaned up only after the manifest is persisted — and best-effort:
-            // the manifest write is the commit point, so a cleanup failure must not turn an already
-            // committed save into a thrown one (callers that commit in-memory state only on success
-            // would diverge from disk). An unremoved stale file is unreferenced and retried next save.
-            let expectedFileNames = Set(fileNames.values.map { $0.lowercased() })
-            let leftovers = (try? FileManager.default.contentsOfDirectory(
-                at: profilesDirectory,
-                includingPropertiesForKeys: nil
-            )) ?? []
-            for url in leftovers
-            where url.pathExtension == "hosts" && !expectedFileNames.contains(url.lastPathComponent.lowercased()) {
-                try? FileManager.default.removeItem(at: url)
+            let latest = try load()
+            var updated = latest
+            do {
+                try change(&updated)
+            } catch {
+                return ReplayedSaveOutcome.conflict(latest: latest, reason: error)
             }
+            try saveLocked(updated, acceptingSystemHostsHash: acceptedHash)
+            return .saved(updated)
         }
     }
 
@@ -328,6 +388,21 @@ public struct Workspace: Sendable {
             }
         }
         return try body()
+    }
+
+    // MARK: - Cross-process change notification (ADR-0010 ③)
+
+    /// Distributed notification a writer (the CLI) posts after changing the workspace on disk so a
+    /// running GUI can refresh its display. Post with the workspace's `changeNotificationObject` as
+    /// the object and `deliverImmediately: true`. The channel is unauthenticated and unreliable —
+    /// a display-refresh optimization only: receipt may trigger a re-read of the workspace but must
+    /// never be trusted beyond that, and correctness must not depend on delivery.
+    public static let changeNotification = Notification.Name("com.heronapp.hostflip.workspace-changed")
+
+    /// The notification object identifying this workspace: observers filter on it so workspaces at
+    /// different roots do not trigger each other.
+    public var changeNotificationObject: String {
+        rootDirectory.standardizedFileURL.path
     }
 
     // MARK: - File layout

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -40,6 +40,16 @@ public struct Workspace: Sendable {
         return try captureSystemHosts(systemHosts)
     }
 
+    /// Opens the workspace without side effects: loads an initialized workspace, or throws
+    /// `notInitialized` instead of capturing the system hosts. Read-only clients (the CLI)
+    /// must never turn a missing workspace into a first capture.
+    public func openReadOnly() throws -> ActivationModel {
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            throw WorkspaceError.notInitialized
+        }
+        return try load()
+    }
+
     /// hosts.orig alone is treated as an interrupted first capture and safe to capture again;
     /// base.hosts or profile files, however, are unreproducible user content.
     private var hasResidualContent: Bool {

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 
 /// hostflip's persistent workspace (defaults to `~/Library/Application Support/hostflip/`).
@@ -7,6 +8,7 @@ import Foundation
 /// - `base.hosts`: Base Hosts content, updatable in a controlled way by the drift reconciliation flow
 /// - `profiles/*.hosts`: each profile's content; file name = profile name (sanitized + conflict suffix)
 /// - `manifest.json`: group structure, active state, ordering
+/// - `manifest.lock`: dedicated cross-process lock file for manifest read-modify-write (ADR-0010 ①)
 public enum WorkspaceError: Error, Equatable, Sendable {
     /// The workspace has residual content (base.hosts or profile files) but no manifest;
     /// it must not be overwritten as a first-run capture and needs manual intervention.
@@ -297,10 +299,34 @@ public struct Workspace: Sendable {
     /// overwrite the other side's freshly written manifest with stale values (#20 re-review).
     private static let manifestLocks = ManifestLockRegistry()
 
-    private func withManifestLock<T>(_ body: () throws -> T) rethrows -> T {
+    private func withManifestLock<T>(_ body: () throws -> T) throws -> T {
         let lock = Self.manifestLocks.lock(forPath: rootDirectory.standardizedFileURL.path)
         lock.lock()
         defer { lock.unlock() }
+        return try withCrossProcessManifestLock(body)
+    }
+
+    /// Serializes manifest read-modify-write across processes (CLI and resident GUI as peer writers,
+    /// ADR-0010 ①) with an exclusive flock. The lock lives on a dedicated lock file, never on
+    /// manifest.json itself: the manifest is atomically replaced, and rename would leave the lock
+    /// attached to a file no other process opens anymore. The in-process NSLock stays in front, so the
+    /// kernel lock only ever mediates between processes and existing in-process semantics are unchanged.
+    /// flock is released by the kernel when its holder exits, so a crash cannot leave a stale deadlock;
+    /// the leftover lock file itself is inert.
+    private func withCrossProcessManifestLock<T>(_ body: () throws -> T) throws -> T {
+        let fd = Darwin.open(manifestLockURL.path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
+        guard fd >= 0 else {
+            // The lock file's parent directory is missing, i.e. there is no workspace to lock.
+            if errno == ENOENT { throw WorkspaceError.notInitialized }
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+        // Closing the descriptor releases the flock.
+        defer { close(fd) }
+        while flock(fd, LOCK_EX) != 0 {
+            guard errno == EINTR else {
+                throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+            }
+        }
         return try body()
     }
 
@@ -309,6 +335,7 @@ public struct Workspace: Sendable {
     private var originalBackupURL: URL { rootDirectory.appendingPathComponent("hosts.orig") }
     private var baseHostsURL: URL { rootDirectory.appendingPathComponent("base.hosts") }
     private var manifestURL: URL { rootDirectory.appendingPathComponent("manifest.json") }
+    private var manifestLockURL: URL { rootDirectory.appendingPathComponent("manifest.lock") }
     private var profilesDirectory: URL { rootDirectory.appendingPathComponent("profiles", isDirectory: true) }
 
     private func write(_ content: String, to url: URL) throws {

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -5,6 +5,9 @@
 public enum ChannelIdentity {
     /// The app's bundle identifier, which is also its code-signing identifier.
     public static let appBundleID = "com.heronapp.hostflip"
+    /// The CLI's code-signing identifier (ADR 0009): its own identity, distinct from the
+    /// app's; the daemon accepts either this or the app identifier as its peer.
+    public static let cliIdentifier = "com.heronapp.hostflip.cli"
     /// The daemon's code-signing identifier, which is also the launchd Label and the Mach service name.
     public static let daemonIdentifier = "com.heronapp.hostflip.daemon"
     /// Name of the plist used for SMAppService registration (in the app bundle's Contents/Library/LaunchDaemons/).

--- a/Sources/HostflipXPC/CodeSigningRequirement.swift
+++ b/Sources/HostflipXPC/CodeSigningRequirement.swift
@@ -7,24 +7,33 @@ public enum CodeSigningRequirementError: Error, Equatable, Sendable {
 }
 
 public enum CodeSigningRequirement {
-    /// The requirement the peer must satisfy: matching signing identifier, certificate
-    /// chain anchored to Apple, matching Team ID. Inputs admit only the bundle-id
-    /// character set and a 10-character uppercase alphanumeric Team ID, ruling out
-    /// requirement syntax injection.
+    /// The requirement the peer must satisfy: one of the given signing identifiers,
+    /// certificate chain anchored to Apple, matching Team ID. Inputs admit only the
+    /// bundle-id character set and a 10-character uppercase alphanumeric Team ID,
+    /// ruling out requirement syntax injection.
     ///
     /// The form is anchor apple generic + leaf[subject.OU]: in Apple developer
     /// certificates the Team ID is bound by Apple and cannot be spoofed; tightening
     /// further by certificate class (the Developer ID OID) would also reject builds
     /// signed with development certificates, so that is left for the release pipeline
     /// (M5 #27) to evaluate.
-    public static func peerRequirement(identifier: String, teamID: String) throws -> String {
-        guard !identifier.isEmpty, identifier.allSatisfy(identifierAlphabet.contains) else {
-            throw CodeSigningRequirementError.invalidIdentifier(identifier)
+    public static func peerRequirement(identifiers: [String], teamID: String) throws -> String {
+        guard !identifiers.isEmpty else {
+            throw CodeSigningRequirementError.invalidIdentifier("")
+        }
+        for identifier in identifiers {
+            guard !identifier.isEmpty, identifier.allSatisfy(identifierAlphabet.contains) else {
+                throw CodeSigningRequirementError.invalidIdentifier(identifier)
+            }
         }
         guard teamID.count == 10, teamID.allSatisfy(teamIDAlphabet.contains) else {
             throw CodeSigningRequirementError.invalidTeamID(teamID)
         }
-        return #"identifier "\#(identifier)" and anchor apple generic and certificate leaf[subject.OU] = "\#(teamID)""#
+        let identifierClause = identifiers.map { #"identifier "\#($0)""# }.joined(separator: " or ")
+        // "or" binds looser than "and" in the requirement language, so the alternation
+        // must be parenthesized to keep the anchor/Team ID constraints on every branch.
+        let alternation = identifiers.count > 1 ? "(\(identifierClause))" : identifierClause
+        return #"\#(alternation) and anchor apple generic and certificate leaf[subject.OU] = "\#(teamID)""#
     }
 
     private static let identifierAlphabet =
@@ -39,11 +48,11 @@ public struct SigningIdentity: Sendable {
     /// Builds the peer requirement from this process's own signing identity (the peer
     /// must share this process's Team ID); an unsigned process fails closed. Both
     /// sides of the channel share this entry point.
-    public static func peerRequirement(identifier: String) throws -> String {
+    public static func peerRequirement(identifiers: [String]) throws -> String {
         guard let identity = current() else {
             throw DaemonChannelError.selfSigningUnavailable
         }
-        return try CodeSigningRequirement.peerRequirement(identifier: identifier, teamID: identity.teamID)
+        return try CodeSigningRequirement.peerRequirement(identifiers: identifiers, teamID: identity.teamID)
     }
 
     /// Reads the Team ID from the current process's signature; returns nil when

--- a/Sources/HostflipXPC/DaemonClient.swift
+++ b/Sources/HostflipXPC/DaemonClient.swift
@@ -43,7 +43,7 @@ public actor DaemonClient {
     private func activeConnection() throws -> NSXPCConnection {
         if let connection { return connection }
         let requirement = try SigningIdentity.peerRequirement(
-            identifier: ChannelIdentity.daemonIdentifier
+            identifiers: [ChannelIdentity.daemonIdentifier]
         )
         let connection = NSXPCConnection(
             machServiceName: ChannelIdentity.daemonIdentifier,

--- a/Sources/hostflipd/main.swift
+++ b/Sources/hostflipd/main.swift
@@ -3,8 +3,8 @@ import HostflipXPC
 import os
 
 // Entry point of the hostflip privileged daemon: publishes the Mach service and only accepts connections
-// from a hostflip app signed with the same Team ID. All business logic lives in HostflipXPC.DaemonService
-// (unit-testable); this file is only launchd/XPC glue.
+// from a hostflip app or CLI signed with the same Team ID (ADR 0009). All business logic lives in
+// HostflipXPC.DaemonService (unit-testable); this file is only launchd/XPC glue.
 
 /// Sets the code signing requirement before accepting a new connection; peers that fail it are rejected by the XPC runtime.
 final class ListenerDelegate: NSObject, NSXPCListenerDelegate, @unchecked Sendable {
@@ -39,7 +39,7 @@ func fail(_ message: String, code: Int32) -> Never {
 
 // If we are unsigned ourselves we cannot verify peers, so fail closed (EX_CONFIG; launchd will not restart endlessly).
 guard let peerRequirement = try? SigningIdentity.peerRequirement(
-    identifier: ChannelIdentity.appBundleID
+    identifiers: [ChannelIdentity.appBundleID, ChannelIdentity.cliIdentifier]
 ) else {
     fail("Refusing to start: unsigned build or signing identity lacks a valid Team ID. See docs/signed-build-verification.md", code: 78)
 }

--- a/Tests/HostflipCLITests/CLITests.swift
+++ b/Tests/HostflipCLITests/CLITests.swift
@@ -246,6 +246,26 @@ final class CLITests: XCTestCase {
         XCTAssertNil(details["candidates"])
     }
 
+    func testCatWithAnIDPastedAsANameHintsAtTheIDOption() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("cat", "dev-id")
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        XCTAssertTrue(result.standardError.contains("'dev-id' is a profile ID, not a profile name; use --id dev-id"))
+    }
+
+    func testTheIDPastedAsANameJSONErrorKeepsTheNotFoundCode() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "cat", "dev-id")
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        // The string code is the machine contract and stays stable; only the human message hints.
+        XCTAssertEqual(details["code"] as? String, "profile-not-found")
+    }
+
     func testCatAmbiguousReferenceListsEveryCandidateWithItsID() async throws {
         try makeAmbiguousWorkspace()
 

--- a/Tests/HostflipCLITests/CLITests.swift
+++ b/Tests/HostflipCLITests/CLITests.swift
@@ -22,10 +22,10 @@ final class CLITests: XCTestCase {
 
     // MARK: - status
 
-    func testStatusReportsRunningActiveProfilesAndNoDrift() throws {
+    func testStatusReportsRunningActiveProfilesAndNoDrift() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("status")
+        let result = await invoke("status")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardError, "")
@@ -37,10 +37,10 @@ final class CLITests: XCTestCase {
             """)
     }
 
-    func testStatusJSONWritesTheResultObjectToStandardOutput() throws {
+    func testStatusJSONWritesTheResultObjectToStandardOutput() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("--json", "status")
+        let result = await invoke("--json", "status")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardError, "")
@@ -54,42 +54,42 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(active.first?["group"] as? String, "Work")
     }
 
-    func testStatusReportsPausedWhilePreservingActiveProfiles() throws {
+    func testStatusReportsPausedWhilePreservingActiveProfiles() async throws {
         try makeInitializedWorkspace(paused: true)
 
-        let result = invoke("status")
+        let result = await invoke("status")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertTrue(result.standardOutput.hasPrefix("Status: paused\nActive: Work/Dev\n"))
     }
 
-    func testStatusReportsDriftWhenTheSystemHostsDiverges() throws {
+    func testStatusReportsDriftWhenTheSystemHostsDiverges() async throws {
         try makeInitializedWorkspace()
         try Data("tampered\n".utf8).write(to: systemHostsURL)
 
-        let result = invoke("--json", "status")
+        let result = await invoke("--json", "status")
 
         // status only reports drift; exit code 3 is reserved for write commands refusing to proceed.
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(try jsonObject(result.standardOutput)["drift"] as? Bool, true)
     }
 
-    func testStatusDriftLineNamesTheDriftInHumanOutput() throws {
+    func testStatusDriftLineNamesTheDriftInHumanOutput() async throws {
         try makeInitializedWorkspace()
         try Data("tampered\n".utf8).write(to: systemHostsURL)
 
-        let result = invoke("status")
+        let result = await invoke("status")
 
         XCTAssertTrue(result.standardOutput.contains("Drift:  detected"))
     }
 
-    func testStatusDriftBaselineFollowsTheLastConfirmedMergeWrite() throws {
+    func testStatusDriftBaselineFollowsTheLastConfirmedMergeWrite() async throws {
         let workspace = try makeInitializedWorkspace()
         let merged = "merged output\n"
         try workspace.recordLastWrittenHash(MergedHosts(content: merged).hash)
         try Data(merged.utf8).write(to: systemHostsURL)
 
-        let result = invoke("--json", "status")
+        let result = await invoke("--json", "status")
 
         // The system hosts no longer matches first capture, but it matches the recorded merge
         // write: no drift — the same baseline the app's drift monitor compares against.
@@ -98,10 +98,10 @@ final class CLITests: XCTestCase {
 
     // MARK: - list
 
-    func testListShowsTheGroupStructureWithIDs() throws {
+    func testListShowsTheGroupStructureWithIDs() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("list")
+        let result = await invoke("list")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardError, "")
@@ -114,10 +114,10 @@ final class CLITests: XCTestCase {
             """)
     }
 
-    func testListJSONContainsStandaloneProfilesAndGroups() throws {
+    func testListJSONContainsStandaloneProfilesAndGroups() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("--json", "list")
+        let result = await invoke("--json", "list")
 
         XCTAssertEqual(result.exitCode, .success)
         let object = try jsonObject(result.standardOutput)
@@ -131,7 +131,7 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(members.map { $0["id"] as? String }, ["dev-id", "staging-id"])
     }
 
-    func testListPadsNonBMPNamesWithoutTruncatingTheIDColumn() throws {
+    func testListPadsNonBMPNamesWithoutTruncatingTheIDColumn() async throws {
         let workspace = Workspace(rootDirectory: workspaceRootDirectory)
         _ = try workspace.open(systemHosts: { capturedHosts })
         let model = try ActivationModel(
@@ -144,7 +144,7 @@ final class CLITests: XCTestCase {
         )
         try workspace.save(model)
 
-        let result = invoke("list")
+        let result = await invoke("list")
 
         // A name whose UTF-16 length exceeds the column width must still be printed whole,
         // with its ID intact after the padding.
@@ -155,11 +155,11 @@ final class CLITests: XCTestCase {
             """)
     }
 
-    func testListWithNoProfilesPrintsAPlaceholder() throws {
+    func testListWithNoProfilesPrintsAPlaceholder() async throws {
         let workspace = Workspace(rootDirectory: workspaceRootDirectory)
         _ = try workspace.open(systemHosts: { capturedHosts })
 
-        let result = invoke("list")
+        let result = await invoke("list")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardOutput, "No profiles.\n")
@@ -167,10 +167,10 @@ final class CLITests: XCTestCase {
 
     // MARK: - cat
 
-    func testCatByNamePrintsTheProfileContentVerbatim() throws {
+    func testCatByNamePrintsTheProfileContentVerbatim() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("cat", "Dev")
+        let result = await invoke("cat", "Dev")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardError, "")
@@ -178,7 +178,7 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(result.standardOutput, "# dev")
     }
 
-    func testCatPreservesATrailingNewlineExactly() throws {
+    func testCatPreservesATrailingNewlineExactly() async throws {
         let workspace = Workspace(rootDirectory: workspaceRootDirectory)
         _ = try workspace.open(systemHosts: { capturedHosts })
         let content = "127.0.0.1 dev.local\n"
@@ -189,33 +189,33 @@ final class CLITests: XCTestCase {
         )
         try workspace.save(model)
 
-        let result = invoke("cat", "Dev")
+        let result = await invoke("cat", "Dev")
 
         XCTAssertEqual(result.standardOutput, content)
     }
 
-    func testCatByPathPrintsTheNamedGroupMember() throws {
+    func testCatByPathPrintsTheNamedGroupMember() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("cat", "Work/Staging")
+        let result = await invoke("cat", "Work/Staging")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardOutput, "# staging")
     }
 
-    func testCatByIDPrintsTheProfile() throws {
+    func testCatByIDPrintsTheProfile() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("cat", "--id", "solo-id")
+        let result = await invoke("cat", "--id", "solo-id")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardOutput, "# solo")
     }
 
-    func testCatJSONReportsTheResolvedProfileWithItsContent() throws {
+    func testCatJSONReportsTheResolvedProfileWithItsContent() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("--json", "cat", "Dev")
+        let result = await invoke("--json", "cat", "Dev")
 
         XCTAssertEqual(result.exitCode, .success)
         let object = try jsonObject(result.standardOutput)
@@ -225,20 +225,20 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(object["content"] as? String, "# dev")
     }
 
-    func testCatUnknownReferenceFailsWithNotFoundExitCode() throws {
+    func testCatUnknownReferenceFailsWithNotFoundExitCode() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("cat", "Missing")
+        let result = await invoke("cat", "Missing")
 
         XCTAssertEqual(result.exitCode, .notFound)
         XCTAssertEqual(result.standardOutput, "")
         XCTAssertTrue(result.standardError.contains("no profile matches 'Missing'"))
     }
 
-    func testCatUnknownReferenceJSONErrorCarriesTheNotFoundCodeWithoutCandidates() throws {
+    func testCatUnknownReferenceJSONErrorCarriesTheNotFoundCodeWithoutCandidates() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("--json", "cat", "--id", "missing-id")
+        let result = await invoke("--json", "cat", "--id", "missing-id")
 
         XCTAssertEqual(result.exitCode, .notFound)
         let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
@@ -246,10 +246,10 @@ final class CLITests: XCTestCase {
         XCTAssertNil(details["candidates"])
     }
 
-    func testCatAmbiguousReferenceListsEveryCandidateWithItsID() throws {
+    func testCatAmbiguousReferenceListsEveryCandidateWithItsID() async throws {
         try makeAmbiguousWorkspace()
 
-        let result = invoke("cat", "Dev")
+        let result = await invoke("cat", "Dev")
 
         XCTAssertEqual(result.exitCode, .ambiguous)
         XCTAssertEqual(result.standardOutput, "")
@@ -262,10 +262,10 @@ final class CLITests: XCTestCase {
             """)
     }
 
-    func testCatAmbiguousReferenceJSONErrorCarriesTheCandidates() throws {
+    func testCatAmbiguousReferenceJSONErrorCarriesTheCandidates() async throws {
         try makeAmbiguousWorkspace()
 
-        let result = invoke("--json", "cat", "Dev")
+        let result = await invoke("--json", "cat", "Dev")
 
         XCTAssertEqual(result.exitCode, .ambiguous)
         let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
@@ -278,16 +278,16 @@ final class CLITests: XCTestCase {
 
     // MARK: - Errors and exit codes
 
-    func testUninitializedWorkspaceFailsWithGeneralErrorExitCode() throws {
-        let result = invoke("status")
+    func testUninitializedWorkspaceFailsWithGeneralErrorExitCode() async throws {
+        let result = await invoke("status")
 
         XCTAssertEqual(result.exitCode, .failure)
         XCTAssertEqual(result.standardOutput, "")
         XCTAssertTrue(result.standardError.contains("not initialized"))
     }
 
-    func testUninitializedWorkspaceJSONErrorCarriesTheStringCode() throws {
-        let result = invoke("--json", "list")
+    func testUninitializedWorkspaceJSONErrorCarriesTheStringCode() async throws {
+        let result = await invoke("--json", "list")
 
         XCTAssertEqual(result.exitCode, .failure)
         XCTAssertEqual(result.standardOutput, "", "results belong to stdout, errors to stderr")
@@ -297,82 +297,82 @@ final class CLITests: XCTestCase {
         XCTAssertFalse(try XCTUnwrap(details["message"] as? String).isEmpty)
     }
 
-    func testUnknownCommandFailsWithUsageExitCode() throws {
-        let result = invoke("frobnicate")
+    func testUnknownCommandFailsWithUsageExitCode() async throws {
+        let result = await invoke("frobnicate")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("unknown command 'frobnicate'"))
     }
 
-    func testUnknownCommandJSONErrorUsesTheUsageCode() throws {
-        let result = invoke("--json", "frobnicate")
+    func testUnknownCommandJSONErrorUsesTheUsageCode() async throws {
+        let result = await invoke("--json", "frobnicate")
 
         XCTAssertEqual(result.exitCode, .usage)
         let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
         XCTAssertEqual(details["code"] as? String, "usage")
     }
 
-    func testUnknownOptionFailsWithUsageExitCode() throws {
-        let result = invoke("status", "--verbose")
+    func testUnknownOptionFailsWithUsageExitCode() async throws {
+        let result = await invoke("status", "--verbose")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("unknown option '--verbose'"))
     }
 
-    func testUnexpectedExtraArgumentFailsWithUsageExitCode() throws {
+    func testUnexpectedExtraArgumentFailsWithUsageExitCode() async throws {
         try makeInitializedWorkspace()
 
-        let result = invoke("status", "extra")
+        let result = await invoke("status", "extra")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("unexpected argument 'extra'"))
     }
 
-    func testCatWithoutAReferenceFailsWithUsageExitCode() throws {
-        let result = invoke("cat")
+    func testCatWithoutAReferenceFailsWithUsageExitCode() async throws {
+        let result = await invoke("cat")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("'cat' needs a profile name, group/profile path, or --id"))
     }
 
-    func testCatWithBothANameAndIDFailsWithUsageExitCode() throws {
-        let result = invoke("cat", "Dev", "--id", "dev-id")
+    func testCatWithBothANameAndIDFailsWithUsageExitCode() async throws {
+        let result = await invoke("cat", "Dev", "--id", "dev-id")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("not both"))
     }
 
-    func testCatWithASecondPositionalFailsWithUsageExitCode() throws {
-        let result = invoke("cat", "Dev", "Staging")
+    func testCatWithASecondPositionalFailsWithUsageExitCode() async throws {
+        let result = await invoke("cat", "Dev", "Staging")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("unexpected argument 'Staging'"))
     }
 
-    func testIDOnACommandThatTakesNoReferenceFailsWithUsageExitCode() throws {
-        let result = invoke("status", "--id", "dev-id")
+    func testIDOnACommandThatTakesNoReferenceFailsWithUsageExitCode() async throws {
+        let result = await invoke("status", "--id", "dev-id")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("unexpected option '--id'"))
     }
 
-    func testIDWithoutAValueFailsWithUsageExitCode() throws {
-        let result = invoke("cat", "--id")
+    func testIDWithoutAValueFailsWithUsageExitCode() async throws {
+        let result = await invoke("cat", "--id")
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertTrue(result.standardError.contains("option '--id' requires a value"))
     }
 
-    func testBareInvocationFailsWithUsageExitCode() throws {
-        let result = invoke()
+    func testBareInvocationFailsWithUsageExitCode() async throws {
+        let result = await invoke()
 
         XCTAssertEqual(result.exitCode, .usage)
         XCTAssertEqual(result.standardOutput, "")
         XCTAssertTrue(result.standardError.contains("no command given"))
     }
 
-    func testHelpPrintsCanonicalCommandsAndSucceeds() throws {
-        let result = invoke("--help")
+    func testHelpPrintsCanonicalCommandsAndSucceeds() async throws {
+        let result = await invoke("--help")
 
         XCTAssertEqual(result.exitCode, .success)
         XCTAssertEqual(result.standardError, "")
@@ -396,8 +396,8 @@ final class CLITests: XCTestCase {
 
     // MARK: - Helpers
 
-    private func invoke(_ arguments: String...) -> CLIResult {
-        CLI.run(
+    private func invoke(_ arguments: String...) async -> CLIResult {
+        await CLI.run(
             arguments: arguments,
             workspaceRootDirectory: workspaceRootDirectory,
             systemHostsURL: systemHostsURL

--- a/Tests/HostflipCLITests/CLITests.swift
+++ b/Tests/HostflipCLITests/CLITests.swift
@@ -1,0 +1,285 @@
+import HostflipCore
+import XCTest
+@testable import HostflipCLI
+
+final class CLITests: XCTestCase {
+    private var rootDirectory: URL!
+    private var workspaceRootDirectory: URL!
+    private var systemHostsURL: URL!
+
+    private let capturedHosts = "127.0.0.1 localhost\n"
+
+    override func setUpWithError() throws {
+        rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hostflip-cli-tests-\(UUID().uuidString)", isDirectory: true)
+        workspaceRootDirectory = rootDirectory.appendingPathComponent("workspace", isDirectory: true)
+        systemHostsURL = rootDirectory.appendingPathComponent("hosts")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootDirectory)
+    }
+
+    // MARK: - status
+
+    func testStatusReportsRunningActiveProfilesAndNoDrift() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("status")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        XCTAssertEqual(result.standardOutput, """
+            Status: running
+            Active: Work/Dev
+            Drift:  none
+
+            """)
+    }
+
+    func testStatusJSONWritesTheResultObjectToStandardOutput() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("--json", "status")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["paused"] as? Bool, false)
+        XCTAssertEqual(object["drift"] as? Bool, false)
+        let active = try XCTUnwrap(object["active"] as? [[String: Any]])
+        XCTAssertEqual(active.count, 1)
+        XCTAssertEqual(active.first?["id"] as? String, "dev-id")
+        XCTAssertEqual(active.first?["name"] as? String, "Dev")
+        XCTAssertEqual(active.first?["group"] as? String, "Work")
+    }
+
+    func testStatusReportsPausedWhilePreservingActiveProfiles() throws {
+        try makeInitializedWorkspace(paused: true)
+
+        let result = invoke("status")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertTrue(result.standardOutput.hasPrefix("Status: paused\nActive: Work/Dev\n"))
+    }
+
+    func testStatusReportsDriftWhenTheSystemHostsDiverges() throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+
+        let result = invoke("--json", "status")
+
+        // status only reports drift; exit code 3 is reserved for write commands refusing to proceed.
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try jsonObject(result.standardOutput)["drift"] as? Bool, true)
+    }
+
+    func testStatusDriftLineNamesTheDriftInHumanOutput() throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+
+        let result = invoke("status")
+
+        XCTAssertTrue(result.standardOutput.contains("Drift:  detected"))
+    }
+
+    func testStatusDriftBaselineFollowsTheLastConfirmedMergeWrite() throws {
+        let workspace = try makeInitializedWorkspace()
+        let merged = "merged output\n"
+        try workspace.recordLastWrittenHash(MergedHosts(content: merged).hash)
+        try Data(merged.utf8).write(to: systemHostsURL)
+
+        let result = invoke("--json", "status")
+
+        // The system hosts no longer matches first capture, but it matches the recorded merge
+        // write: no drift — the same baseline the app's drift monitor compares against.
+        XCTAssertEqual(try jsonObject(result.standardOutput)["drift"] as? Bool, false)
+    }
+
+    // MARK: - list
+
+    func testListShowsTheGroupStructureWithIDs() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("list")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        XCTAssertEqual(result.standardOutput, """
+            Solo       solo-id
+            Work/      work-id
+              Dev      dev-id
+              Staging  staging-id
+
+            """)
+    }
+
+    func testListJSONContainsStandaloneProfilesAndGroups() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("--json", "list")
+
+        XCTAssertEqual(result.exitCode, .success)
+        let object = try jsonObject(result.standardOutput)
+        let standalone = try XCTUnwrap(object["standaloneProfiles"] as? [[String: Any]])
+        XCTAssertEqual(standalone.map { $0["id"] as? String }, ["solo-id"])
+        XCTAssertEqual(standalone.map { $0["name"] as? String }, ["Solo"])
+        let groups = try XCTUnwrap(object["groups"] as? [[String: Any]])
+        XCTAssertEqual(groups.map { $0["id"] as? String }, ["work-id"])
+        XCTAssertEqual(groups.map { $0["name"] as? String }, ["Work"])
+        let members = try XCTUnwrap(groups.first?["profiles"] as? [[String: Any]])
+        XCTAssertEqual(members.map { $0["id"] as? String }, ["dev-id", "staging-id"])
+    }
+
+    func testListPadsNonBMPNamesWithoutTruncatingTheIDColumn() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [
+                Profile(id: .init("emoji-id"), name: "🚀🚀🚀🚀🚀🚀", content: "# a"),
+                Profile(id: .init("plain-id"), name: "Plain", content: "# b"),
+            ],
+            groups: []
+        )
+        try workspace.save(model)
+
+        let result = invoke("list")
+
+        // A name whose UTF-16 length exceeds the column width must still be printed whole,
+        // with its ID intact after the padding.
+        XCTAssertEqual(result.standardOutput, """
+            🚀🚀🚀🚀🚀🚀  emoji-id
+            Plain   plain-id
+
+            """)
+    }
+
+    func testListWithNoProfilesPrintsAPlaceholder() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+
+        let result = invoke("list")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "No profiles.\n")
+    }
+
+    // MARK: - Errors and exit codes
+
+    func testUninitializedWorkspaceFailsWithGeneralErrorExitCode() throws {
+        let result = invoke("status")
+
+        XCTAssertEqual(result.exitCode, .failure)
+        XCTAssertEqual(result.standardOutput, "")
+        XCTAssertTrue(result.standardError.contains("not initialized"))
+    }
+
+    func testUninitializedWorkspaceJSONErrorCarriesTheStringCode() throws {
+        let result = invoke("--json", "list")
+
+        XCTAssertEqual(result.exitCode, .failure)
+        XCTAssertEqual(result.standardOutput, "", "results belong to stdout, errors to stderr")
+        let envelope = try jsonObject(result.standardError)
+        let details = try XCTUnwrap(envelope["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "workspace-not-initialized")
+        XCTAssertFalse(try XCTUnwrap(details["message"] as? String).isEmpty)
+    }
+
+    func testUnknownCommandFailsWithUsageExitCode() throws {
+        let result = invoke("frobnicate")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unknown command 'frobnicate'"))
+    }
+
+    func testUnknownCommandJSONErrorUsesTheUsageCode() throws {
+        let result = invoke("--json", "frobnicate")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "usage")
+    }
+
+    func testUnknownOptionFailsWithUsageExitCode() throws {
+        let result = invoke("status", "--verbose")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unknown option '--verbose'"))
+    }
+
+    func testUnexpectedExtraArgumentFailsWithUsageExitCode() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("status", "extra")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unexpected argument 'extra'"))
+    }
+
+    func testBareInvocationFailsWithUsageExitCode() throws {
+        let result = invoke()
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertEqual(result.standardOutput, "")
+        XCTAssertTrue(result.standardError.contains("no command given"))
+    }
+
+    func testHelpPrintsCanonicalCommandsAndSucceeds() throws {
+        let result = invoke("--help")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        XCTAssertTrue(result.standardOutput.contains("Usage: hostflip"))
+        XCTAssertTrue(result.standardOutput.contains("status"))
+        XCTAssertTrue(result.standardOutput.contains("list"))
+    }
+
+    func testExitCodeFrameworkPinsTheNumericContract() {
+        XCTAssertEqual(ExitCode.success.rawValue, 0)
+        XCTAssertEqual(ExitCode.failure.rawValue, 1)
+        XCTAssertEqual(ExitCode.usage.rawValue, 2)
+        // Reserved by the framework; enabled by later commands.
+        XCTAssertEqual(ExitCode.drift.rawValue, 3)
+        XCTAssertEqual(ExitCode.daemonUnavailable.rawValue, 4)
+        XCTAssertEqual(ExitCode.notFound.rawValue, 5)
+        XCTAssertEqual(ExitCode.ambiguous.rawValue, 6)
+    }
+
+    // MARK: - Helpers
+
+    private func invoke(_ arguments: String...) -> CLIResult {
+        CLI.run(
+            arguments: arguments,
+            workspaceRootDirectory: workspaceRootDirectory,
+            systemHostsURL: systemHostsURL
+        )
+    }
+
+    /// Initializes a workspace holding one standalone profile and one two-member group with its
+    /// first profile active, plus a matching (drift-free) system hosts file.
+    @discardableResult
+    private func makeInitializedWorkspace(paused: Bool = false) throws -> Workspace {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [Profile(id: .init("solo-id"), name: "Solo", content: "# solo")],
+            groups: [
+                Group(id: .init("work-id"), name: "Work", profiles: [
+                    Profile(id: .init("dev-id"), name: "Dev", content: "# dev"),
+                    Profile(id: .init("staging-id"), name: "Staging", content: "# staging"),
+                ]),
+            ],
+            activeProfileIDs: [.init("dev-id")],
+            isPaused: paused
+        )
+        try workspace.save(model)
+        try Data(capturedHosts.utf8).write(to: systemHostsURL)
+        return workspace
+    }
+
+    private func jsonObject(_ text: String) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+}

--- a/Tests/HostflipCLITests/CLITests.swift
+++ b/Tests/HostflipCLITests/CLITests.swift
@@ -165,6 +165,117 @@ final class CLITests: XCTestCase {
         XCTAssertEqual(result.standardOutput, "No profiles.\n")
     }
 
+    // MARK: - cat
+
+    func testCatByNamePrintsTheProfileContentVerbatim() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("cat", "Dev")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        // Verbatim: the fixture content has no trailing newline, so neither has stdout.
+        XCTAssertEqual(result.standardOutput, "# dev")
+    }
+
+    func testCatPreservesATrailingNewlineExactly() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let content = "127.0.0.1 dev.local\n"
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [Profile(id: .init("dev-id"), name: "Dev", content: content)],
+            groups: []
+        )
+        try workspace.save(model)
+
+        let result = invoke("cat", "Dev")
+
+        XCTAssertEqual(result.standardOutput, content)
+    }
+
+    func testCatByPathPrintsTheNamedGroupMember() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("cat", "Work/Staging")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "# staging")
+    }
+
+    func testCatByIDPrintsTheProfile() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("cat", "--id", "solo-id")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "# solo")
+    }
+
+    func testCatJSONReportsTheResolvedProfileWithItsContent() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("--json", "cat", "Dev")
+
+        XCTAssertEqual(result.exitCode, .success)
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["id"] as? String, "dev-id")
+        XCTAssertEqual(object["name"] as? String, "Dev")
+        XCTAssertEqual(object["group"] as? String, "Work")
+        XCTAssertEqual(object["content"] as? String, "# dev")
+    }
+
+    func testCatUnknownReferenceFailsWithNotFoundExitCode() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("cat", "Missing")
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        XCTAssertEqual(result.standardOutput, "")
+        XCTAssertTrue(result.standardError.contains("no profile matches 'Missing'"))
+    }
+
+    func testCatUnknownReferenceJSONErrorCarriesTheNotFoundCodeWithoutCandidates() throws {
+        try makeInitializedWorkspace()
+
+        let result = invoke("--json", "cat", "--id", "missing-id")
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-not-found")
+        XCTAssertNil(details["candidates"])
+    }
+
+    func testCatAmbiguousReferenceListsEveryCandidateWithItsID() throws {
+        try makeAmbiguousWorkspace()
+
+        let result = invoke("cat", "Dev")
+
+        XCTAssertEqual(result.exitCode, .ambiguous)
+        XCTAssertEqual(result.standardOutput, "")
+        // The standalone candidate has no path prefix — that's exactly the case --id exists for.
+        XCTAssertEqual(result.standardError, """
+            hostflip: 'Dev' matches multiple profiles; disambiguate with a group/profile path or --id:
+              Dev       solo-dev-id
+              Work/Dev  work-dev-id
+
+            """)
+    }
+
+    func testCatAmbiguousReferenceJSONErrorCarriesTheCandidates() throws {
+        try makeAmbiguousWorkspace()
+
+        let result = invoke("--json", "cat", "Dev")
+
+        XCTAssertEqual(result.exitCode, .ambiguous)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-ambiguous")
+        let candidates = try XCTUnwrap(details["candidates"] as? [[String: Any]])
+        XCTAssertEqual(candidates.map { $0["id"] as? String }, ["solo-dev-id", "work-dev-id"])
+        XCTAssertEqual(candidates.map { $0["name"] as? String }, ["Dev", "Dev"])
+        XCTAssertEqual(candidates.map { $0["group"] as? String }, [nil, "Work"])
+    }
+
     // MARK: - Errors and exit codes
 
     func testUninitializedWorkspaceFailsWithGeneralErrorExitCode() throws {
@@ -217,6 +328,41 @@ final class CLITests: XCTestCase {
         XCTAssertTrue(result.standardError.contains("unexpected argument 'extra'"))
     }
 
+    func testCatWithoutAReferenceFailsWithUsageExitCode() throws {
+        let result = invoke("cat")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("'cat' needs a profile name, group/profile path, or --id"))
+    }
+
+    func testCatWithBothANameAndIDFailsWithUsageExitCode() throws {
+        let result = invoke("cat", "Dev", "--id", "dev-id")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("not both"))
+    }
+
+    func testCatWithASecondPositionalFailsWithUsageExitCode() throws {
+        let result = invoke("cat", "Dev", "Staging")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unexpected argument 'Staging'"))
+    }
+
+    func testIDOnACommandThatTakesNoReferenceFailsWithUsageExitCode() throws {
+        let result = invoke("status", "--id", "dev-id")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unexpected option '--id'"))
+    }
+
+    func testIDWithoutAValueFailsWithUsageExitCode() throws {
+        let result = invoke("cat", "--id")
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("option '--id' requires a value"))
+    }
+
     func testBareInvocationFailsWithUsageExitCode() throws {
         let result = invoke()
 
@@ -233,6 +379,8 @@ final class CLITests: XCTestCase {
         XCTAssertTrue(result.standardOutput.contains("Usage: hostflip"))
         XCTAssertTrue(result.standardOutput.contains("status"))
         XCTAssertTrue(result.standardOutput.contains("list"))
+        XCTAssertTrue(result.standardOutput.contains("cat"))
+        XCTAssertTrue(result.standardOutput.contains("--id"))
     }
 
     func testExitCodeFrameworkPinsTheNumericContract() {
@@ -277,6 +425,23 @@ final class CLITests: XCTestCase {
         try workspace.save(model)
         try Data(capturedHosts.utf8).write(to: systemHostsURL)
         return workspace
+    }
+
+    /// Initializes a workspace where the bare name "Dev" is ambiguous between a standalone
+    /// profile and a group member.
+    private func makeAmbiguousWorkspace() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [Profile(id: .init("solo-dev-id"), name: "Dev", content: "# solo dev")],
+            groups: [
+                Group(id: .init("work-id"), name: "Work", profiles: [
+                    Profile(id: .init("work-dev-id"), name: "Dev", content: "# work dev"),
+                ]),
+            ]
+        )
+        try workspace.save(model)
     }
 
     private func jsonObject(_ text: String) throws -> [String: Any] {

--- a/Tests/HostflipCLITests/ContentCommandTests.swift
+++ b/Tests/HostflipCLITests/ContentCommandTests.swift
@@ -1,0 +1,655 @@
+import Foundation
+import HostflipCore
+import HostflipXPC
+import XCTest
+@testable import HostflipCLI
+
+/// The content commands (create / write / delete): creation addressing and its duplicate-name
+/// rejection, whole-content replacement from stdin or --file with syntax validation, and the
+/// merge-before-remove discipline for deleting an active profile.
+final class ContentCommandTests: XCTestCase {
+    private var rootDirectory: URL!
+    private var workspaceRootDirectory: URL!
+    private var systemHostsURL: URL!
+
+    private let capturedHosts = "127.0.0.1 localhost\n"
+
+    override func setUpWithError() throws {
+        rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hostflip-content-tests-\(UUID().uuidString)", isDirectory: true)
+        workspaceRootDirectory = rootDirectory.appendingPathComponent("workspace", isDirectory: true)
+        systemHostsURL = rootDirectory.appendingPathComponent("hosts")
+        try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootDirectory)
+    }
+
+    // MARK: - create
+
+    func testCreateMakesAnInactiveEmptyStandaloneProfileByDefault() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("create", "Fresh", merger: merger, onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        XCTAssertEqual(result.standardOutput, "Created Fresh.\n")
+        let persisted = try reloadModel()
+        let fresh = try XCTUnwrap(persisted.standaloneProfiles.first { $0.name == "Fresh" })
+        XCTAssertEqual(fresh.content, "", "a CLI-created profile starts empty")
+        XCTAssertFalse(persisted.activeProfileIDs.contains(fresh.id))
+        XCTAssertEqual(merger.recordedRequests.count, 0, "creating never touches the daemon")
+        XCTAssertEqual(spy.postCount, 1)
+        XCTAssertEqual(
+            spy.observedProfileNames.first?.contains("Fresh"),
+            true,
+            "at post time the manifest must already carry the new profile"
+        )
+    }
+
+    func testCreateJSONReportsTheNewProfile() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "create", "Fresh", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["name"] as? String, "Fresh")
+        XCTAssertNil(object["group"])
+        let id = try XCTUnwrap(object["id"] as? String)
+        XCTAssertTrue(try reloadModel().standaloneProfiles.contains { $0.id.rawValue == id })
+    }
+
+    func testCreateWithAGroupPathLandsInThatGroup() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "create", "Work/Fresh", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try jsonObject(result.standardOutput)["group"] as? String, "Work")
+        let group = try XCTUnwrap(try reloadModel().groups.first { $0.name == "Work" })
+        XCTAssertTrue(group.profiles.contains { $0.name == "Fresh" })
+    }
+
+    func testCreateInAMissingGroupExitsFiveWithoutSideEffects() async throws {
+        try makeInitializedWorkspace()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("--json", "create", "Missing/Fresh", merger: MergerStub(), onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "group-not-found")
+        XCTAssertFalse(try allProfileNames().contains("Fresh"), "the CLI never auto-creates groups")
+        XCTAssertEqual(spy.postCount, 0)
+    }
+
+    func testCreateADuplicateStandaloneNameIsRejectedWithoutSideEffects() async throws {
+        try makeInitializedWorkspace()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("--json", "create", "Solo", merger: MergerStub(), onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-exists")
+        XCTAssertEqual(try reloadModel().standaloneProfiles.count, 1, "a retry must not pollute the addressing space")
+        XCTAssertEqual(spy.postCount, 0)
+    }
+
+    func testCreateADuplicateNameInsideTheSameGroupIsRejected() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "create", "Work/Dev", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-exists")
+        let group = try XCTUnwrap(try reloadModel().groups.first { $0.name == "Work" })
+        XCTAssertEqual(group.profiles.filter { $0.name == "Dev" }.count, 1)
+    }
+
+    func testCreateTheSameNameInADifferentLocationSucceeds() async throws {
+        try makeInitializedWorkspace()
+
+        // "Dev" exists in the Work group; only a namesake in the same location is rejected.
+        let result = await invoke("create", "Dev", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertTrue(try reloadModel().standaloneProfiles.contains { $0.name == "Dev" })
+    }
+
+    func testCreateInAnAmbiguousGroupNameExitsSix() async throws {
+        try makeDuplicateGroupsWorkspace()
+
+        let result = await invoke("--json", "create", "Work/Fresh", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .ambiguous)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "group-ambiguous")
+        XCTAssertFalse(try allProfileNames().contains("Fresh"))
+    }
+
+    func testCreateWithAnEmptyPathHalfFailsWithUsageExitCode() async throws {
+        try makeInitializedWorkspace()
+
+        // Either half of a group/name path coming out empty is a malformed target, not a
+        // lookup miss: usage, never not-found.
+        let bare = await invoke("create", "", merger: MergerStub())
+        let emptyName = await invoke("create", "Work/", merger: MergerStub())
+        let emptyGroup = await invoke("create", "/Fresh", merger: MergerStub())
+
+        XCTAssertEqual(bare.exitCode, .usage)
+        XCTAssertEqual(emptyName.exitCode, .usage)
+        XCTAssertEqual(emptyGroup.exitCode, .usage)
+    }
+
+    func testCreateWithoutANameFailsWithUsageExitCode() async throws {
+        let result = await invoke("create", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("'create' needs a profile name"))
+    }
+
+    func testCreateRejectsTheIDOption() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("create", "--id", "some-id", "Fresh", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unexpected option '--id'"))
+    }
+
+    // MARK: - write
+
+    func testWriteFromStdinReplacesAnInactiveProfilesContent() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+        let spy = WorkspaceChangeSpy()
+        let content = "0.0.0.0 ads.example.com\n"
+
+        let result = await invoke(
+            "write", "Solo",
+            standardInput: Data(content.utf8),
+            merger: merger,
+            onWorkspaceChanged: spy
+        )
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Wrote Solo.\n")
+        XCTAssertEqual(try reloadProfile("solo-id").content, content)
+        XCTAssertEqual(merger.recordedRequests.count, 0, "an inactive profile is a purely local edit")
+        XCTAssertEqual(spy.postCount, 1)
+    }
+
+    func testWriteJSONReportsTheResolvedProfileAndTheChange() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke(
+            "--json", "write", "Solo",
+            standardInput: Data("0.0.0.0 ads.example.com\n".utf8),
+            merger: MergerStub()
+        )
+
+        XCTAssertEqual(result.exitCode, .success)
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["id"] as? String, "solo-id")
+        XCTAssertEqual(object["name"] as? String, "Solo")
+        XCTAssertNil(object["group"])
+        XCTAssertEqual(object["changed"] as? Bool, true)
+    }
+
+    func testWriteFromAFileReplacesContent() async throws {
+        try makeInitializedWorkspace()
+        let content = "0.0.0.0 tracker.example.com\n"
+        let fileURL = rootDirectory.appendingPathComponent("new-content.hosts")
+        try Data(content.utf8).write(to: fileURL)
+
+        let result = await invoke("write", "Solo", "--file", fileURL.path, merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try reloadProfile("solo-id").content, content)
+    }
+
+    func testWriteToAnActiveProfileMergesTheNewContentThenPersists() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        // At merge time the daemon call sees the new content in the preview while the old
+        // content is still what is persisted: the system hosts write lands first.
+        let merger = MergerStub(script: [{ merged in
+            XCTAssertTrue(merged.content.contains("tracker.example.com"))
+            XCTAssertFalse(merged.content.contains("# dev"))
+            let persisted = try workspace.openReadOnly()
+            XCTAssertEqual(
+                persisted.groups.first { $0.name == "Work" }?.profiles.first { $0.name == "Dev" }?.content,
+                "# dev"
+            )
+            return merged.hash
+        }])
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke(
+            "write", "Work/Dev",
+            standardInput: Data("0.0.0.0 tracker.example.com\n".utf8),
+            merger: merger,
+            onWorkspaceChanged: spy
+        )
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(merger.recordedRequests.count, 1)
+        XCTAssertEqual(try reloadProfile("dev-id").content, "0.0.0.0 tracker.example.com\n")
+        XCTAssertEqual(spy.postCount, 1)
+    }
+
+    func testWriteInvalidSyntaxIsRejectedLeavingTheContentUntouched() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+        let spy = WorkspaceChangeSpy()
+
+        // Line 2 has an IP address without any hostname.
+        let result = await invoke(
+            "--json", "write", "Work/Dev",
+            standardInput: Data("0.0.0.0 ads.example.com\n127.0.0.1\n".utf8),
+            merger: merger,
+            onWorkspaceChanged: spy
+        )
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "invalid-hosts-syntax")
+        XCTAssertEqual((details["message"] as? String)?.contains("line 2"), true)
+        XCTAssertEqual(try reloadProfile("dev-id").content, "# dev", "a rejected write leaves the content untouched")
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+        XCTAssertEqual(spy.postCount, 0)
+    }
+
+    func testWriteToAnActiveProfileUnderDriftExitsThree() async throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+        let merger = MergerStub()
+
+        let result = await invoke(
+            "write", "Work/Dev",
+            standardInput: Data("0.0.0.0 ads.example.com\n".utf8),
+            merger: merger
+        )
+
+        XCTAssertEqual(result.exitCode, .drift)
+        XCTAssertEqual(try reloadProfile("dev-id").content, "# dev")
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testWriteToAnInactiveProfileUnderDriftIsALocalEditThatSucceeds() async throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+
+        // An inactive profile's content is outside the merged output, so the write never
+        // vouches for the system hosts and the drift gate does not apply.
+        let result = await invoke(
+            "write", "Solo",
+            standardInput: Data("0.0.0.0 ads.example.com\n".utf8),
+            merger: MergerStub()
+        )
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try reloadProfile("solo-id").content, "0.0.0.0 ads.example.com\n")
+    }
+
+    func testWriteIdenticalContentIsAnIdempotentNoOp() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke(
+            "--json", "write", "Work/Dev",
+            standardInput: Data("# dev".utf8),
+            merger: merger,
+            onWorkspaceChanged: spy
+        )
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try jsonObject(result.standardOutput)["changed"] as? Bool, false)
+        XCTAssertEqual(merger.recordedRequests.count, 0, "unchanged content never touches the daemon")
+        XCTAssertEqual(spy.postCount, 0, "no write, no change notification")
+    }
+
+    func testWriteNonUTF8InputIsRejected() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke(
+            "--json", "write", "Solo",
+            standardInput: Data([0xFF, 0xFE, 0xFD]),
+            merger: MergerStub()
+        )
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "invalid-encoding")
+        XCTAssertEqual(try reloadProfile("solo-id").content, "# solo")
+    }
+
+    func testWriteAnUnreadableFileIsRejected() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke(
+            "--json", "write", "Solo",
+            "--file", rootDirectory.appendingPathComponent("missing.hosts").path,
+            merger: MergerStub()
+        )
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "file-unreadable")
+        XCTAssertEqual(try reloadProfile("solo-id").content, "# solo")
+    }
+
+    func testWriteAnUnknownProfileExitsFive() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke(
+            "write", "Missing",
+            standardInput: Data("0.0.0.0 ads.example.com\n".utf8),
+            merger: MergerStub()
+        )
+
+        XCTAssertEqual(result.exitCode, .notFound)
+    }
+
+    func testTheFileOptionOnAnotherCommandFailsWithUsageExitCode() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("cat", "Solo", "--file", "somewhere", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("--file"))
+    }
+
+    func testTheFileOptionWithoutAValueFailsWithUsageExitCode() async throws {
+        let result = await invoke("write", "Solo", "--file", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("option '--file' requires a value"))
+    }
+
+    // MARK: - delete
+
+    func testDeleteAnInactiveProfileRemovesItLocally() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("delete", "Solo", merger: merger, onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Deleted Solo.\n")
+        XCTAssertFalse(try allProfileNames().contains("Solo"))
+        XCTAssertEqual(merger.recordedRequests.count, 0, "an inactive profile never goes through the daemon")
+        XCTAssertEqual(spy.postCount, 1)
+        XCTAssertEqual(spy.observedProfileNames.first?.contains("Solo"), false)
+    }
+
+    func testDeleteJSONReportsTheRemovedProfile() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "delete", "Solo", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["id"] as? String, "solo-id")
+        XCTAssertEqual(object["name"] as? String, "Solo")
+        XCTAssertNil(object["group"])
+    }
+
+    func testDeleteAnActiveProfileMergesWithoutItBeforeRemoving() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        // Dev is the only active profile: the merge preview must be Base Hosts alone, and at
+        // merge time the profile must still exist on disk — the exit from the merge lands
+        // before the removal does.
+        let merger = MergerStub(script: [{ [capturedHosts] merged in
+            XCTAssertEqual(merged.content, capturedHosts)
+            XCTAssertEqual(
+                try workspace.openReadOnly().groups.first { $0.name == "Work" }?.profiles.contains { $0.name == "Dev" },
+                true
+            )
+            return merged.hash
+        }])
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("delete", "Work/Dev", merger: merger, onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Deleted Work/Dev.\n")
+        XCTAssertEqual(merger.recordedRequests.count, 1)
+        let persisted = try reloadModel()
+        XCTAssertFalse(try allProfileNames().contains("Dev"))
+        XCTAssertFalse(persisted.activeProfileIDs.contains(.init("dev-id")))
+        XCTAssertEqual(spy.postCount, 1)
+    }
+
+    func testDeleteAnActiveProfileUnderDriftExitsThree() async throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+        let merger = MergerStub()
+
+        let result = await invoke("delete", "Work/Dev", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .drift)
+        XCTAssertTrue(try allProfileNames().contains("Dev"))
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testDeleteAnActiveProfileWithAnUnavailableDaemonExitsFourWithoutRemoving() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub(script: [{ _ in throw DaemonChannelError.unavailable }])
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("delete", "Work/Dev", merger: merger, onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .daemonUnavailable)
+        XCTAssertTrue(try allProfileNames().contains("Dev"))
+        XCTAssertEqual(spy.postCount, 0)
+    }
+
+    func testDeleteAnUnknownProfileExitsFive() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "delete", "Missing", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-not-found")
+    }
+
+    // MARK: - Cross-process persistence (ADR-0010)
+
+    func testAConcurrentExternalEditSurvivesTheWritePersistence() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        // A peer writer (the GUI) adds a profile while the daemon call is in flight; the
+        // reload-and-replay save must keep it (ADR-0010 ②).
+        let merger = MergerStub(script: [{ merged in
+            _ = try workspace.save(applying: {
+                try $0.addProfile(id: .init("injected-id"), name: "Injected", content: "# injected")
+            })
+            return merged.hash
+        }])
+
+        let result = await invoke(
+            "write", "Work/Dev",
+            standardInput: Data("0.0.0.0 tracker.example.com\n".utf8),
+            merger: merger
+        )
+
+        XCTAssertEqual(result.exitCode, .success)
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.standaloneProfiles.contains { $0.id == .init("injected-id") })
+        XCTAssertEqual(try reloadProfile("dev-id").content, "0.0.0.0 tracker.example.com\n")
+    }
+
+    func testAPeerDeletingTheProfileMidMergeIsReportedAsASaveConflict() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        // The peer removes Work/Dev after the merge lands but before the replay commits: the
+        // change cannot be recorded, which must be surfaced instead of silently dropped.
+        let merger = MergerStub(script: [{ merged in
+            _ = try workspace.save(applying: { try $0.deleteProfile(.init("dev-id")) })
+            return merged.hash
+        }])
+
+        let result = await invoke(
+            "--json", "write", "Work/Dev",
+            standardInput: Data("0.0.0.0 tracker.example.com\n".utf8),
+            merger: merger
+        )
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "state-save-conflict")
+    }
+
+    // MARK: - Help
+
+    func testHelpListsTheContentCommands() {
+        let commandLines = CLI.usageText
+            .split(separator: "\n")
+            .filter { $0.hasPrefix("  ") }
+            .map { $0.split(separator: " ", omittingEmptySubsequences: true).first.map(String.init) }
+        for verb in ["create", "write", "delete"] {
+            XCTAssertTrue(commandLines.contains(verb), "help must list '\(verb)'")
+        }
+    }
+
+    // MARK: - Doubles
+
+    /// Scripted stand-in for the daemon channel seam, same shape as SwitchCommandTests':
+    /// replies (or throws) per call in script order — an empty script confirms every merge with
+    /// its own hash — and records every request for assertions.
+    private final class MergerStub: HostsMerging, @unchecked Sendable {
+        struct Request {
+            let merged: MergedHosts
+            let mergeID: UUID
+            let isInterruptedRetry: Bool
+        }
+
+        private let lock = NSLock()
+        private var script: [(MergedHosts) throws -> String]
+        private var requests: [Request] = []
+
+        init(script: [(MergedHosts) throws -> String] = []) {
+            self.script = script
+        }
+
+        func merge(_ merged: MergedHosts, mergeID: UUID, isInterruptedRetry: Bool) async throws -> String {
+            let reply = lock.withLock {
+                requests.append(Request(merged: merged, mergeID: mergeID, isInterruptedRetry: isInterruptedRetry))
+                return script.isEmpty ? { $0.hash } : script.removeFirst()
+            }
+            return try reply(merged)
+        }
+
+        var recordedRequests: [Request] {
+            lock.withLock { requests }
+        }
+    }
+
+    /// Records every workspace-change notification post, capturing the on-disk profile names at
+    /// post time so tests can assert the persist-then-notify ordering.
+    private final class WorkspaceChangeSpy: @unchecked Sendable {
+        private let lock = NSLock()
+        private var observations: [Set<String>] = []
+
+        func record(_ workspace: Workspace) {
+            let names = (try? workspace.openReadOnly()).map { model in
+                Set(model.standaloneProfiles.map(\.name) + model.groups.flatMap { $0.profiles.map(\.name) })
+            } ?? []
+            lock.withLock { observations.append(names) }
+        }
+
+        var postCount: Int { lock.withLock { observations.count } }
+        var observedProfileNames: [Set<String>] { lock.withLock { observations } }
+    }
+
+    // MARK: - Helpers
+
+    private func invoke(
+        _ arguments: String...,
+        standardInput: Data = Data(),
+        merger: MergerStub,
+        onWorkspaceChanged spy: WorkspaceChangeSpy? = nil
+    ) async -> CLIResult {
+        await CLI.run(
+            arguments: arguments,
+            workspaceRootDirectory: workspaceRootDirectory,
+            systemHostsURL: systemHostsURL,
+            makeHostsMerger: { _ in merger },
+            postWorkspaceChanged: { spy?.record($0) },
+            readStandardInput: { standardInput }
+        )
+    }
+
+    private func reloadModel() throws -> ActivationModel {
+        try Workspace(rootDirectory: workspaceRootDirectory).openReadOnly()
+    }
+
+    private func reloadProfile(_ id: String) throws -> Profile {
+        let model = try reloadModel()
+        let profiles = model.standaloneProfiles + model.groups.flatMap(\.profiles)
+        return try XCTUnwrap(profiles.first { $0.id.rawValue == id })
+    }
+
+    private func allProfileNames() throws -> Set<String> {
+        let model = try reloadModel()
+        return Set(model.standaloneProfiles.map(\.name) + model.groups.flatMap { $0.profiles.map(\.name) })
+    }
+
+    /// Same fixture as SwitchCommandTests: one standalone profile and one two-member group with
+    /// its first profile active, plus a matching (drift-free) system hosts file.
+    private func makeInitializedWorkspace() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [Profile(id: .init("solo-id"), name: "Solo", content: "# solo")],
+            groups: [
+                Group(id: .init("work-id"), name: "Work", profiles: [
+                    Profile(id: .init("dev-id"), name: "Dev", content: "# dev"),
+                    Profile(id: .init("staging-id"), name: "Staging", content: "# staging"),
+                ]),
+            ],
+            activeProfileIDs: [.init("dev-id")],
+            isPaused: false
+        )
+        try workspace.save(model)
+        try Data(capturedHosts.utf8).write(to: systemHostsURL)
+    }
+
+    /// Group names are not unique (only IDs are): two groups named "Work" make the group half
+    /// of a create path ambiguous.
+    private func makeDuplicateGroupsWorkspace() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [],
+            groups: [
+                Group(id: .init("work-id"), name: "Work", profiles: [
+                    Profile(id: .init("dev-id"), name: "Dev", content: "# dev"),
+                ]),
+                Group(id: .init("work-2-id"), name: "Work", profiles: [
+                    Profile(id: .init("beta-id"), name: "Beta", content: "# beta"),
+                ]),
+            ]
+        )
+        try workspace.save(model)
+        try Data(capturedHosts.utf8).write(to: systemHostsURL)
+    }
+
+    private func jsonObject(_ text: String) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+}

--- a/Tests/HostflipCLITests/ProfileResolverTests.swift
+++ b/Tests/HostflipCLITests/ProfileResolverTests.swift
@@ -1,0 +1,210 @@
+import HostflipCore
+import XCTest
+@testable import HostflipCLI
+
+final class ProfileResolverTests: XCTestCase {
+    // MARK: - Bare name
+
+    func testUniqueBareNameResolvesAStandaloneProfile() throws {
+        let model = try makeModel(
+            standalone: [("solo-id", "Solo")],
+            groups: [("work-id", "Work", [("dev-id", "Dev")])]
+        )
+
+        let match = try ProfileResolver.resolve(.nameOrPath("Solo"), in: model)
+
+        XCTAssertEqual(match.profile.id.rawValue, "solo-id")
+        XCTAssertNil(match.groupName)
+    }
+
+    func testUniqueBareNameResolvesAGroupMember() throws {
+        let model = try makeModel(
+            standalone: [("solo-id", "Solo")],
+            groups: [("work-id", "Work", [("dev-id", "Dev")])]
+        )
+
+        let match = try ProfileResolver.resolve(.nameOrPath("Dev"), in: model)
+
+        XCTAssertEqual(match.profile.id.rawValue, "dev-id")
+        XCTAssertEqual(match.groupName, "Work")
+    }
+
+    func testUnknownBareNameFailsWithNotFound() throws {
+        let model = try makeModel(
+            standalone: [("solo-id", "Solo")],
+            groups: []
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Missing"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .notFound(reference: "Missing"))
+        }
+    }
+
+    // MARK: - Ambiguity
+
+    func testCrossGroupDuplicateNamesFailWithEveryCandidateInModelOrder() throws {
+        let model = try makeModel(
+            standalone: [],
+            groups: [
+                ("work-id", "Work", [("work-dev-id", "Dev")]),
+                ("home-id", "Home", [("home-dev-id", "Dev")]),
+            ]
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Dev"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .ambiguous(reference: "Dev", candidates: [
+                .init(id: "work-dev-id", name: "Dev", group: "Work"),
+                .init(id: "home-dev-id", name: "Dev", group: "Home"),
+            ]))
+        }
+    }
+
+    func testStandaloneAndGroupMemberDuplicateNamesFailWithBothCandidates() throws {
+        let model = try makeModel(
+            standalone: [("solo-dev-id", "Dev")],
+            groups: [("work-id", "Work", [("work-dev-id", "Dev")])]
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Dev"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .ambiguous(reference: "Dev", candidates: [
+                .init(id: "solo-dev-id", name: "Dev", group: nil),
+                .init(id: "work-dev-id", name: "Dev", group: "Work"),
+            ]))
+        }
+    }
+
+    func testDuplicateNamesWithinOneGroupFailWithBothCandidates() throws {
+        let model = try makeModel(
+            standalone: [],
+            groups: [("work-id", "Work", [("first-id", "Dev"), ("second-id", "Dev")])]
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Dev"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .ambiguous(reference: "Dev", candidates: [
+                .init(id: "first-id", name: "Dev", group: "Work"),
+                .init(id: "second-id", name: "Dev", group: "Work"),
+            ]))
+        }
+    }
+
+    // MARK: - group/profile path
+
+    func testPathResolvesTheMemberOfTheNamedGroup() throws {
+        let model = try makeModel(
+            standalone: [("solo-dev-id", "Dev")],
+            groups: [
+                ("work-id", "Work", [("work-dev-id", "Dev")]),
+                ("home-id", "Home", [("home-dev-id", "Dev")]),
+            ]
+        )
+
+        let match = try ProfileResolver.resolve(.nameOrPath("Home/Dev"), in: model)
+
+        XCTAssertEqual(match.profile.id.rawValue, "home-dev-id")
+        XCTAssertEqual(match.groupName, "Home")
+    }
+
+    func testPathWithUnknownGroupOrProfileFailsWithNotFound() throws {
+        let model = try makeModel(
+            standalone: [],
+            groups: [("work-id", "Work", [("dev-id", "Dev")])]
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Home/Dev"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .notFound(reference: "Home/Dev"))
+        }
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Work/Staging"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .notFound(reference: "Work/Staging"))
+        }
+    }
+
+    func testPathAcrossDuplicateGroupNamesFailsWithBothCandidates() throws {
+        let model = try makeModel(
+            standalone: [],
+            groups: [
+                ("first-work-id", "Work", [("first-dev-id", "Dev")]),
+                ("second-work-id", "Work", [("second-dev-id", "Dev")]),
+            ]
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Work/Dev"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .ambiguous(reference: "Work/Dev", candidates: [
+                .init(id: "first-dev-id", name: "Dev", group: "Work"),
+                .init(id: "second-dev-id", name: "Dev", group: "Work"),
+            ]))
+        }
+    }
+
+    func testSlashInAStandaloneNameReadsAsAPathSoOnlyIDReachesIt() throws {
+        let model = try makeModel(
+            standalone: [("tricky-id", "Work/Dev")],
+            groups: []
+        )
+
+        // A reference containing a slash is always a path; the standalone profile literally
+        // named "Work/Dev" is reachable only through --id.
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("Work/Dev"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .notFound(reference: "Work/Dev"))
+        }
+        XCTAssertEqual(
+            try ProfileResolver.resolve(.id("tricky-id"), in: model).profile.name,
+            "Work/Dev"
+        )
+    }
+
+    func testPathSplitsOnTheFirstSlashSoMemberNamesMayContainSlashes() throws {
+        let model = try makeModel(
+            standalone: [],
+            groups: [("work-id", "Work", [("tricky-id", "a/b")])]
+        )
+
+        let match = try ProfileResolver.resolve(.nameOrPath("Work/a/b"), in: model)
+
+        XCTAssertEqual(match.profile.id.rawValue, "tricky-id")
+    }
+
+    // MARK: - --id
+
+    func testIDResolvesAGroupMemberRegardlessOfDuplicateNames() throws {
+        let model = try makeModel(
+            standalone: [("solo-dev-id", "Dev")],
+            groups: [("work-id", "Work", [("work-dev-id", "Dev")])]
+        )
+
+        let match = try ProfileResolver.resolve(.id("work-dev-id"), in: model)
+
+        XCTAssertEqual(match.profile.id.rawValue, "work-dev-id")
+        XCTAssertEqual(match.groupName, "Work")
+    }
+
+    func testUnknownIDFailsWithNotFound() throws {
+        let model = try makeModel(
+            standalone: [("solo-id", "Solo")],
+            groups: []
+        )
+
+        XCTAssertThrowsError(try ProfileResolver.resolve(.id("missing-id"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .notFound(reference: "missing-id"))
+        }
+    }
+
+    // MARK: - Helpers
+
+    /// Builds a model from (id, name) tuples; content is irrelevant to addressing.
+    private func makeModel(
+        standalone: [(id: String, name: String)],
+        groups: [(id: String, name: String, profiles: [(id: String, name: String)])]
+    ) throws -> ActivationModel {
+        try ActivationModel(
+            baseHosts: BaseHosts(content: "127.0.0.1 localhost\n"),
+            standaloneProfiles: standalone.map {
+                Profile(id: .init($0.id), name: $0.name, content: "# \($0.id)")
+            },
+            groups: groups.map { group in
+                Group(id: .init(group.id), name: group.name, profiles: group.profiles.map {
+                    Profile(id: .init($0.id), name: $0.name, content: "# \($0.id)")
+                })
+            }
+        )
+    }
+}

--- a/Tests/HostflipCLITests/ProfileResolverTests.swift
+++ b/Tests/HostflipCLITests/ProfileResolverTests.swift
@@ -40,6 +40,32 @@ final class ProfileResolverTests: XCTestCase {
         }
     }
 
+    func testAnIDPastedAsANameFailsWithTheDedicatedHint() throws {
+        let model = try makeModel(
+            standalone: [("solo-id", "Solo")],
+            groups: [("work-id", "Work", [("dev-id", "Dev")])]
+        )
+
+        // The ambiguity listing shows IDs, so pasting one positionally is the natural next
+        // mistake; it must point at --id instead of a bare not-found.
+        XCTAssertThrowsError(try ProfileResolver.resolve(.nameOrPath("dev-id"), in: model)) {
+            XCTAssertEqual($0 as? ProfileResolver.Failure, .idPassedAsName(reference: "dev-id"))
+        }
+    }
+
+    func testANameThatLooksLikeAnotherProfilesIDStillResolvesAsAName() throws {
+        let model = try makeModel(
+            standalone: [("solo-id", "dev-id")],
+            groups: [("work-id", "Work", [("dev-id", "Dev")])]
+        )
+
+        // Names are arbitrary strings: name matching always wins, the ID hint only fires
+        // when the reference matches no name at all.
+        let match = try ProfileResolver.resolve(.nameOrPath("dev-id"), in: model)
+
+        XCTAssertEqual(match.profile.id.rawValue, "solo-id")
+    }
+
     // MARK: - Ambiguity
 
     func testCrossGroupDuplicateNamesFailWithEveryCandidateInModelOrder() throws {

--- a/Tests/HostflipCLITests/SwitchCommandTests.swift
+++ b/Tests/HostflipCLITests/SwitchCommandTests.swift
@@ -1,0 +1,580 @@
+import Foundation
+import HostflipCore
+import HostflipXPC
+import XCTest
+@testable import HostflipCLI
+
+/// The activation commands (activate / deactivate / pause / resume) against a scripted stand-in
+/// of the daemon channel seam: success, drift, daemon-not-ready, addressing failures, and the
+/// cross-process persistence contract.
+final class SwitchCommandTests: XCTestCase {
+    private var rootDirectory: URL!
+    private var workspaceRootDirectory: URL!
+    private var systemHostsURL: URL!
+
+    private let capturedHosts = "127.0.0.1 localhost\n"
+
+    override func setUpWithError() throws {
+        rootDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hostflip-switch-tests-\(UUID().uuidString)", isDirectory: true)
+        workspaceRootDirectory = rootDirectory.appendingPathComponent("workspace", isDirectory: true)
+        systemHostsURL = rootDirectory.appendingPathComponent("hosts")
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: rootDirectory)
+    }
+
+    // MARK: - activate
+
+    func testActivateMergesThePreviewAndPersistsTheState() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        XCTAssertEqual(result.standardOutput, "Activated Solo.\n")
+        let requests = merger.recordedRequests
+        XCTAssertEqual(requests.count, 1)
+        XCTAssertTrue(requests[0].merged.content.contains("# solo"))
+        XCTAssertTrue(requests[0].merged.content.contains(MergedHosts.appendedBlockBegin))
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("solo-id")))
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("dev-id")), "unrelated active state is kept")
+    }
+
+    func testActivateJSONReportsTheResolvedProfileAndTheChange() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "activate", "Solo", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["action"] as? String, "activate")
+        XCTAssertEqual(object["id"] as? String, "solo-id")
+        XCTAssertEqual(object["name"] as? String, "Solo")
+        XCTAssertNil(object["group"])
+        XCTAssertEqual(object["changed"] as? Bool, true)
+    }
+
+    func testActivateAnAlreadyActiveProfileIsAnIdempotentNoOp() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("--json", "activate", "Work/Dev", merger: merger, onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try jsonObject(result.standardOutput)["changed"] as? Bool, false)
+        XCTAssertEqual(merger.recordedRequests.count, 0, "an unchanged state never touches the daemon")
+        XCTAssertEqual(spy.postCount, 0, "no write, no change notification")
+    }
+
+    func testActivateAGroupMemberDeactivatesTheActiveSibling() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("activate", "Work/Staging", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        let merged = merger.recordedRequests[0].merged.content
+        XCTAssertTrue(merged.contains("# staging"))
+        XCTAssertFalse(merged.contains("# dev"), "in-group mutual exclusion applies to the merge preview")
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("staging-id")))
+        XCTAssertFalse(persisted.activeProfileIDs.contains(.init("dev-id")))
+    }
+
+    func testActivateWhilePausedWritesBaseHostsOnlyButRecordsTheState() async throws {
+        try makeInitializedWorkspace(paused: true)
+        let merger = MergerStub()
+
+        let result = await invoke("activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(merger.recordedRequests[0].merged.content, capturedHosts)
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.isPaused)
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("solo-id")))
+    }
+
+    // MARK: - deactivate
+
+    func testDeactivateMergesWithoutTheProfileAndPersists() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("deactivate", "Work/Dev", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Deactivated Work/Dev.\n")
+        // Dev was the only active profile, so the merge preview is Base Hosts alone: no fence.
+        XCTAssertEqual(merger.recordedRequests[0].merged.content, capturedHosts)
+        XCTAssertFalse(try reloadModel().activeProfileIDs.contains(.init("dev-id")))
+    }
+
+    func testDeactivateAnInactiveProfileIsAnIdempotentNoOp() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("deactivate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Solo is not active.\n")
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    // MARK: - pause / resume
+
+    func testPauseWritesBaseHostsOnlyAndKeepsEveryActiveProfile() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("pause", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Paused. The system hosts now carries Base Hosts only.\n")
+        XCTAssertEqual(merger.recordedRequests[0].merged.content, capturedHosts)
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.isPaused)
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("dev-id")), "pausing preserves active state")
+    }
+
+    func testResumeRestoresTheKeptActiveProfilesIntoTheMerge() async throws {
+        try makeInitializedWorkspace(paused: true)
+        let merger = MergerStub()
+
+        let result = await invoke("resume", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertTrue(merger.recordedRequests[0].merged.content.contains("# dev"))
+        XCTAssertFalse(try reloadModel().isPaused)
+    }
+
+    func testPauseWhenAlreadyPausedIsAnIdempotentNoOp() async throws {
+        try makeInitializedWorkspace(paused: true)
+        let merger = MergerStub()
+
+        let result = await invoke("--json", "pause", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try jsonObject(result.standardOutput)["changed"] as? Bool, false)
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testResumeWhenRunningIsAnIdempotentNoOp() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("resume", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardOutput, "Not paused.\n")
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testPauseWithAnArgumentFailsWithUsageExitCode() async throws {
+        let result = await invoke("pause", "Dev", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("unexpected argument 'Dev'"))
+    }
+
+    // MARK: - Aliases
+
+    func testOnAliasActivatesButReportsTheCanonicalAction() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("--json", "on", "Solo", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(try jsonObject(result.standardOutput)["action"] as? String, "activate")
+        XCTAssertTrue(try reloadModel().activeProfileIDs.contains(.init("solo-id")))
+    }
+
+    func testOffAliasDeactivates() async throws {
+        try makeInitializedWorkspace()
+
+        let result = await invoke("off", "Work/Dev", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertFalse(try reloadModel().activeProfileIDs.contains(.init("dev-id")))
+    }
+
+    func testBareOnFailsWithUsageExitCode() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("on", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("'on' needs a profile name"))
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testBareOffFailsWithUsageExitCodeInsteadOfActingAsPause() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("off", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .usage)
+        XCTAssertTrue(result.standardError.contains("'off' needs a profile name"))
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+        XCTAssertFalse(try reloadModel().isPaused, "a bare 'off' must never pause")
+    }
+
+    func testHelpShowsTheCanonicalVerbsButNotTheAliases() {
+        let commandLines = CLI.usageText
+            .split(separator: "\n")
+            .filter { $0.hasPrefix("  ") }
+            .map { $0.split(separator: " ", omittingEmptySubsequences: true).first.map(String.init) }
+        for verb in ["activate", "deactivate", "pause", "resume"] {
+            XCTAssertTrue(commandLines.contains(verb), "help must list '\(verb)'")
+        }
+        for alias in ["on", "off"] {
+            XCTAssertFalse(commandLines.contains(alias), "help must not list the '\(alias)' alias")
+        }
+    }
+
+    // MARK: - Drift (exit code 3)
+
+    func testActivateWithLocalDriftRefusesBeforeTouchingTheDaemon() async throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+        let merger = MergerStub()
+
+        let result = await invoke("activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .drift)
+        XCTAssertEqual(result.standardOutput, "")
+        XCTAssertTrue(result.standardError.contains("reconcile in the Hostflip app"))
+        XCTAssertEqual(merger.recordedRequests.count, 0, "the CLI reports drift, it never merges over it")
+        XCTAssertFalse(try reloadModel().activeProfileIDs.contains(.init("solo-id")))
+    }
+
+    func testLocalDriftJSONErrorCarriesTheHostsDriftCode() async throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+
+        let result = await invoke("--json", "activate", "Solo", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .drift)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "hosts-drift")
+    }
+
+    func testDriftBeatsTheIdempotentNoOpForActivate() async throws {
+        try makeInitializedWorkspace()
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+        let merger = MergerStub()
+
+        // Dev is already active per the manifest, but under drift the actual hosts content is
+        // unknown — "already active" would vouch for a state the CLI cannot see, so the drift
+        // verdict (stop, hand back to a human) must win over the no-op.
+        let result = await invoke("activate", "Work/Dev", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .drift)
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testDriftBeatsTheIdempotentNoOpForPause() async throws {
+        try makeInitializedWorkspace(paused: true)
+        try Data("tampered\n".utf8).write(to: systemHostsURL)
+
+        let result = await invoke("pause", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .drift)
+    }
+
+    func testADaemonDriftRejectionAlsoExitsThreeWithoutPersisting() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub(script: [{ _ in
+            throw DaemonChannelError.mergeRejected(.hostsDrift(expected: "a", actual: "b"))
+        }])
+
+        let result = await invoke("--json", "activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .drift)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "hosts-drift")
+        XCTAssertFalse(try reloadModel().activeProfileIDs.contains(.init("solo-id")))
+    }
+
+    // MARK: - Daemon not ready (exit code 4)
+
+    func testAnUnavailableDaemonExitsFourWithoutPersisting() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub(script: [{ _ in throw DaemonChannelError.unavailable }])
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("--json", "activate", "Solo", merger: merger, onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .daemonUnavailable)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "daemon-unavailable")
+        XCTAssertFalse(try reloadModel().activeProfileIDs.contains(.init("solo-id")))
+        XCTAssertEqual(spy.postCount, 0)
+    }
+
+    func testAnInterruptedMergeIsRetriedOnceWithTheSameMergeID() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub(script: [
+            { _ in throw DaemonChannelError.interrupted },
+            { $0.hash },
+        ])
+
+        let result = await invoke("activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        let requests = merger.recordedRequests
+        XCTAssertEqual(requests.count, 2)
+        XCTAssertEqual(requests[0].mergeID, requests[1].mergeID, "the retry replays the same logical merge")
+        XCTAssertEqual(requests.map(\.isInterruptedRetry), [false, true])
+        XCTAssertTrue(try reloadModel().activeProfileIDs.contains(.init("solo-id")))
+    }
+
+    func testASecondInterruptionExitsFour() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub(script: [
+            { _ in throw DaemonChannelError.interrupted },
+            { _ in throw DaemonChannelError.interrupted },
+        ])
+
+        let result = await invoke("activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .daemonUnavailable)
+        XCTAssertEqual(merger.recordedRequests.count, 2, "exactly one retry")
+    }
+
+    // MARK: - Addressing failures
+
+    func testActivateAnUnknownProfileExitsFiveWithoutTouchingTheDaemon() async throws {
+        try makeInitializedWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("--json", "activate", "Missing", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .notFound)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-not-found")
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testActivateAnAmbiguousNameExitsSixListingTheCandidates() async throws {
+        try makeAmbiguousWorkspace()
+        let merger = MergerStub()
+
+        let result = await invoke("--json", "activate", "Dev", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .ambiguous)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "profile-ambiguous")
+        let candidates = try XCTUnwrap(details["candidates"] as? [[String: Any]])
+        XCTAssertEqual(candidates.map { $0["id"] as? String }, ["solo-dev-id", "work-dev-id"])
+        XCTAssertEqual(merger.recordedRequests.count, 0)
+    }
+
+    func testActivateByIDBypassesTheAmbiguousName() async throws {
+        try makeAmbiguousWorkspace()
+
+        let result = await invoke("activate", "--id", "solo-dev-id", merger: MergerStub())
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertTrue(try reloadModel().activeProfileIDs.contains(.init("solo-dev-id")))
+    }
+
+    // MARK: - Cross-process persistence (ADR-0010)
+
+    func testTheChangeNotificationFiresAfterTheStateIsPersisted() async throws {
+        try makeInitializedWorkspace()
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("activate", "Solo", merger: MergerStub(), onWorkspaceChanged: spy)
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(spy.postCount, 1)
+        XCTAssertEqual(
+            spy.observedActiveIDs.first?.contains("solo-id"),
+            true,
+            "at post time the manifest must already carry the switched state"
+        )
+    }
+
+    func testAConcurrentExternalEditSurvivesTheSwitchPersistence() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        // A peer writer (the GUI) adds a profile while the daemon call is in flight; the
+        // reload-and-replay save must keep it (ADR-0010 ②).
+        let merger = MergerStub(script: [{ merged in
+            _ = try workspace.save(applying: {
+                try $0.addProfile(id: .init("injected-id"), name: "Injected", content: "# injected")
+            })
+            return merged.hash
+        }])
+
+        let result = await invoke("activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .success)
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.standaloneProfiles.contains { $0.id == .init("injected-id") })
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("solo-id")))
+    }
+
+    // MARK: - Landed write with a failed flush
+
+    func testAFlushFailureAfterALandedWriteStillPersistsTheSwitch() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        let merger = MergerStub(script: [{ merged in
+            throw DaemonChannelError.mergeWriteFailed(
+                HostsWriteError(stage: .flushDNS, message: "boom", writtenHash: merged.hash)
+            )
+        }])
+        let spy = WorkspaceChangeSpy()
+
+        let result = await invoke("--json", "activate", "Solo", merger: merger, onWorkspaceChanged: spy)
+
+        // The replacement physically landed, so the switch is committed and the baseline hash
+        // recorded — not committing would misreport the very next status as drift.
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "dns-flush-failed")
+        let persisted = try reloadModel()
+        XCTAssertTrue(persisted.activeProfileIDs.contains(.init("solo-id")))
+        XCTAssertEqual(try workspace.lastWrittenHash(), merger.recordedRequests[0].merged.hash)
+        XCTAssertEqual(spy.postCount, 1)
+    }
+
+    func testAFailedReplacementDoesNotPersistAnything() async throws {
+        try makeInitializedWorkspace()
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        let merger = MergerStub(script: [{ _ in
+            throw DaemonChannelError.mergeWriteFailed(
+                HostsWriteError(stage: .replace, message: "boom", writtenHash: nil)
+            )
+        }])
+
+        let result = await invoke("--json", "activate", "Solo", merger: merger)
+
+        XCTAssertEqual(result.exitCode, .failure)
+        let details = try XCTUnwrap(try jsonObject(result.standardError)["error"] as? [String: Any])
+        XCTAssertEqual(details["code"] as? String, "hosts-write-failed")
+        XCTAssertFalse(try reloadModel().activeProfileIDs.contains(.init("solo-id")))
+        XCTAssertNil(try workspace.lastWrittenHash())
+    }
+
+    // MARK: - Doubles
+
+    /// Scripted stand-in for the daemon channel seam: replies (or throws) per call in script
+    /// order — an empty script confirms every merge with its own hash — and records every
+    /// request for assertions.
+    private final class MergerStub: HostsMerging, @unchecked Sendable {
+        struct Request {
+            let merged: MergedHosts
+            let mergeID: UUID
+            let isInterruptedRetry: Bool
+        }
+
+        private let lock = NSLock()
+        private var script: [(MergedHosts) throws -> String]
+        private var requests: [Request] = []
+
+        init(script: [(MergedHosts) throws -> String] = []) {
+            self.script = script
+        }
+
+        func merge(_ merged: MergedHosts, mergeID: UUID, isInterruptedRetry: Bool) async throws -> String {
+            let reply = lock.withLock {
+                requests.append(Request(merged: merged, mergeID: mergeID, isInterruptedRetry: isInterruptedRetry))
+                return script.isEmpty ? { $0.hash } : script.removeFirst()
+            }
+            return try reply(merged)
+        }
+
+        var recordedRequests: [Request] {
+            lock.withLock { requests }
+        }
+    }
+
+    /// Records every workspace-change notification post, capturing the on-disk active state at
+    /// post time so tests can assert the persist-then-notify ordering.
+    private final class WorkspaceChangeSpy: @unchecked Sendable {
+        private let lock = NSLock()
+        private var observations: [Set<String>] = []
+
+        func record(_ workspace: Workspace) {
+            let ids = (try? workspace.openReadOnly())
+                .map { Set($0.activeProfileIDs.map(\.rawValue)) } ?? []
+            lock.withLock { observations.append(ids) }
+        }
+
+        var postCount: Int { lock.withLock { observations.count } }
+        var observedActiveIDs: [Set<String>] { lock.withLock { observations } }
+    }
+
+    // MARK: - Helpers
+
+    private func invoke(
+        _ arguments: String...,
+        merger: MergerStub,
+        onWorkspaceChanged spy: WorkspaceChangeSpy? = nil
+    ) async -> CLIResult {
+        await CLI.run(
+            arguments: arguments,
+            workspaceRootDirectory: workspaceRootDirectory,
+            systemHostsURL: systemHostsURL,
+            makeHostsMerger: { _ in merger },
+            postWorkspaceChanged: { spy?.record($0) }
+        )
+    }
+
+    private func reloadModel() throws -> ActivationModel {
+        try Workspace(rootDirectory: workspaceRootDirectory).openReadOnly()
+    }
+
+    /// Same fixture as CLITests: one standalone profile and one two-member group with its first
+    /// profile active, plus a matching (drift-free) system hosts file.
+    private func makeInitializedWorkspace(paused: Bool = false) throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [Profile(id: .init("solo-id"), name: "Solo", content: "# solo")],
+            groups: [
+                Group(id: .init("work-id"), name: "Work", profiles: [
+                    Profile(id: .init("dev-id"), name: "Dev", content: "# dev"),
+                    Profile(id: .init("staging-id"), name: "Staging", content: "# staging"),
+                ]),
+            ],
+            activeProfileIDs: [.init("dev-id")],
+            isPaused: paused
+        )
+        try workspace.save(model)
+        try Data(capturedHosts.utf8).write(to: systemHostsURL)
+    }
+
+    /// A workspace where the bare name "Dev" is ambiguous between a standalone profile and a
+    /// group member, with a matching system hosts file so switches pass the drift gate.
+    private func makeAmbiguousWorkspace() throws {
+        let workspace = Workspace(rootDirectory: workspaceRootDirectory)
+        _ = try workspace.open(systemHosts: { capturedHosts })
+        let model = try ActivationModel(
+            baseHosts: BaseHosts(content: capturedHosts),
+            standaloneProfiles: [Profile(id: .init("solo-dev-id"), name: "Dev", content: "# solo dev")],
+            groups: [
+                Group(id: .init("work-id"), name: "Work", profiles: [
+                    Profile(id: .init("work-dev-id"), name: "Dev", content: "# work dev"),
+                ]),
+            ]
+        )
+        try workspace.save(model)
+        try Data(capturedHosts.utf8).write(to: systemHostsURL)
+    }
+
+    private func jsonObject(_ text: String) throws -> [String: Any] {
+        try XCTUnwrap(JSONSerialization.jsonObject(with: Data(text.utf8)) as? [String: Any])
+    }
+}

--- a/Tests/HostflipCoreTests/HostsSyntaxTests.swift
+++ b/Tests/HostflipCoreTests/HostsSyntaxTests.swift
@@ -74,4 +74,37 @@ final class HostsSyntaxTests: XCTestCase {
             token(.hostname, 19, 1),
         ])
     }
+
+    // MARK: - Structural validation
+
+    func testCompleteEntriesCommentsAndBlankLinesAreNotIncomplete() {
+        XCTAssertNil(HostsSyntax.firstIncompleteLine(in: """
+            # blocklist
+            0.0.0.0 ads.example.com tracker.example.com
+
+            1.2.3.4 example.com # staging
+            """))
+    }
+
+    func testEmptyContentIsNotIncomplete() {
+        XCTAssertNil(HostsSyntax.firstIncompleteLine(in: ""))
+    }
+
+    func testALoneFieldLineIsIncomplete() {
+        XCTAssertEqual(HostsSyntax.firstIncompleteLine(in: "127.0.0.1 localhost\n127.0.0.1\n"), 2)
+    }
+
+    func testASingleFieldBeforeAnInlineCommentIsIncomplete() {
+        XCTAssertEqual(HostsSyntax.firstIncompleteLine(in: "127.0.0.1 # hostname to be decided"), 1)
+    }
+
+    func testTheFirstOfSeveralIncompleteLinesIsReported() {
+        XCTAssertEqual(HostsSyntax.firstIncompleteLine(in: "stray\n1.1.1.1 a\nstray again\n"), 1)
+    }
+
+    func testFieldValuesAreNotValidated() {
+        // Value correctness stays out of scope, matching the tokenizer: two fields make a
+        // structurally complete entry regardless of what the fields contain.
+        XCTAssertNil(HostsSyntax.firstIncompleteLine(in: "not-an-ip some-host"))
+    }
 }

--- a/Tests/HostflipCoreTests/WorkspaceTests.swift
+++ b/Tests/HostflipCoreTests/WorkspaceTests.swift
@@ -313,7 +313,7 @@ final class WorkspaceTests: XCTestCase {
                 group.addTask { try workspace.recordLastWrittenHash(hash) }
                 try await group.waitForAll()
             }
-            XCTAssertEqual(try workspace.lastWrittenHash(), hash, "第 \(iteration) 轮丢失回写的哈希")
+            XCTAssertEqual(try workspace.lastWrittenHash(), hash, "round \(iteration) lost the recorded hash")
         }
     }
 
@@ -409,7 +409,7 @@ final class WorkspaceTests: XCTestCase {
     func testSaveWaitsForAForeignManifestLockHolder() throws {
         let workspace = Workspace(rootDirectory: rootDirectory)
         let model = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
-        XCTAssertTrue(workspaceFileExists("manifest.lock"), "锁应落在专用 lock 文件上，与 manifest 本体分离")
+        XCTAssertTrue(workspaceFileExists("manifest.lock"), "the lock must live on the dedicated lock file, separate from the manifest itself")
 
         let foreign = try acquireForeignManifestLock()
         defer { close(foreign) }
@@ -419,16 +419,16 @@ final class WorkspaceTests: XCTestCase {
             do {
                 try workspace.save(model)
             } catch {
-                XCTFail("save 失败：\(error)")
+                XCTFail("save failed: \(error)")
             }
             finished.set()
         }
 
         Thread.sleep(forTimeInterval: 0.3)
-        XCTAssertFalse(finished.isSet, "外部进程持锁期间 save 不应完成")
+        XCTAssertFalse(finished.isSet, "save must not complete while a foreign process holds the lock")
 
         XCTAssertEqual(flock(foreign, LOCK_UN), 0)
-        XCTAssertTrue(finished.wait(timeout: 5), "外部锁释放后 save 应完成")
+        XCTAssertTrue(finished.wait(timeout: 5), "save must complete once the foreign lock is released")
     }
 
     func testForeignReadModifyWriteUnderTheLockLosesNoUpdate() throws {
@@ -451,21 +451,21 @@ final class WorkspaceTests: XCTestCase {
             do {
                 try workspace.recordLastWrittenHash("cross-process")
             } catch {
-                XCTFail("recordLastWrittenHash 失败：\(error)")
+                XCTFail("recordLastWrittenHash failed: \(error)")
             }
             finished.set()
         }
         Thread.sleep(forTimeInterval: 0.3)
-        XCTAssertFalse(finished.isSet, "外部进程持锁期间哈希回写不应完成")
+        XCTAssertFalse(finished.isSet, "the hash record must not complete while a foreign process holds the lock")
 
         // The foreign process's "modify-write" step: atomically replace the manifest, then release the lock
         foreignManifest["isPaused"] = true
         try JSONSerialization.data(withJSONObject: foreignManifest).write(to: manifestURL, options: .atomic)
         XCTAssertEqual(flock(foreign, LOCK_UN), 0)
 
-        XCTAssertTrue(finished.wait(timeout: 5), "外部锁释放后哈希回写应完成")
+        XCTAssertTrue(finished.wait(timeout: 5), "the hash record must complete once the foreign lock is released")
         XCTAssertEqual(try workspace.lastWrittenHash(), "cross-process")
-        XCTAssertTrue(try reopenWithoutImporting(workspace).isPaused, "外部在锁内写入的更新不得被覆盖")
+        XCTAssertTrue(try reopenWithoutImporting(workspace).isPaused, "an update a foreign process wrote under the lock must not be overwritten")
     }
 
     func testSaveUnderTheLockPreservesAForeignlyRecordedHash() throws {
@@ -487,19 +487,19 @@ final class WorkspaceTests: XCTestCase {
             do {
                 try workspace.save(model)
             } catch {
-                XCTFail("save 失败：\(error)")
+                XCTFail("save failed: \(error)")
             }
             finished.set()
         }
         Thread.sleep(forTimeInterval: 0.3)
-        XCTAssertFalse(finished.isSet, "外部进程持锁期间 save 不应完成")
+        XCTAssertFalse(finished.isSet, "save must not complete while a foreign process holds the lock")
 
         foreignManifest["lastWrittenHash"] = "foreign-hash"
         try JSONSerialization.data(withJSONObject: foreignManifest).write(to: manifestURL, options: .atomic)
         XCTAssertEqual(flock(foreign, LOCK_UN), 0)
 
-        XCTAssertTrue(finished.wait(timeout: 5), "外部锁释放后 save 应完成")
-        XCTAssertEqual(try workspace.lastWrittenHash(), "foreign-hash", "外部在锁内回写的哈希不得被 save 重置")
+        XCTAssertTrue(finished.wait(timeout: 5), "save must complete once the foreign lock is released")
+        XCTAssertEqual(try workspace.lastWrittenHash(), "foreign-hash", "a hash a foreign process recorded under the lock must not be reset by save")
     }
 
     func testALeftoverLockFileFromACrashDoesNotBlockAnything() throws {
@@ -534,7 +534,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         guard case .saved(let saved) = outcome else {
-            return XCTFail("在最新状态上重放应当成功保存")
+            return XCTFail("replaying on the latest state must save successfully")
         }
         XCTAssertEqual(saved.standaloneProfiles.map(\.id), [.init("cli"), .init("gui")])
         XCTAssertEqual(saved.activeProfileIDs, [.init("cli")])
@@ -574,7 +574,7 @@ final class WorkspaceTests: XCTestCase {
         })
 
         guard case .conflict(let latest, let reason) = outcome else {
-            return XCTFail("在被外部删除的 profile 上重放应当报告冲突")
+            return XCTFail("replaying on a foreignly deleted profile must report a conflict")
         }
         XCTAssertEqual(latest.standaloneProfiles, [])
         XCTAssertEqual(
@@ -617,14 +617,14 @@ final class WorkspaceTests: XCTestCase {
     private func acquireForeignManifestLock() throws -> Int32 {
         let path = rootDirectory.appendingPathComponent("manifest.lock").path
         let fd = Darwin.open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
-        let locked = try XCTUnwrap(fd >= 0 ? fd : nil, "打开 manifest.lock 失败")
+        let locked = try XCTUnwrap(fd >= 0 ? fd : nil, "failed to open manifest.lock")
         XCTAssertEqual(flock(locked, LOCK_EX), 0)
         return locked
     }
 
     private func reopenWithoutImporting(_ workspace: Workspace) throws -> ActivationModel {
         try workspace.open(systemHosts: {
-            XCTFail("已初始化的工作区不应再读取系统 hosts")
+            XCTFail("an initialized workspace must not read the system hosts again")
             return ""
         })
     }

--- a/Tests/HostflipCoreTests/WorkspaceTests.swift
+++ b/Tests/HostflipCoreTests/WorkspaceTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import XCTest
 @testable import HostflipCore
 
@@ -403,6 +404,132 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertFalse(workspaceFileExists("hosts.orig"))
     }
 
+    // MARK: - Cross-process manifest lock (#50, ADR-0010 ①)
+
+    func testSaveWaitsForAForeignManifestLockHolder() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        let model = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        XCTAssertTrue(workspaceFileExists("manifest.lock"), "锁应落在专用 lock 文件上，与 manifest 本体分离")
+
+        let foreign = try acquireForeignManifestLock()
+        defer { close(foreign) }
+
+        let finished = CompletionFlag()
+        Thread.detachNewThread {
+            do {
+                try workspace.save(model)
+            } catch {
+                XCTFail("save 失败：\(error)")
+            }
+            finished.set()
+        }
+
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertFalse(finished.isSet, "外部进程持锁期间 save 不应完成")
+
+        XCTAssertEqual(flock(foreign, LOCK_UN), 0)
+        XCTAssertTrue(finished.wait(timeout: 5), "外部锁释放后 save 应完成")
+    }
+
+    func testForeignReadModifyWriteUnderTheLockLosesNoUpdate() throws {
+        // The CLI and the resident GUI are peer writers: a foreign holder reads then writes under
+        // the lock, so this process's hash write-back must wait for the release and re-read the state
+        // the foreign side wrote — both updates must land, neither side may overwrite the other.
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        _ = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+
+        let foreign = try acquireForeignManifestLock()
+        defer { close(foreign) }
+        // The foreign process's "read" step inside the lock
+        let manifestURL = rootDirectory.appendingPathComponent("manifest.json")
+        var foreignManifest = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL)) as? [String: Any]
+        )
+
+        let finished = CompletionFlag()
+        Thread.detachNewThread {
+            do {
+                try workspace.recordLastWrittenHash("cross-process")
+            } catch {
+                XCTFail("recordLastWrittenHash 失败：\(error)")
+            }
+            finished.set()
+        }
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertFalse(finished.isSet, "外部进程持锁期间哈希回写不应完成")
+
+        // The foreign process's "modify-write" step: atomically replace the manifest, then release the lock
+        foreignManifest["isPaused"] = true
+        try JSONSerialization.data(withJSONObject: foreignManifest).write(to: manifestURL, options: .atomic)
+        XCTAssertEqual(flock(foreign, LOCK_UN), 0)
+
+        XCTAssertTrue(finished.wait(timeout: 5), "外部锁释放后哈希回写应完成")
+        XCTAssertEqual(try workspace.lastWrittenHash(), "cross-process")
+        XCTAssertTrue(try reopenWithoutImporting(workspace).isPaused, "外部在锁内写入的更新不得被覆盖")
+    }
+
+    func testSaveUnderTheLockPreservesAForeignlyRecordedHash() throws {
+        // The reverse direction of the lost-update pair: a foreign process records the last-written
+        // hash under the lock, and a local save that was waiting must re-read and carry that hash
+        // forward instead of resetting it to the value it knew before blocking.
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        let model = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+
+        let foreign = try acquireForeignManifestLock()
+        defer { close(foreign) }
+        let manifestURL = rootDirectory.appendingPathComponent("manifest.json")
+        var foreignManifest = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: Data(contentsOf: manifestURL)) as? [String: Any]
+        )
+
+        let finished = CompletionFlag()
+        Thread.detachNewThread {
+            do {
+                try workspace.save(model)
+            } catch {
+                XCTFail("save 失败：\(error)")
+            }
+            finished.set()
+        }
+        Thread.sleep(forTimeInterval: 0.3)
+        XCTAssertFalse(finished.isSet, "外部进程持锁期间 save 不应完成")
+
+        foreignManifest["lastWrittenHash"] = "foreign-hash"
+        try JSONSerialization.data(withJSONObject: foreignManifest).write(to: manifestURL, options: .atomic)
+        XCTAssertEqual(flock(foreign, LOCK_UN), 0)
+
+        XCTAssertTrue(finished.wait(timeout: 5), "外部锁释放后 save 应完成")
+        XCTAssertEqual(try workspace.lastWrittenHash(), "foreign-hash", "外部在锁内回写的哈希不得被 save 重置")
+    }
+
+    func testALeftoverLockFileFromACrashDoesNotBlockAnything() throws {
+        // flock-style kernel locks die with their holder, so a crash leaves only the lock file
+        // itself behind; an unheld leftover is neither a deadlock nor residual content — first
+        // capture proceeds as usual.
+        try FileManager.default.createDirectory(at: rootDirectory, withIntermediateDirectories: true)
+        try Data().write(to: rootDirectory.appendingPathComponent("manifest.lock"))
+
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        var model = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        try model.addProfile(id: .init("blocker"), name: "Blocker", content: "# blocker")
+        try workspace.save(model)
+        try workspace.recordLastWrittenHash("a249a12a2f3b5dd513ea921e2b02fa1f")
+
+        XCTAssertEqual(try workspace.lastWrittenHash(), "a249a12a2f3b5dd513ea921e2b02fa1f")
+    }
+
+    /// Holds the kernel-exclusive flock on manifest.lock through an independently opened descriptor,
+    /// simulating another process's holder: flock ownership follows the open file description, so an
+    /// independent descriptor contends with Workspace's own exactly like a real foreign process would —
+    /// an equivalent of a child-process test.
+    private func acquireForeignManifestLock() throws -> Int32 {
+        let path = rootDirectory.appendingPathComponent("manifest.lock").path
+        let fd = Darwin.open(path, O_RDWR | O_CREAT | O_CLOEXEC, 0o644)
+        let locked = try XCTUnwrap(fd >= 0 ? fd : nil, "打开 manifest.lock 失败")
+        XCTAssertEqual(flock(locked, LOCK_EX), 0)
+        return locked
+    }
+
     private func reopenWithoutImporting(_ workspace: Workspace) throws -> ActivationModel {
         try workspace.open(systemHosts: {
             XCTFail("已初始化的工作区不应再读取系统 hosts")
@@ -421,5 +548,24 @@ final class WorkspaceTests: XCTestCase {
         FileManager.default.fileExists(
             atPath: rootDirectory.appendingPathComponent(relativePath).path
         )
+    }
+}
+
+/// Cross-thread completion marker: a background thread sets it, the test thread polls it — used to
+/// assert "not finished while the lock is held, finished after release".
+private final class CompletionFlag: @unchecked Sendable {
+    private let lock = NSLock()
+    private var flag = false
+
+    var isSet: Bool { lock.withLock { flag } }
+    func set() { lock.withLock { flag = true } }
+
+    func wait(timeout: TimeInterval) -> Bool {
+        let deadline = Date(timeIntervalSinceNow: timeout)
+        while !isSet {
+            guard Date() < deadline else { return false }
+            Thread.sleep(forTimeInterval: 0.01)
+        }
+        return true
     }
 }

--- a/Tests/HostflipCoreTests/WorkspaceTests.swift
+++ b/Tests/HostflipCoreTests/WorkspaceTests.swift
@@ -518,6 +518,98 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertEqual(try workspace.lastWrittenHash(), "a249a12a2f3b5dd513ea921e2b02fa1f")
     }
 
+    // MARK: - Reload-and-replay saving (ADR-0010 ②)
+
+    func testSaveApplyingReplaysTheChangeOnTheLatestDiskState() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        _ = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        // A foreign writer (the CLI) adds a profile and activates it after this instance last read the workspace
+        var foreign = try reopenWithoutImporting(Workspace(rootDirectory: rootDirectory))
+        try foreign.addProfile(id: .init("cli"), name: "CLI", content: "# cli")
+        try foreign.toggleProfile(.init("cli"))
+        try Workspace(rootDirectory: rootDirectory).save(foreign)
+
+        let outcome = try workspace.save(applying: {
+            try $0.addProfile(id: .init("gui"), name: "GUI", content: "# gui")
+        })
+
+        guard case .saved(let saved) = outcome else {
+            return XCTFail("在最新状态上重放应当成功保存")
+        }
+        XCTAssertEqual(saved.standaloneProfiles.map(\.id), [.init("cli"), .init("gui")])
+        XCTAssertEqual(saved.activeProfileIDs, [.init("cli")])
+        let reloaded = try reopenWithoutImporting(workspace)
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.id), [.init("cli"), .init("gui")])
+        XCTAssertEqual(reloaded.activeProfileIDs, [.init("cli")])
+        XCTAssertTrue(workspaceFileExists("profiles/CLI.hosts"))
+    }
+
+    func testSaveApplyingKeepsAForeignlyCreatedProfileFileOutOfStaleCleanup() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        _ = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        var foreign = try reopenWithoutImporting(Workspace(rootDirectory: rootDirectory))
+        try foreign.addProfile(id: .init("cli"), name: "CLI", content: "# cli")
+        try Workspace(rootDirectory: rootDirectory).save(foreign)
+
+        _ = try workspace.save(applying: { _ in })
+
+        XCTAssertTrue(workspaceFileExists("profiles/CLI.hosts"))
+        XCTAssertEqual(
+            try reopenWithoutImporting(workspace).standaloneProfiles.map(\.id),
+            [.init("cli")]
+        )
+    }
+
+    func testSaveApplyingConflictWritesNothingAndReturnsTheLatestState() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        var model = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        try model.addProfile(id: .init("doomed"), name: "Doomed", content: "# doomed")
+        try workspace.save(model)
+        var foreign = try reopenWithoutImporting(Workspace(rootDirectory: rootDirectory))
+        try foreign.deleteProfile(.init("doomed"))
+        try Workspace(rootDirectory: rootDirectory).save(foreign)
+
+        let outcome = try workspace.save(applying: {
+            try $0.renameProfile(.init("doomed"), to: "Renamed")
+        })
+
+        guard case .conflict(let latest, let reason) = outcome else {
+            return XCTFail("在被外部删除的 profile 上重放应当报告冲突")
+        }
+        XCTAssertEqual(latest.standaloneProfiles, [])
+        XCTAssertEqual(
+            reason as? ActivationModelError,
+            .unknownProfile(.init("doomed"))
+        )
+        XCTAssertEqual(try reopenWithoutImporting(workspace).standaloneProfiles, [])
+        XCTAssertFalse(workspaceFileExists("profiles/Doomed.hosts"))
+    }
+
+    func testSaveApplyingPreservesTheRecordedHashAndAcceptsANewOne() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        _ = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        try workspace.recordLastWrittenHash("a249a12a2f3b5dd513ea921e2b02fa1f")
+
+        _ = try workspace.save(applying: {
+            try $0.addProfile(id: .init("blocker"), name: "Blocker", content: "# blocker")
+        })
+        XCTAssertEqual(try workspace.lastWrittenHash(), "a249a12a2f3b5dd513ea921e2b02fa1f")
+
+        _ = try workspace.save(
+            applying: { $0.baseHosts.content = "127.0.0.1 localhost reviewed" },
+            acceptingSystemHostsHash: "ffffffffffffffffffffffffffffffff"
+        )
+        XCTAssertEqual(try workspace.lastWrittenHash(), "ffffffffffffffffffffffffffffffff")
+    }
+
+    func testSaveApplyingIntoAnUninitializedWorkspaceIsRejected() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+
+        XCTAssertThrowsError(try workspace.save(applying: { _ in })) { error in
+            XCTAssertEqual(error as? WorkspaceError, .notInitialized)
+        }
+    }
+
     /// Holds the kernel-exclusive flock on manifest.lock through an independently opened descriptor,
     /// simulating another process's holder: flock ownership follows the open file description, so an
     /// independent descriptor contends with Workspace's own exactly like a real foreign process would —

--- a/Tests/HostflipCoreTests/WorkspaceTests.swift
+++ b/Tests/HostflipCoreTests/WorkspaceTests.swift
@@ -381,6 +381,28 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertFalse(workspaceFileExists("manifest.json"))
     }
 
+    func testOpenReadOnlyLoadsAnInitializedWorkspace() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        var model = try workspace.open(systemHosts: { "127.0.0.1 localhost" })
+        try model.addProfile(id: .init("dev"), name: "Dev", content: "# dev")
+        try workspace.save(model)
+
+        let reloaded = try workspace.openReadOnly()
+
+        XCTAssertEqual(reloaded.baseHosts.content, "127.0.0.1 localhost")
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.name), ["Dev"])
+    }
+
+    func testOpenReadOnlyOnAnUninitializedWorkspaceThrowsWithoutCapturing() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+
+        XCTAssertThrowsError(try workspace.openReadOnly()) { error in
+            XCTAssertEqual(error as? WorkspaceError, .notInitialized)
+        }
+        XCTAssertFalse(workspaceFileExists("manifest.json"))
+        XCTAssertFalse(workspaceFileExists("hosts.orig"))
+    }
+
     private func reopenWithoutImporting(_ workspace: Workspace) throws -> ActivationModel {
         try workspace.open(systemHosts: {
             XCTFail("已初始化的工作区不应再读取系统 hosts")

--- a/Tests/HostflipTests/CLIInstallPresentationTests.swift
+++ b/Tests/HostflipTests/CLIInstallPresentationTests.swift
@@ -1,0 +1,133 @@
+import SwiftUI
+import XCTest
+@testable import Hostflip
+
+/// Settings > Command Line presents the symlink install command instead of
+/// creating the link itself: creating it needs root, and privileged work stays
+/// out of the app — the daemon's XPC surface deliberately has exactly one
+/// operation (ADR-0009), so the user runs the command in Terminal.
+final class CLIInstallPresentationTests: XCTestCase {
+    // MARK: Command building
+
+    func testCommandSymlinksTheGivenCLIPathIntoUsrLocalBin() {
+        let presentation = CLIInstallPresentation(
+            cliPath: "/Applications/Hostflip.app/Contents/Helpers/hostflip",
+            linkState: .absent
+        )
+        XCTAssertEqual(
+            presentation.command,
+            """
+            sudo mkdir -p /usr/local/bin
+            sudo ln -sf /Applications/Hostflip.app/Contents/Helpers/hostflip /usr/local/bin/hostflip
+            """
+        )
+    }
+
+    func testCommandSingleQuotesAPathContainingSpaces() {
+        let presentation = CLIInstallPresentation(
+            cliPath: "/Users/sam/My Apps/Hostflip.app/Contents/Helpers/hostflip",
+            linkState: .absent
+        )
+        XCTAssertTrue(
+            presentation.command.contains(
+                "sudo ln -sf '/Users/sam/My Apps/Hostflip.app/Contents/Helpers/hostflip' /usr/local/bin/hostflip"
+            )
+        )
+    }
+
+    func testCommandEscapesASingleQuoteInsideTheQuotedPath() {
+        let presentation = CLIInstallPresentation(
+            cliPath: "/Users/sam/Sam's Apps/Hostflip.app/Contents/Helpers/hostflip",
+            linkState: .absent
+        )
+        XCTAssertTrue(
+            presentation.command.contains(
+                "sudo ln -sf '/Users/sam/Sam'\\''s Apps/Hostflip.app/Contents/Helpers/hostflip' /usr/local/bin/hostflip"
+            )
+        )
+    }
+
+    // MARK: Status mapping
+
+    func testAbsentLinkPresentsAsNotLinkedAndNeutral() {
+        let presentation = CLIInstallPresentation(
+            cliPath: "/Applications/Hostflip.app/Contents/Helpers/hostflip",
+            linkState: .absent
+        )
+        XCTAssertEqual(presentation.statusTitle, "Not linked yet")
+        XCTAssertNotEqual(presentation.statusColor, .red)
+        XCTAssertNotEqual(presentation.statusColor, .orange)
+    }
+
+    func testLinkPointingAtThisAppPresentsAsLinked() {
+        let cliPath = "/Applications/Hostflip.app/Contents/Helpers/hostflip"
+        let presentation = CLIInstallPresentation(
+            cliPath: cliPath,
+            linkState: .linked(destination: cliPath)
+        )
+        XCTAssertEqual(presentation.statusTitle, "Linked at /usr/local/bin/hostflip")
+        XCTAssertEqual(presentation.statusColor, .green)
+    }
+
+    func testLinkPointingElsewherePresentsTheStaleDestination() {
+        let presentation = CLIInstallPresentation(
+            cliPath: "/Applications/Hostflip.app/Contents/Helpers/hostflip",
+            linkState: .linked(destination: "/Users/sam/Old/Hostflip.app/Contents/Helpers/hostflip")
+        )
+        XCTAssertEqual(
+            presentation.statusTitle,
+            "Links elsewhere: /Users/sam/Old/Hostflip.app/Contents/Helpers/hostflip"
+        )
+        XCTAssertEqual(presentation.statusColor, .orange)
+    }
+
+    func testNonSymlinkOccupantPresentsAsOccupied() {
+        let presentation = CLIInstallPresentation(
+            cliPath: "/Applications/Hostflip.app/Contents/Helpers/hostflip",
+            linkState: .occupiedByFile
+        )
+        XCTAssertEqual(
+            presentation.statusTitle,
+            "Something else occupies /usr/local/bin/hostflip"
+        )
+        XCTAssertEqual(presentation.statusColor, .orange)
+    }
+
+    // MARK: Link probing
+
+    func testProbeReportsAbsentForMissingPath() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let state = CLIInstallProbe.linkState(at: directory.appendingPathComponent("hostflip").path)
+        XCTAssertEqual(state, .absent)
+    }
+
+    func testProbeReportsOccupiedForRegularFile() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let file = directory.appendingPathComponent("hostflip")
+        try Data().write(to: file)
+        XCTAssertEqual(CLIInstallProbe.linkState(at: file.path), .occupiedByFile)
+    }
+
+    func testProbeReportsTheLiteralDestinationForASymlink() throws {
+        let directory = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let link = directory.appendingPathComponent("hostflip")
+        try FileManager.default.createSymbolicLink(
+            atPath: link.path,
+            withDestinationPath: "/Applications/Hostflip.app/Contents/Helpers/hostflip"
+        )
+        XCTAssertEqual(
+            CLIInstallProbe.linkState(at: link.path),
+            .linked(destination: "/Applications/Hostflip.app/Contents/Helpers/hostflip")
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CLIInstallPresentationTests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+}

--- a/Tests/HostflipTests/HostsDriftMonitorTests.swift
+++ b/Tests/HostflipTests/HostsDriftMonitorTests.swift
@@ -144,14 +144,14 @@ final class HostsDriftMonitorTests: XCTestCase {
 
     func testRecheckClearsTheDriftVerdictAfterAnExternalWriterRecordsItsBaseline() async throws {
         let initialCheck = expectation(description: "初查无漂移")
-        let falseDrift = expectation(description: "外部写入的文件事件先于其 manifest 记录，误判漂移")
-        let cleared = expectation(description: "复查读到已落盘的基线，误报解除")
+        let staleDrift = expectation(description: "文件事件先于 manifest 记录到达，按旧基线判为漂移")
+        let cleared = expectation(description: "复查读到已落盘的基线，陈旧判定解除")
         let driftCounter = DriftCallbackCounter()
         let nonDriftCounter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
         monitor.start { hasDrift in
             if hasDrift {
-                if driftCounter.next() == 1 { falseDrift.fulfill() }
+                if driftCounter.next() == 1 { staleDrift.fulfill() }
             } else if nonDriftCounter.next() == 1 {
                 initialCheck.fulfill()
             } else {
@@ -165,7 +165,7 @@ final class HostsDriftMonitorTests: XCTestCase {
         // still-stale manifest reports drift.
         let written = MergedHosts(content: "10.0.0.1 cli-written.local\n")
         try Data(written.content.utf8).write(to: hostsURL, options: .atomic)
-        await fulfillment(of: [falseDrift], timeout: 1)
+        await fulfillment(of: [staleDrift], timeout: 1)
 
         // The record lands (no further hosts file event), then the writer's change notification
         // triggers a recheck: the fresh read sees a consistent baseline and clears the verdict.

--- a/Tests/HostflipTests/HostsDriftMonitorTests.swift
+++ b/Tests/HostflipTests/HostsDriftMonitorTests.swift
@@ -176,6 +176,38 @@ final class HostsDriftMonitorTests: XCTestCase {
         monitor.stop()
     }
 
+    func testAnExternalWriteWhoseRecordLandsWithinTheConfirmationWindowNeverReportsDrift() async throws {
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let refreshed = expectation(description: "the settled external write reports as a drift-free refresh")
+        let unexpectedDrift = expectation(description: "a write whose record lands within the window must not flash drift")
+        unexpectedDrift.isInverted = true
+        let nonDriftCounter = DriftCallbackCounter()
+        let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
+        monitor.start { hasDrift in
+            if hasDrift {
+                unexpectedDrift.fulfill()
+            } else if nonDriftCounter.next() == 1 {
+                initialCheck.fulfill()
+            } else {
+                refreshed.fulfill()
+            }
+        }
+        await fulfillment(of: [initialCheck], timeout: 1)
+
+        // The external write is noticed while the manifest is still stale (the recheck stands in
+        // for the file event, whose delivery moment is uncontrollable)...
+        let written = MergedHosts(content: "10.0.0.1 cli-written.local\n")
+        try Data(written.content.utf8).write(to: hostsURL, options: .atomic)
+        monitor.recheck()
+        // ...but the record and its change notification land within the confirmation window, so
+        // the deferred verdict dissolves instead of flashing a drift banner.
+        try workspace.recordLastWrittenHash(written.hash)
+        monitor.recheck()
+
+        await fulfillment(of: [refreshed, unexpectedDrift], timeout: 1)
+        monitor.stop()
+    }
+
     func testExpectedWriteWindowNeverHidesPreexistingDrift() async throws {
         let target = MergedHosts(content: "10.0.0.1 managed.local\n")
         try Data(target.content.utf8).write(to: hostsURL, options: .atomic)

--- a/Tests/HostflipTests/HostsDriftMonitorTests.swift
+++ b/Tests/HostflipTests/HostsDriftMonitorTests.swift
@@ -35,8 +35,8 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testStartChecksImmediatelyAndContinuesAfterAtomicReplacement() async throws {
-        let initialCheck = expectation(description: "建立监听时立即检查")
-        let driftDetected = expectation(description: "原子替换后检测漂移")
+        let initialCheck = expectation(description: "checks immediately when the watch is armed")
+        let driftDetected = expectation(description: "detects drift after an atomic replacement")
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
         monitor.start { hasDrift in
             if hasDrift {
@@ -55,9 +55,9 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testReportsAgainWhenTheDriftedContentChanges() async throws {
-        let initialCheck = expectation(description: "初查无漂移")
-        let firstDrift = expectation(description: "发现第一版漂移")
-        let secondDrift = expectation(description: "漂移期间继续报告新现场")
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let firstDrift = expectation(description: "reports the first drifted version")
+        let secondDrift = expectation(description: "keeps reporting new content while drifted")
         let counter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
         monitor.start { hasDrift in
@@ -84,9 +84,9 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testExpectedDaemonWriteDoesNotReportDrift() async throws {
-        let initialCheck = expectation(description: "初查无漂移")
-        let writeObserved = expectation(description: "自身写入以无漂移状态通知")
-        let unexpectedDrift = expectation(description: "自身写入不应报警")
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let writeObserved = expectation(description: "reports the own write as drift-free")
+        let unexpectedDrift = expectation(description: "an own write must not alert")
         unexpectedDrift.isInverted = true
         let nonDriftCounter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
@@ -112,9 +112,9 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testConfirmedDaemonWriteDoesNotReportDriftWhenManifestRecordFails() async throws {
-        let initialCheck = expectation(description: "初查无漂移")
-        let writeObserved = expectation(description: "已确认写入以无漂移状态通知")
-        let unexpectedDrift = expectation(description: "daemon 已确认写入不应误报")
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let writeObserved = expectation(description: "reports the confirmed write as drift-free")
+        let unexpectedDrift = expectation(description: "a daemon-confirmed write must not be misreported")
         unexpectedDrift.isInverted = true
         let nonDriftCounter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
@@ -143,9 +143,9 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testRecheckClearsTheDriftVerdictAfterAnExternalWriterRecordsItsBaseline() async throws {
-        let initialCheck = expectation(description: "初查无漂移")
-        let staleDrift = expectation(description: "文件事件先于 manifest 记录到达，按旧基线判为漂移")
-        let cleared = expectation(description: "复查读到已落盘的基线，陈旧判定解除")
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let staleDrift = expectation(description: "the file event outruns the manifest record, so the old baseline reads as drift")
+        let cleared = expectation(description: "the recheck reads the recorded baseline and clears the stale verdict")
         let driftCounter = DriftCallbackCounter()
         let nonDriftCounter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
@@ -179,8 +179,8 @@ final class HostsDriftMonitorTests: XCTestCase {
     func testExpectedWriteWindowNeverHidesPreexistingDrift() async throws {
         let target = MergedHosts(content: "10.0.0.1 managed.local\n")
         try Data(target.content.utf8).write(to: hostsURL, options: .atomic)
-        let driftDetected = expectation(description: "启动时发现既有漂移")
-        let unexpectedClear = expectation(description: "预期窗口不应掩盖既有漂移")
+        let driftDetected = expectation(description: "finds the preexisting drift on start")
+        let unexpectedClear = expectation(description: "the expected-write window must not hide preexisting drift")
         unexpectedClear.isInverted = true
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
         monitor.start { hasDrift in
@@ -200,9 +200,9 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testReviewedDriftWriteTreatsOnlyTheReconciliationTargetAsExpected() async throws {
-        let initialCheck = expectation(description: "初查无漂移")
-        let driftDetected = expectation(description: "发现用户将要审阅的漂移")
-        let targetAccepted = expectation(description: "调和目标写入不再作为新漂移报告")
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let driftDetected = expectation(description: "reports the drift the user is about to review")
+        let targetAccepted = expectation(description: "the reconciliation target write is not reported as new drift")
         let nonDriftCounter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
         monitor.start { hasDrift in
@@ -233,8 +233,8 @@ final class HostsDriftMonitorTests: XCTestCase {
     }
 
     func testOverlappingExpectedWriteWindowsDoNotClearEachOther() async throws {
-        let initialCheck = expectation(description: "初查无漂移")
-        let unexpectedDrift = expectation(description: "重叠窗口不应误报")
+        let initialCheck = expectation(description: "no drift on the initial check")
+        let unexpectedDrift = expectation(description: "overlapping windows must not misreport")
         unexpectedDrift.isInverted = true
         let nonDriftCounter = DriftCallbackCounter()
         let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)

--- a/Tests/HostflipTests/HostsDriftMonitorTests.swift
+++ b/Tests/HostflipTests/HostsDriftMonitorTests.swift
@@ -142,6 +142,40 @@ final class HostsDriftMonitorTests: XCTestCase {
         monitor.stop()
     }
 
+    func testRecheckClearsTheDriftVerdictAfterAnExternalWriterRecordsItsBaseline() async throws {
+        let initialCheck = expectation(description: "初查无漂移")
+        let falseDrift = expectation(description: "外部写入的文件事件先于其 manifest 记录，误判漂移")
+        let cleared = expectation(description: "复查读到已落盘的基线，误报解除")
+        let driftCounter = DriftCallbackCounter()
+        let nonDriftCounter = DriftCallbackCounter()
+        let monitor = HostsDriftMonitor(workspace: workspace, hostsURL: hostsURL)
+        monitor.start { hasDrift in
+            if hasDrift {
+                if driftCounter.next() == 1 { falseDrift.fulfill() }
+            } else if nonDriftCounter.next() == 1 {
+                initialCheck.fulfill()
+            } else {
+                cleared.fulfill()
+            }
+        }
+        await fulfillment(of: [initialCheck], timeout: 1)
+
+        // An external writer (the CLI) merges through the daemon: the hosts file event reaches
+        // the monitor before the writer's recordLastWrittenHash lands, so the check against the
+        // still-stale manifest reports drift.
+        let written = MergedHosts(content: "10.0.0.1 cli-written.local\n")
+        try Data(written.content.utf8).write(to: hostsURL, options: .atomic)
+        await fulfillment(of: [falseDrift], timeout: 1)
+
+        // The record lands (no further hosts file event), then the writer's change notification
+        // triggers a recheck: the fresh read sees a consistent baseline and clears the verdict.
+        try workspace.recordLastWrittenHash(written.hash)
+        monitor.recheck()
+
+        await fulfillment(of: [cleared], timeout: 1)
+        monitor.stop()
+    }
+
     func testExpectedWriteWindowNeverHidesPreexistingDrift() async throws {
         let target = MergedHosts(content: "10.0.0.1 managed.local\n")
         try Data(target.content.utf8).write(to: hostsURL, options: .atomic)

--- a/Tests/HostflipTests/MainWindowPresentationTests.swift
+++ b/Tests/HostflipTests/MainWindowPresentationTests.swift
@@ -33,7 +33,7 @@ final class MainWindowPresentationTests: XCTestCase {
         )
 
         XCTAssertTrue(presentation.activationControlsDisabled)
-        XCTAssertFalse(presentation.activationControlsDimmed, "瞬态切换不应让整列控件闪烁置灰")
+        XCTAssertFalse(presentation.activationControlsDimmed, "a transient switch must not flash the whole control column dimmed")
     }
 
     func testHostsDriftBlocksActivationAndTakesBannerPriority() {

--- a/Tests/HostflipTests/MaintenanceStoreTests.swift
+++ b/Tests/HostflipTests/MaintenanceStoreTests.swift
@@ -48,7 +48,7 @@ final class MaintenanceStoreTests: XCTestCase {
 
         XCTAssertEqual(store.helperStatus, .enabled)
         guard case .helperRemovalFailed(let message) = store.feedback else {
-            return XCTFail("应保留 helper 移除失败反馈")
+            return XCTFail("the helper removal failure feedback must be kept")
         }
         XCTAssertTrue(message.contains("Try again"))
     }
@@ -68,7 +68,7 @@ final class MaintenanceStoreTests: XCTestCase {
         await store.removeHelper()
 
         let reloaded = try workspace.open(systemHosts: {
-            XCTFail("维护操作不应重新初始化工作区")
+            XCTFail("a maintenance operation must not reinitialize the workspace")
             return ""
         })
         XCTAssertEqual(reloaded.standaloneProfiles.first?.id, profileID)
@@ -114,7 +114,7 @@ final class MaintenanceStoreTests: XCTestCase {
         await helper.setStatus(.requiresApproval)
         await gate.tick()
         for _ in 0 ..< 50 { await Task.yield() }
-        XCTAssertEqual(store.helperStatus, .enabled, "轮询应在批准后停止")
+        XCTAssertEqual(store.helperStatus, .enabled, "polling must stop once approved")
     }
 
     /// Yields until the condition holds (the poll task needs a few actor hops to land).
@@ -124,7 +124,7 @@ final class MaintenanceStoreTests: XCTestCase {
             if condition() { return }
             await Task.yield()
         }
-        XCTFail("等待条件超时")
+        XCTFail("timed out waiting for the condition")
     }
 
     @MainActor

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -1359,6 +1359,223 @@ final class WorkspaceStoreTests: XCTestCase {
         return url
     }
 
+    // MARK: - External-writer coexistence (#53, ADR-0010 ②③)
+
+    @MainActor
+    func testEditReplaysOnAForeignlyModifiedWorkspace() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        foreignlyModifyWorkspace {
+            try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+            try $0.toggleProfile(.init("cli"))
+        }
+
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [.init("cli"), profileID])
+        XCTAssertEqual(store.model?.activeProfileIDs, [.init("cli")])
+        XCTAssertNil(store.saveError)
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.id), [.init("cli"), profileID])
+        XCTAssertEqual(reloaded.activeProfileIDs, [.init("cli")])
+        // The foreign profile's file must survive the save's stale-file cleanup
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: rootDirectory.appendingPathComponent("profiles/CLI.hosts").path
+        ))
+    }
+
+    @MainActor
+    func testEditOnAForeignlyDeletedProfileIsDroppedAndAdoptsTheLatestState() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        foreignlyModifyWorkspace { try $0.deleteProfile(profileID) }
+
+        store.renameProfile(profileID, to: "Renamed")
+
+        XCTAssertEqual(store.standaloneProfiles, [])
+        XCTAssertNil(store.saveError)
+        XCTAssertEqual(try reloadModel().standaloneProfiles, [])
+    }
+
+    @MainActor
+    func testSwitchCommitReplaysOnForeignChangesMadeWhileInFlight() async throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        stub.whileSwitchInFlight = { [self] in
+            foreignlyModifyWorkspace {
+                try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+            }
+        }
+
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+
+        XCTAssertEqual(store.switchFeedback, .merged)
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [profileID, .init("cli")])
+        XCTAssertTrue(store.isActive(profileID))
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.id), [profileID, .init("cli")])
+        XCTAssertEqual(reloaded.activeProfileIDs, [profileID])
+    }
+
+    @MainActor
+    func testSwitchCommitOnAForeignlyDeletedProfileDropsTheCommit() async throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        stub.whileSwitchInFlight = { [self] in
+            foreignlyModifyWorkspace { try $0.deleteProfile(profileID) }
+        }
+
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+
+        XCTAssertEqual(store.standaloneProfiles, [])
+        XCTAssertEqual(store.model?.activeProfileIDs, [])
+        XCTAssertEqual(try reloadModel().standaloneProfiles, [])
+        // The system hosts was already written with the dropped state; the follow-up merge converges it back
+        XCTAssertNotNil(store.followUpMergeTask)
+    }
+
+    @MainActor
+    func testReconciliationReplaysOnForeignChangesMadeWhileInFlight() async throws {
+        let actualHosts = Self.importedHosts + "1.2.3.4 external.local\n"
+        let coordinator = SwitchCoordinatingStub()
+        let monitor = HostsDriftMonitoringStub()
+        let store = makeStore(
+            coordinator: coordinator,
+            driftMonitor: monitor,
+            systemHosts: Data(actualHosts.utf8)
+        )
+        monitor.report(true)
+        coordinator.whileReconciliationInFlight = { [self] in
+            foreignlyModifyWorkspace {
+                try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+            }
+        }
+
+        store.reconcileHosts(.addDriftLinesToBaseHosts)
+        await store.reconciliationTask?.value
+
+        XCTAssertEqual(store.baseHostsContent, Self.importedHosts + "1.2.3.4 external.local\n")
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [.init("cli")])
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.baseHosts.content, store.baseHostsContent)
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.id), [.init("cli")])
+    }
+
+    @MainActor
+    func testImportReplaysOnAForeignlyModifiedWorkspace() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        foreignlyModifyWorkspace {
+            try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+        }
+
+        let outcome = store.importFiles(at: [
+            try writeImportFile(named: "Team DB.hosts", Data("10.0.0.3 db.example\n".utf8))
+        ])
+
+        XCTAssertEqual(outcome, .imported)
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["CLI", "Team DB"])
+        XCTAssertEqual(try reloadModel().standaloneProfiles.map(\.name), ["CLI", "Team DB"])
+    }
+
+    @MainActor
+    func testDegradedSaveSelfHealsUnsavedEditsOnceTheDiskRecovers() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        let manifestURL = rootDirectory.appendingPathComponent("manifest.json")
+        let validManifest = try Data(contentsOf: manifestURL)
+        try Data("invalid manifest".utf8).write(to: manifestURL, options: .atomic)
+
+        store.renameProfile(profileID, to: "First Edit")
+        XCTAssertNotNil(store.saveError)
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["First Edit"])
+
+        try validManifest.write(to: manifestURL, options: .atomic)
+        store.updateProfileContent(profileID, content: "# healed\n")
+
+        XCTAssertNil(store.saveError)
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.name), ["First Edit"])
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.content), ["# healed\n"])
+    }
+
+    @MainActor
+    func testRefreshFromExternalChangeReloadsTheModelWithoutMerging() throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        foreignlyModifyWorkspace {
+            try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+        }
+
+        store.refreshFromExternalChange()
+
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [.init("cli")])
+        // Display refresh only: nothing reaches the coordinator and no follow-up merge is scheduled
+        XCTAssertNil(store.followUpMergeTask)
+        XCTAssertTrue(stub.authorizedMerges.isEmpty)
+        XCTAssertTrue(stub.performedSwitches.isEmpty)
+    }
+
+    @MainActor
+    func testRefreshFromExternalChangeSkipsWhileASaveErrorKeepsUnsavedEdits() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        let manifestURL = rootDirectory.appendingPathComponent("manifest.json")
+        let validManifest = try Data(contentsOf: manifestURL)
+        try Data("invalid manifest".utf8).write(to: manifestURL, options: .atomic)
+        store.renameProfile(profileID, to: "Kept Edit")
+        XCTAssertNotNil(store.saveError)
+        try validManifest.write(to: manifestURL, options: .atomic)
+        foreignlyModifyWorkspace {
+            try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+        }
+
+        store.refreshFromExternalChange()
+
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["Kept Edit"])
+        XCTAssertNotNil(store.saveError)
+    }
+
+    @MainActor
+    func testRefreshFromExternalChangeSkipsWhileASwitchIsInFlight() async throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        var refreshedDuringSwitch = true
+        stub.whileSwitchInFlight = { [self] in
+            foreignlyModifyWorkspace {
+                try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+            }
+            store.refreshFromExternalChange()
+            refreshedDuringSwitch = store.standaloneProfiles.contains { $0.id == .init("cli") }
+        }
+
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+
+        XCTAssertFalse(refreshedDuringSwitch)
+        // The commit's own reload-and-replay picks the foreign change up afterwards
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [profileID, .init("cli")])
+    }
+
+    /// Simulates a foreign writer (e.g. the CLI): mutates the on-disk state through an independent
+    /// Workspace instance, bypassing the store's in-memory model.
+    private func foreignlyModifyWorkspace(_ change: (inout ActivationModel) throws -> Void) {
+        do {
+            let workspace = Workspace(rootDirectory: rootDirectory)
+            var model = try workspace.open(systemHosts: {
+                XCTFail("已初始化的工作区不应再导入系统 hosts")
+                return ""
+            })
+            try change(&model)
+            try workspace.save(model)
+        } catch {
+            XCTFail("外部修改工作区失败：\(error)")
+        }
+    }
+
     // MARK: - Helpers
 
     @MainActor

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -46,9 +46,19 @@ private struct StubError: Error {}
 
 private final class HostsDriftMonitoringStub: HostsDriftMonitoring, @unchecked Sendable {
     private var onChange: (@MainActor @Sendable (Bool) -> Void)?
+    private let lock = NSLock()
+    private var recheckCount = 0
 
     func start(onChange: @escaping @MainActor @Sendable (Bool) -> Void) {
         self.onChange = onChange
+    }
+
+    func recheck() {
+        lock.withLock { recheckCount += 1 }
+    }
+
+    var recordedRechecks: Int {
+        lock.withLock { recheckCount }
     }
 
     @MainActor
@@ -1516,6 +1526,21 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertNil(store.followUpMergeTask)
         XCTAssertTrue(stub.authorizedMerges.isEmpty)
         XCTAssertTrue(stub.performedSwitches.isEmpty)
+    }
+
+    @MainActor
+    func testRefreshFromExternalChangeRechecksTheDriftMonitor() throws {
+        let monitor = HostsDriftMonitoringStub()
+        let store = makeStore(coordinator: SwitchCoordinatingStub(), driftMonitor: monitor)
+        foreignlyModifyWorkspace {
+            try $0.addProfile(id: .init("cli"), name: "CLI", content: "# cli\n")
+        }
+
+        store.refreshFromExternalChange()
+
+        // The external writer's hosts file event can outrun its manifest record, leaving a stale
+        // drift verdict; the change notification arrives after the record, so it re-checks.
+        XCTAssertEqual(monitor.recordedRechecks, 1)
     }
 
     @MainActor

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -1011,7 +1011,7 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertFalse(store.hasHostsDrift)
         XCTAssertNotNil(store.reconciliationError)
         guard case .failed = store.switchFeedback else {
-            return XCTFail("DNS 刷新失败应保留失败反馈")
+            return XCTFail("a DNS flush failure must keep the failure feedback")
         }
 
         monitor.report(false)
@@ -1076,7 +1076,7 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertNil(store.backgroundSyncError)
         XCTAssertNotNil(store.reconciliationError)
         guard case .failed = store.switchFeedback else {
-            return XCTFail("工作区保存失败后应保留失败反馈")
+            return XCTFail("a workspace save failure must keep the failure feedback")
         }
     }
 
@@ -1153,7 +1153,7 @@ final class WorkspaceStoreTests: XCTestCase {
 
         XCTAssertFalse(store.isActive(profileID))
         guard case .failed = store.switchFeedback else {
-            return XCTFail("应报告失败反馈，实际：\(String(describing: store.switchFeedback))")
+            return XCTFail("expected failure feedback, got: \(String(describing: store.switchFeedback))")
         }
         XCTAssertEqual(try reloadModel().activeProfileIDs, [])
     }
@@ -1244,7 +1244,7 @@ final class WorkspaceStoreTests: XCTestCase {
 
         XCTAssertFalse(store.isActive(profileID))
         guard case .failed = store.switchFeedback else {
-            return XCTFail("应报告失败反馈，实际：\(String(describing: store.switchFeedback))")
+            return XCTFail("expected failure feedback, got: \(String(describing: store.switchFeedback))")
         }
     }
 
@@ -1321,7 +1321,7 @@ final class WorkspaceStoreTests: XCTestCase {
         let outcome = store.importFiles(at: urls)
 
         guard case .failed(let message) = outcome else {
-            return XCTFail("导入应整体失败，实际结果：\(outcome)")
+            return XCTFail("the import must fail as a whole, got: \(outcome)")
         }
         XCTAssertTrue(message.contains("bad.json"), message)
         XCTAssertTrue(store.standaloneProfiles.isEmpty)
@@ -1341,7 +1341,7 @@ final class WorkspaceStoreTests: XCTestCase {
         let outcome = store.importFiles(at: [url])
 
         guard case .failed = outcome else {
-            return XCTFail("保存失败时导入应失败，实际结果：\(outcome)")
+            return XCTFail("the import must fail when saving fails, got: \(outcome)")
         }
         XCTAssertTrue(store.standaloneProfiles.isEmpty)
         XCTAssertNil(store.followUpMergeTask)
@@ -1591,13 +1591,13 @@ final class WorkspaceStoreTests: XCTestCase {
         do {
             let workspace = Workspace(rootDirectory: rootDirectory)
             var model = try workspace.open(systemHosts: {
-                XCTFail("已初始化的工作区不应再导入系统 hosts")
+                XCTFail("an initialized workspace must not capture the system hosts again")
                 return ""
             })
             try change(&model)
             try workspace.save(model)
         } catch {
-            XCTFail("外部修改工作区失败：\(error)")
+            XCTFail("foreign workspace modification failed: \(error)")
         }
     }
 
@@ -1627,7 +1627,7 @@ final class WorkspaceStoreTests: XCTestCase {
     /// Reloads with a fresh Workspace instance to verify persisted state; at this point the system hosts must never be imported again.
     private func reloadModel() throws -> ActivationModel {
         try Workspace(rootDirectory: rootDirectory).open(systemHosts: {
-            XCTFail("已初始化的工作区不应再导入系统 hosts")
+            XCTFail("an initialized workspace must not capture the system hosts again")
             return ""
         })
     }

--- a/Tests/HostflipXPCTests/CodeSigningRequirementTests.swift
+++ b/Tests/HostflipXPCTests/CodeSigningRequirementTests.swift
@@ -2,9 +2,9 @@ import XCTest
 @testable import HostflipXPC
 
 final class CodeSigningRequirementTests: XCTestCase {
-    func testBuildsDesignatedRequirementForPeer() throws {
+    func testBuildsDesignatedRequirementForSingleIdentifier() throws {
         let requirement = try CodeSigningRequirement.peerRequirement(
-            identifier: "com.heronapp.hostflip.daemon",
+            identifiers: ["com.heronapp.hostflip.daemon"],
             teamID: "ABCDE12345"
         )
 
@@ -14,20 +14,54 @@ final class CodeSigningRequirementTests: XCTestCase {
         )
     }
 
+    func testBuildsAlternationRequirementForAppAndCLIIdentifiers() throws {
+        let requirement = try CodeSigningRequirement.peerRequirement(
+            identifiers: [ChannelIdentity.appBundleID, ChannelIdentity.cliIdentifier],
+            teamID: "ABCDE12345"
+        )
+
+        XCTAssertEqual(
+            requirement,
+            #"(identifier "com.heronapp.hostflip" or identifier "com.heronapp.hostflip.cli") and anchor apple generic and certificate leaf[subject.OU] = "ABCDE12345""#
+        )
+    }
+
+    func testRejectsEmptyIdentifierList() {
+        XCTAssertThrowsError(
+            try CodeSigningRequirement.peerRequirement(identifiers: [], teamID: "ABCDE12345")
+        ) { error in
+            XCTAssertEqual(error as? CodeSigningRequirementError, .invalidIdentifier(""))
+        }
+    }
+
     func testRejectsIdentifierWithCharactersOutsideBundleIDAlphabet() {
         for identifier in [#"a"b"#, "a\"", "a b", "", "a\n.b"] {
             XCTAssertThrowsError(
-                try CodeSigningRequirement.peerRequirement(identifier: identifier, teamID: "ABCDE12345")
+                try CodeSigningRequirement.peerRequirement(identifiers: [identifier], teamID: "ABCDE12345")
             ) { error in
                 XCTAssertEqual(error as? CodeSigningRequirementError, .invalidIdentifier(identifier))
             }
         }
     }
 
+    func testRejectsInvalidIdentifierAnywhereInTheList() {
+        XCTAssertThrowsError(
+            try CodeSigningRequirement.peerRequirement(
+                identifiers: ["com.heronapp.hostflip", #"evil" or identifier "x"#],
+                teamID: "ABCDE12345"
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? CodeSigningRequirementError,
+                .invalidIdentifier(#"evil" or identifier "x"#)
+            )
+        }
+    }
+
     func testRejectsMalformedTeamID() {
         for teamID in ["", "abcde12345", "ABCDE1234", "ABCDE123456", #"ABCDE1234""#] {
             XCTAssertThrowsError(
-                try CodeSigningRequirement.peerRequirement(identifier: "com.heronapp.hostflip", teamID: teamID)
+                try CodeSigningRequirement.peerRequirement(identifiers: ["com.heronapp.hostflip"], teamID: teamID)
             ) { error in
                 XCTAssertEqual(error as? CodeSigningRequirementError, .invalidTeamID(teamID))
             }

--- a/Tests/HostflipXPCTests/CodeSigningRequirementTests.swift
+++ b/Tests/HostflipXPCTests/CodeSigningRequirementTests.swift
@@ -1,3 +1,4 @@
+import Security
 import XCTest
 @testable import HostflipXPC
 
@@ -24,6 +25,24 @@ final class CodeSigningRequirementTests: XCTestCase {
             requirement,
             #"(identifier "com.heronapp.hostflip" or identifier "com.heronapp.hostflip.cli") and anchor apple generic and certificate leaf[subject.OU] = "ABCDE12345""#
         )
+    }
+
+    func testGeneratedRequirementsCompileInTheRequirementLanguage() throws {
+        for identifiers in [
+            [ChannelIdentity.daemonIdentifier],
+            [ChannelIdentity.appBundleID, ChannelIdentity.cliIdentifier],
+        ] {
+            let requirement = try CodeSigningRequirement.peerRequirement(
+                identifiers: identifiers,
+                teamID: "ABCDE12345"
+            )
+            var compiled: SecRequirement?
+            XCTAssertEqual(
+                SecRequirementCreateWithString(requirement as CFString, SecCSFlags(), &compiled),
+                errSecSuccess,
+                "not valid requirement syntax: \(requirement)"
+            )
+        }
     }
 
     func testRejectsEmptyIdentifierList() {

--- a/Tests/HostflipXPCTests/DaemonChannelErrorTests.swift
+++ b/Tests/HostflipXPCTests/DaemonChannelErrorTests.swift
@@ -78,7 +78,7 @@ final class DaemonChannelErrorTests: XCTestCase {
     }
 
     func testDecodeMergeOutcomeSurfacesWriteFailureWithStage() {
-        let failure = HostsWriteError(stage: .replace, message: "重命名失败")
+        let failure = HostsWriteError(stage: .replace, message: "rename failed")
         let data = XPCPayload.encode(MergeReply.writeFailed(failure))
 
         XCTAssertThrowsError(try DaemonClient.decodeMergeOutcome(data)) { error in

--- a/Tests/HostflipXPCTests/DaemonServiceTests.swift
+++ b/Tests/HostflipXPCTests/DaemonServiceTests.swift
@@ -71,7 +71,7 @@ final class DaemonServiceTests: XCTestCase {
 
     func testMergeReportsWriteFailureStageFromSink() {
         let sink = SpySink()
-        let failure = HostsWriteError(stage: .flushDNS, message: "dscacheutil 退出码 1")
+        let failure = HostsWriteError(stage: .flushDNS, message: "dscacheutil exited with status 1")
         sink.failure = failure
         let service = DaemonService(sink: sink, daemonVersion: "0.1.0")
         let merged = MergedHosts(content: "127.0.0.1 localhost\n")

--- a/Tests/HostflipXPCTests/MergeCoordinatorTests.swift
+++ b/Tests/HostflipXPCTests/MergeCoordinatorTests.swift
@@ -99,14 +99,14 @@ final class MergeCoordinatorTests: XCTestCase {
     func testMergeKeepsPriorHashWhenDaemonReportsFailure() async throws {
         let prior = MergedHosts(content: "127.0.0.1 localhost\n")
         try await MergeCoordinator(workspace: workspace, send: { merged, _, _, _ in merged.hash }).merge(prior)
-        let failure = HostsWriteError(stage: .flushDNS, message: "dscacheutil 退出码 1")
+        let failure = HostsWriteError(stage: .flushDNS, message: "dscacheutil exited with status 1")
         let failing = MergeCoordinator(workspace: workspace, send: { _, _, _, _ in
             throw DaemonChannelError.mergeWriteFailed(failure)
         })
 
         do {
             try await failing.merge(MergedHosts(content: "2.2.2.2 b\n"))
-            XCTFail("失败的合并写入不应正常返回")
+            XCTFail("a failed merge write must not return normally")
         } catch let error as DaemonChannelError {
             XCTAssertEqual(error, .mergeWriteFailed(failure))
         }
@@ -119,7 +119,7 @@ final class MergeCoordinatorTests: XCTestCase {
         let tracker = ConfirmedWriteTrackerSpy(overrideHash: prior.hash)
         let failure = HostsWriteError(
             stage: .flushDNS,
-            message: "dscacheutil 退出码 1",
+            message: "dscacheutil exited with status 1",
             writtenHash: merged.hash
         )
         let coordinator = MergeCoordinator(
@@ -130,7 +130,7 @@ final class MergeCoordinatorTests: XCTestCase {
 
         do {
             try await coordinator.merge(merged)
-            XCTFail("DNS 刷新失败应上抛")
+            XCTFail("a DNS flush failure must be rethrown")
         } catch let error as DaemonChannelError {
             XCTAssertEqual(error, .mergeWriteFailed(failure))
         }
@@ -157,7 +157,7 @@ final class MergeCoordinatorTests: XCTestCase {
 
         do {
             try await coordinator.merge(merged)
-            XCTFail("manifest 记录失败应上抛")
+            XCTFail("a manifest record failure must be rethrown")
         } catch let error as WorkspaceError {
             XCTAssertEqual(error, .notInitialized)
         }

--- a/Tests/HostflipXPCTests/SwitchCoordinatorTests.swift
+++ b/Tests/HostflipXPCTests/SwitchCoordinatorTests.swift
@@ -300,11 +300,11 @@ final class SwitchCoordinatorTests: XCTestCase {
 
         do {
             _ = try await coordinator.performSwitch(merged)
-            XCTFail("非通道错误应上抛")
+            XCTFail("a non-channel error must be rethrown")
         } catch let error as WorkspaceError {
             XCTAssertEqual(error, .notInitialized)
         } catch {
-            XCTFail("错误类型不符：\(error)")
+            XCTFail("unexpected error type: \(error)")
         }
     }
 }

--- a/Tests/HostflipXPCTests/XPCPayloadsTests.swift
+++ b/Tests/HostflipXPCTests/XPCPayloadsTests.swift
@@ -56,7 +56,7 @@ final class XPCPayloadsTests: XCTestCase {
     func testMergeReplyWriteFailedRoundTripCarriesStageMessageAndWrittenHash() throws {
         let failed = MergeReply.writeFailed(HostsWriteError(
             stage: .flushDNS,
-            message: "dscacheutil 退出码 1",
+            message: "dscacheutil exited with status 1",
             writtenHash: "written-hash"
         ))
 

--- a/docs/signed-build-verification.md
+++ b/docs/signed-build-verification.md
@@ -18,9 +18,10 @@ closed (which is exactly what the negative verification in step 4 relies on).
     build/Hostflip.app/Contents/MacOS/Hostflip --print-requirement
     build/Hostflip.app/Contents/MacOS/hostflipd --print-requirement
 
-The Team IDs in the two requirements must match. The identifier the app
-prints is `com.heronapp.hostflip.daemon` (the peer it requires); the daemon
-prints `com.heronapp.hostflip`.
+The Team IDs in the two requirements must match. The app prints the daemon
+identifier `com.heronapp.hostflip.daemon` (the peer it requires); the daemon
+prints an alternation accepting either client identifier:
+`(identifier "com.heronapp.hostflip" or identifier "com.heronapp.hostflip.cli")`.
 
 ## 3. Channel round trip (requires sudo)
 
@@ -50,6 +51,18 @@ locations such as /tmp, failing with `Bootstrap failed: 5: Input/output error`:
     # SMAppService queries the system domain by Label: enabled while manually
     # loaded, notFound when not loaded
 
+**CLI-identifier acceptance**: the daemon also accepts a client signed with
+the CLI identifier `com.heronapp.hostflip.cli` (same Team ID). Until the
+bundled CLI binary ships, verify by re-signing a copy of the app binary with
+the CLI identifier and handshaking:
+
+    cp /Applications/Hostflip.app/Contents/MacOS/Hostflip /tmp/Hostflip-cli-id
+    codesign --force --options runtime --identifier com.heronapp.hostflip.cli \
+        --sign "Developer ID Application: <Name> (<TEAMID>)" /tmp/Hostflip-cli-id
+    /tmp/Hostflip-cli-id --handshake
+    # expected: protocolVersion=1 daemonVersion=<version> — the CLI identifier
+    # is inside the accepted pair, so the daemon keeps the connection
+
 ## 4. Negative verification (rejection in both directions)
 
 - **Unsigned app**: on an ad-hoc build, `Hostflip --handshake` should fail
@@ -58,9 +71,9 @@ locations such as /tmp, failing with `Bootstrap failed: 5: Input/output error`:
 - **Unsigned daemon**: running an ad-hoc built `hostflipd` directly should
   exit immediately (exit code 78) with a message about the unsigned build.
 - **Daemon-side rejection** (while the step 3 load is active): copy the app
-  binary out, re-sign it with the same certificate but a wrong identifier,
-  then handshake; the daemon cuts the connection and the app side reports
-  `interrupted`:
+  binary out, re-sign it with the same certificate but an identifier outside
+  the accepted app/CLI pair, then handshake; the daemon cuts the connection
+  and the app side reports `interrupted`:
 
       cp /Applications/Hostflip.app/Contents/MacOS/Hostflip /tmp/Hostflip-wrong-id
       codesign --force --options runtime --identifier com.evil.hostflip \
@@ -101,7 +114,7 @@ locations such as /tmp, failing with `Bootstrap failed: 5: Input/output error`:
         rm -rf /Applications/Hostflip.app'
     rm -f /tmp/com.heronapp.hostflip.daemon.plist \
         /tmp/com.heronapp.hostflip.wrong-daemon.plist \
-        /tmp/Hostflip-wrong-id /tmp/hostflipd-wrong-id
+        /tmp/Hostflip-wrong-id /tmp/hostflipd-wrong-id /tmp/Hostflip-cli-id
 
 ## Verification log
 
@@ -112,6 +125,17 @@ the daemon-side wrong-identifier rejection were both reproduced; the
 "handshake interruption" item was not executed separately (error mapping is
 covered by unit tests, and the daemon-side rejection path was observed in
 practice to produce `interrupted`).
+
+2026-08-14, after relaxing the daemon-side requirement to accept the app or
+CLI identifier: steps 1–2 re-run with a Developer ID certificate — the daemon
+prints the parenthesized alternation and the app's requirement is unchanged.
+Requirement semantics checked offline with `codesign --verify -R=` against
+the signed binaries: the app identifier and a copy re-signed with the CLI
+identifier both satisfy the daemon's requirement; a third identifier (the
+daemon binary) and a wrong Team ID paired with a matching identifier both
+fail — confirming the alternation is parenthesized so the Team ID constraint
+binds on every branch. The sudo-based channel round trip (steps 3–4) was not
+re-run.
 
 2026-08-07 (later the same day), follow-up test of the app-side rejection
 path added in review: the correct app handshaking with a daemon signed by

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -19,7 +19,7 @@ swift build -c release
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Library/LaunchDaemons" \
     "$APP/Contents/Frameworks"
-cp "$BIN/Hostflip" "$APP/Contents/MacOS/Hostflip"
+cp "$BIN/HostflipApp" "$APP/Contents/MacOS/Hostflip"
 cp "$BIN/hostflipd" "$APP/Contents/MacOS/hostflipd"
 cp Packaging/HostflipApp-Info.plist "$APP/Contents/Info.plist"
 cp Packaging/Hostflip.icns "$APP/Contents/Resources/Hostflip.icns"

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -18,9 +18,12 @@ swift build -c release
 
 rm -rf "$APP"
 mkdir -p "$APP/Contents/MacOS" "$APP/Contents/Resources" "$APP/Contents/Library/LaunchDaemons" \
-    "$APP/Contents/Frameworks"
+    "$APP/Contents/Frameworks" "$APP/Contents/Helpers"
 cp "$BIN/HostflipApp" "$APP/Contents/MacOS/Hostflip"
 cp "$BIN/hostflipd" "$APP/Contents/MacOS/hostflipd"
+# The CLI lives in Helpers/, never MacOS/: APFS is case-insensitive by default,
+# so `hostflip` next to `Hostflip` would collide (ADR 0009).
+cp "$BIN/hostflip" "$APP/Contents/Helpers/hostflip"
 cp Packaging/HostflipApp-Info.plist "$APP/Contents/Info.plist"
 cp Packaging/Hostflip.icns "$APP/Contents/Resources/Hostflip.icns"
 cp Packaging/com.heronapp.hostflip.daemon.plist "$APP/Contents/Library/LaunchDaemons/"
@@ -47,11 +50,16 @@ codesign --force --options runtime $TIMESTAMP_FLAG \
     --sign "$IDENTITY" "$FRAMEWORK/Versions/B/Updater.app"
 codesign --force --options runtime $TIMESTAMP_FLAG --sign "$IDENTITY" "$FRAMEWORK"
 
-# Sign the embedded daemon first (displaced nested code), then the whole bundle.
-# The daemon is not a bundle, so its signing identifier must be set explicitly.
+# Sign the embedded daemon and CLI first (displaced nested code), then the whole
+# bundle. Neither is a bundle, so their signing identifiers must be set explicitly;
+# each executable carries its own identity (ADR 0009) and the daemon accepts either
+# the app's or the CLI's as its peer.
 codesign --force --options runtime $TIMESTAMP_FLAG \
     --identifier com.heronapp.hostflip.daemon \
     --sign "$IDENTITY" "$APP/Contents/MacOS/hostflipd"
+codesign --force --options runtime $TIMESTAMP_FLAG \
+    --identifier com.heronapp.hostflip.cli \
+    --sign "$IDENTITY" "$APP/Contents/Helpers/hostflip"
 codesign --force --options runtime $TIMESTAMP_FLAG --sign "$IDENTITY" "$APP"
 codesign --verify --strict "$APP"
 

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -113,6 +113,7 @@ echo "==> Signature acceptance gate (per object, every check is a hard failure)"
 codesign --verify --deep --strict "$APP"
 FRAMEWORK="$APP/Contents/Frameworks/Sparkle.framework"
 for T in "$APP/Contents/MacOS/Hostflip" "$APP/Contents/MacOS/hostflipd" \
+    "$APP/Contents/Helpers/hostflip" \
     "$FRAMEWORK/Versions/B/XPCServices/Installer.xpc" \
     "$FRAMEWORK/Versions/B/XPCServices/Downloader.xpc" \
     "$FRAMEWORK/Versions/B/Autoupdate" \
@@ -133,6 +134,9 @@ done
 DAEMON_INFO="$(codesign -dvv "$APP/Contents/MacOS/hostflipd" 2>&1)"
 echo "$DAEMON_INFO" | grep -q "Identifier=com.heronapp.hostflip.daemon" || \
     { echo "error: daemon signing identifier is not com.heronapp.hostflip.daemon" >&2; exit 1; }
+CLI_INFO="$(codesign -dvv "$APP/Contents/Helpers/hostflip" 2>&1)"
+echo "$CLI_INFO" | grep -q "Identifier=com.heronapp.hostflip.cli" || \
+    { echo "error: cli signing identifier is not com.heronapp.hostflip.cli" >&2; exit 1; }
 
 # notarytool --wait's exit code is not fully trustworthy; trust "status: Accepted"
 # in its output instead (observed in practice).

--- a/scripts/update-tap.sh
+++ b/scripts/update-tap.sh
@@ -26,6 +26,13 @@ if ! grep -q "^  auto_updates true$" "$CASK"; then
     sed -i '' "s|^  sha256 \"$SHA256\"$|  sha256 \"$SHA256\"\n\n  auto_updates true|" "$CASK"
     grep -q "^  auto_updates true$" "$CASK" || { echo "error: cask auto_updates insert failed" >&2; exit 1; }
 fi
+# Link the bundled CLI onto PATH. Inserted here, not pre-seeded in the cask: brew fails the
+# whole install when a binary stanza's source is missing, so the stanza must never point at
+# a shipped DMG that predates the CLI (0.1.6 and earlier).
+if ! grep -q "^  binary " "$CASK"; then
+    sed -i '' "s|^  app \"Hostflip.app\"$|  app \"Hostflip.app\"\n  binary \"#{appdir}/Hostflip.app/Contents/Helpers/hostflip\"|" "$CASK"
+    grep -q "^  binary \"#{appdir}/Hostflip.app/Contents/Helpers/hostflip\"$" "$CASK" || { echo "error: cask binary stanza insert failed" >&2; exit 1; }
+fi
 
 # Commit as the GitHub noreply identity, so the machine's global git config
 # email never leaks into the public tap.


### PR DESCRIPTION
CLI milestone 1: a standalone `hostflip` command-line companion, shipped inside the app bundle.

- **CLI binary** (`Contents/Helpers/hostflip`, signed `com.heronapp.hostflip.cli`): `status` / `list` / `cat` / `create` / `write` / `delete` / `activate` / `deactivate` / `pause` / `resume`, with name / `group/profile` / `--id` addressing, `--json` machine output with stable string error codes, and meaningful exit codes (`3` = hosts drift; the CLI reports and never reconciles).
- **Daemon**: the peer code-signing requirement now accepts the app or CLI identifier (same Team ID), with the requirement text compiled and negatively tested.
- **Cross-process coexistence**: manifest read-modify-write is serialized under a file lock; the GUI reloads-and-replays before saving and rechecks drift when an external writer announces a change.
- **Packaging**: the CLI is built, signed, and verified into the bundle by the release pipeline; the Homebrew cask gains a `binary` stanza automatically on the next release, so `brew install --cask hostflip` puts `hostflip` on PATH.
- **Docs**: README gains a Command line section and symlink guidance for direct-download users.
- **Settings**: a Command Line tab shows and copies the symlink install command with the app's real bundle path.
