### PR TITLE
feat: version flag, embedded release notes, and a settings refresh

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .executableTarget(name: "HostflipCLI", dependencies: ["HostflipCore", "HostflipXPC"]),
         .executableTarget(name: "hostflipd", dependencies: ["HostflipCore", "HostflipXPC"]),
         .testTarget(name: "HostflipCoreTests", dependencies: ["HostflipCore"]),
-        .testTarget(name: "HostflipCLITests", dependencies: ["HostflipCLI", "HostflipCore"]),
+        .testTarget(name: "HostflipCLITests", dependencies: ["HostflipCLI", "HostflipCore", "HostflipXPC"]),
         .testTarget(name: "HostflipXPCTests", dependencies: ["HostflipCore", "HostflipXPC"]),
         .testTarget(name: "HostflipTests", dependencies: ["Hostflip", "HostflipCore", "HostflipXPC"]),
     ]

--- a/Packaging/ReleaseNotes/0.1.7.html
+++ b/Packaging/ReleaseNotes/0.1.7.html
@@ -1,0 +1,6 @@
+<h2>What's New</h2>
+<ul>
+  <li><b>Command-line tool.</b> The bundle now ships a <code>hostflip</code> CLI: switch profiles, edit content, and script hostflip from the terminal. Homebrew installs put it on your PATH automatically; Settings &gt; Command Line covers direct downloads.</li>
+  <li><b>Plays well with other tools.</b> The app and the CLI share one workspace safely: saves no longer race external edits, and hosts drift is rechecked the moment another writer announces a change.</li>
+  <li><b>Fixes.</b> The drift banner no longer flashes during hostflip's own switches, and pasting a profile ID where a name is expected now hints at <code>--id</code>.</li>
+</ul>

--- a/Packaging/ReleaseNotes/0.1.8.html
+++ b/Packaging/ReleaseNotes/0.1.8.html
@@ -1,0 +1,6 @@
+<h2>What's New</h2>
+<ul>
+  <li><b>Release notes, right here.</b> Update dialogs now tell you what changed — starting with this one.</li>
+  <li><b>Version at a glance.</b> <code>hostflip --version</code> prints the bundled CLI's version (also under <code>--json</code>), so a stale PATH symlink is easy to spot.</li>
+  <li><b>Settings refresh.</b> The Settings window now follows the classic macOS app-settings layout, with a cleaner Helper pane and a roomier Command Line tab.</li>
+</ul>

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -9,36 +9,19 @@ struct ApplicationSettingsView: View {
     let launchAtLoginStore: LaunchAtLoginStore
     let updater: SPUUpdater
 
+    // All four tabs share the classic settings-form look of Apple's own app
+    // settings windows (right-aligned label column, controls left-aligned,
+    // captions under their controls) — the app-settings convention, distinct
+    // from the System Settings grouped cards. Top-aligned so switching tabs
+    // never jumps; growth goes in as new rows — e.g. a future appearance
+    // picker joins General.
     var body: some View {
         TabView {
-            Form {
-                Picker(
-                    "Show Dock Icon",
-                    selection: Binding(
-                        get: { dockIconStore.policy },
-                        set: { dockIconStore.setPolicy($0) }
-                    )
-                ) {
-                    ForEach(DockIconVisibilityPolicy.allCases, id: \.rawValue) { policy in
-                        Text(policy.title).tag(policy)
-                    }
-                }
-
-                Text("The menu bar icon is always shown.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-
-                Toggle("Launch at Login", isOn: Binding(
-                    get: { launchAtLoginStore.isEnabled },
-                    set: { launchAtLoginStore.setEnabled($0) }
-                ))
-
-                Text("hostflip starts silently in the menu bar when you log in.")
-                    .font(.callout)
-                    .foregroundStyle(.secondary)
-            }
-            .padding(20)
-            .frame(width: 460, height: 190)
+            GeneralSettingsView(
+                dockIconStore: dockIconStore,
+                launchAtLoginStore: launchAtLoginStore
+            )
+            .frame(width: 500, height: 170, alignment: .top)
             .tabItem {
                 Label("General", systemImage: "gearshape")
             }
@@ -46,27 +29,58 @@ struct ApplicationSettingsView: View {
             // Second home of helper management alongside the toolbar popover (#41):
             // Settings is where users expect to find privileged-component removal,
             // e.g. before uninstalling. The extra height leaves room for feedback.
-            HelperMaintenanceSection(store: store, maintenanceStore: maintenanceStore)
-                .padding(20)
-                .frame(width: 460, height: 230, alignment: .topLeading)
+            HelperSettingsPane(store: store, maintenanceStore: maintenanceStore)
+                .frame(width: 500, height: 180, alignment: .topLeading)
                 .tabItem {
                     Label("Helper", systemImage: "gearshape.2")
                 }
 
             CLIInstallSection()
-                .padding(20)
-                .frame(width: 460, height: 250, alignment: .topLeading)
+                .frame(width: 500, height: 260, alignment: .topLeading)
                 .tabItem {
                     Label("Command Line", systemImage: "terminal")
                 }
 
             UpdatesSettingsView(updater: updater)
-                .padding(20)
-                .frame(width: 460, height: 190)
+                .frame(width: 500, height: 150, alignment: .top)
                 .tabItem {
                     Label("Updates", systemImage: "arrow.triangle.2.circlepath")
                 }
         }
+    }
+}
+
+/// Everyday preferences; future rows (an appearance picker, say) join as more rows.
+private struct GeneralSettingsView: View {
+    let dockIconStore: DockIconVisibilityStore
+    let launchAtLoginStore: LaunchAtLoginStore
+
+    var body: some View {
+        Form {
+            Picker(
+                "Show Dock Icon",
+                selection: Binding(
+                    get: { dockIconStore.policy },
+                    set: { dockIconStore.setPolicy($0) }
+                )
+            ) {
+                ForEach(DockIconVisibilityPolicy.allCases, id: \.rawValue) { policy in
+                    Text(policy.title).tag(policy)
+                }
+            }
+            Text("The menu bar icon is always shown.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
+            Toggle("Launch at Login", isOn: Binding(
+                get: { launchAtLoginStore.isEnabled },
+                set: { launchAtLoginStore.setEnabled($0) }
+            ))
+            Text("hostflip starts silently in the menu bar when you log in.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+        }
+        .padding(20)
     }
 }
 
@@ -95,6 +109,7 @@ private struct UpdatesSettingsView: View {
 
             CheckForUpdatesButton(updater: updater)
         }
+        .padding(20)
     }
 }
 

--- a/Sources/Hostflip/CLIInstallView.swift
+++ b/Sources/Hostflip/CLIInstallView.swift
@@ -81,16 +81,12 @@ struct CLIInstallSection: View {
     var body: some View {
         let presentation = CLIInstallPresentation(cliPath: cliPath, linkState: linkState)
         VStack(alignment: .leading, spacing: 14) {
-            VStack(alignment: .leading, spacing: 8) {
-                Label("Command-Line Tool", systemImage: "terminal")
-                    .font(.subheadline.weight(.semibold))
-                Text(
-                    "The bundled hostflip command drives the same profiles and helper as the app. Homebrew puts it on your PATH automatically; for a direct download, run this once in Terminal:"
-                )
-                .font(.callout)
-                .foregroundStyle(.secondary)
-                .fixedSize(horizontal: false, vertical: true)
-            }
+            Text(
+                "The bundled hostflip command drives the same profiles and helper as the app. Homebrew puts it on your PATH automatically; for a direct download, run this once in Terminal:"
+            )
+            .font(.callout)
+            .foregroundStyle(.secondary)
+            .fixedSize(horizontal: false, vertical: true)
 
             Text(presentation.command)
                 .font(.system(.callout, design: .monospaced))
@@ -100,30 +96,29 @@ struct CLIInstallSection: View {
                 .frame(maxWidth: .infinity, alignment: .leading)
                 .background(.quaternary.opacity(0.5), in: RoundedRectangle(cornerRadius: 6))
 
-            HStack {
-                HStack(spacing: 5) {
-                    Image(systemName: "circle.fill")
-                        .font(.system(size: 7))
-                        .foregroundStyle(presentation.statusColor)
-                    Text(presentation.statusTitle)
-                        .font(.caption)
-                        .lineLimit(1)
-                        .truncationMode(.middle)
-                }
-                Spacer()
-                Button(isShowingCopied ? "Copied" : "Copy Command") {
-                    let pasteboard = NSPasteboard.general
-                    pasteboard.clearContents()
-                    pasteboard.setString(presentation.command, forType: .string)
-                    isShowingCopied = true
-                    Task {
-                        try? await Task.sleep(for: .seconds(1.5))
-                        isShowingCopied = false
-                    }
-                }
-                .disabled(isShowingCopied)
+            HStack(spacing: 5) {
+                Image(systemName: "circle.fill")
+                    .font(.system(size: 7))
+                    .foregroundStyle(presentation.statusColor)
+                Text(presentation.statusTitle)
+                    .font(.caption)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
             }
+
+            Button(isShowingCopied ? "Copied" : "Copy Command") {
+                let pasteboard = NSPasteboard.general
+                pasteboard.clearContents()
+                pasteboard.setString(presentation.command, forType: .string)
+                isShowingCopied = true
+                Task {
+                    try? await Task.sleep(for: .seconds(1.5))
+                    isShowingCopied = false
+                }
+            }
+            .disabled(isShowingCopied)
         }
+        .padding(20)
         .task { linkState = CLIInstallProbe.linkState(at: CLIInstallPresentation.linkPath) }
     }
 }

--- a/Sources/Hostflip/HelperMaintenanceView.swift
+++ b/Sources/Hostflip/HelperMaintenanceView.swift
@@ -111,7 +111,6 @@ struct HelperMaintenanceSection: View {
     let maintenanceStore: MaintenanceStore
     /// Runs before jumping to System Settings; the popover closes itself here.
     var beforeOpeningSystemSettings: () -> Void = {}
-    @State private var isConfirmingRemoval = false
 
     var body: some View {
         let helperPresentation = HelperStatusPresentation(maintenanceStore.helperStatus)
@@ -134,15 +133,8 @@ struct HelperMaintenanceSection: View {
                             }
                         }
                         Spacer()
-                        if maintenanceStore.isRemovingHelper {
-                            ProgressView()
-                                .controlSize(.small)
-                        }
                         if helperPresentation.canRemove {
-                            Button(removalButtonTitle, role: .destructive) {
-                                isConfirmingRemoval = true
-                            }
-                            .disabled(maintenanceStore.isRemovingHelper)
+                            HelperRemovalButton(maintenanceStore: maintenanceStore)
                         }
                     }
                     .controlSize(.small)
@@ -150,26 +142,68 @@ struct HelperMaintenanceSection: View {
             }
 
             if let feedback = maintenanceStore.feedback {
-                let feedbackPresentation = feedback.presentation
-                Label {
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(feedbackPresentation.title)
-                            .fontWeight(.semibold)
-                        Text(feedbackPresentation.message)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                } icon: {
-                    Image(
-                        systemName: feedbackPresentation.isFailure
-                            ? "xmark.octagon.fill"
-                            : "checkmark.circle.fill"
-                    )
-                }
-                .font(.callout)
-                .foregroundStyle(feedbackPresentation.isFailure ? .red : .green)
+                MaintenanceFeedbackLabel(feedback: feedback)
             }
         }
         .task { await maintenanceStore.refreshHelperStatus() }
+    }
+}
+
+/// Settings > Helper: the same status and removal flow as the popover, laid out as a
+/// label-less full-width block like the Command Line tab (the tab title already names
+/// the pane). Both homes share the store and the controls below, so they can never
+/// disagree (#41).
+struct HelperSettingsPane: View {
+    let store: WorkspaceStore
+    let maintenanceStore: MaintenanceStore
+
+    var body: some View {
+        let presentation = HelperStatusPresentation(maintenanceStore.helperStatus)
+        VStack(alignment: .leading, spacing: 14) {
+            VStack(alignment: .leading, spacing: 6) {
+                HelperStatusLabel(status: maintenanceStore.helperStatus)
+                Text(presentation.description)
+                    .font(.callout)
+                    .foregroundStyle(.secondary)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if presentation.canOpenApprovalSettings {
+                Button("Open System Settings…") {
+                    store.openApprovalSettings()
+                }
+            }
+
+            if presentation.canRemove {
+                HelperRemovalButton(maintenanceStore: maintenanceStore)
+            }
+
+            if let feedback = maintenanceStore.feedback {
+                MaintenanceFeedbackLabel(feedback: feedback)
+            }
+        }
+        .padding(20)
+        .task { await maintenanceStore.refreshHelperStatus() }
+    }
+}
+
+/// The destructive removal flow — confirmation dialog, in-flight progress, retry title —
+/// shared by the popover and Settings so the two homes can never diverge.
+struct HelperRemovalButton: View {
+    let maintenanceStore: MaintenanceStore
+    @State private var isConfirmingRemoval = false
+
+    var body: some View {
+        HStack {
+            if maintenanceStore.isRemovingHelper {
+                ProgressView()
+                    .controlSize(.small)
+            }
+            Button(title, role: .destructive) {
+                isConfirmingRemoval = true
+            }
+            .disabled(maintenanceStore.isRemovingHelper)
+        }
         .confirmationDialog(
             "Deactivate and Remove Helper?",
             isPresented: $isConfirmingRemoval,
@@ -183,10 +217,35 @@ struct HelperMaintenanceSection: View {
         }
     }
 
-    private var removalButtonTitle: String {
+    private var title: String {
         if case .helperRemovalFailed = maintenanceStore.feedback {
             return "Retry Remove Helper…"
         }
         return "Deactivate and Remove Helper…"
+    }
+}
+
+/// Outcome of the last maintenance operation, rendered identically in both homes.
+struct MaintenanceFeedbackLabel: View {
+    let feedback: MaintenanceFeedback
+
+    var body: some View {
+        let presentation = feedback.presentation
+        Label {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(presentation.title)
+                    .fontWeight(.semibold)
+                Text(presentation.message)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+        } icon: {
+            Image(
+                systemName: presentation.isFailure
+                    ? "xmark.octagon.fill"
+                    : "checkmark.circle.fill"
+            )
+        }
+        .font(.callout)
+        .foregroundStyle(presentation.isFailure ? .red : .green)
     }
 }

--- a/Sources/HostflipCLI/CLI.swift
+++ b/Sources/HostflipCLI/CLI.swift
@@ -27,6 +27,7 @@ enum CLI {
           --id <id>      Address a profile by its unique ID
           --file <path>  Read the new content for 'write' from a file instead of stdin
           --json         Machine-readable output: result object on stdout, JSON errors on stderr
+          --version      Print the version and exit
           --help         Show this help
         """
 
@@ -46,14 +47,19 @@ enum CLI {
             if invocation.wantsHelp {
                 return CLIResult(exitCode: .success, standardOutput: usageText + "\n", standardError: "")
             }
-            let payload = try await dispatch(
-                invocation,
-                workspace: Workspace(rootDirectory: workspaceRootDirectory),
-                systemHostsURL: systemHostsURL,
-                makeHostsMerger: makeHostsMerger,
-                postWorkspaceChanged: postWorkspaceChanged,
-                readStandardInput: readStandardInput
-            )
+            let payload: any CommandPayload
+            if invocation.wantsVersion {
+                payload = VersionPayload()
+            } else {
+                payload = try await dispatch(
+                    invocation,
+                    workspace: Workspace(rootDirectory: workspaceRootDirectory),
+                    systemHostsURL: systemHostsURL,
+                    makeHostsMerger: makeHostsMerger,
+                    postWorkspaceChanged: postWorkspaceChanged,
+                    readStandardInput: readStandardInput
+                )
+            }
             let output: String
             if wantsJSON {
                 output = CLIJSON.encode(payload) + "\n"
@@ -77,9 +83,17 @@ enum CLI {
 
     private struct Invocation {
         var wantsHelp = false
+        var wantsVersion = false
         var profileID: String?
         var filePath: String?
         var commandArguments: [String] = []
+    }
+
+    /// The CLI ships in the app bundle at the app's version (ADR-0009), so this is the one
+    /// version constant release.sh already guards against the bundle plist.
+    private struct VersionPayload: CommandPayload {
+        let version = HostflipBuild.version
+        var humanText: String { version }
     }
 
     private static func parse(_ arguments: [String]) throws -> Invocation {
@@ -91,6 +105,8 @@ enum CLI {
                 break // Handled by the argv scan in run.
             case "--help", "-h":
                 invocation.wantsHelp = true
+            case "--version":
+                invocation.wantsVersion = true
             case "--id":
                 guard let value = iterator.next() else {
                     throw CLIError.usage("option '--id' requires a value")

--- a/Tests/HostflipCLITests/CLITests.swift
+++ b/Tests/HostflipCLITests/CLITests.swift
@@ -1,4 +1,5 @@
 import HostflipCore
+import HostflipXPC
 import XCTest
 @testable import HostflipCLI
 
@@ -401,6 +402,24 @@ final class CLITests: XCTestCase {
         XCTAssertTrue(result.standardOutput.contains("list"))
         XCTAssertTrue(result.standardOutput.contains("cat"))
         XCTAssertTrue(result.standardOutput.contains("--id"))
+    }
+
+    func testVersionPrintsTheBundleVersionAndSucceeds() async throws {
+        let result = await invoke("--version")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        XCTAssertEqual(result.standardOutput, HostflipBuild.version + "\n")
+        XCTAssertTrue(CLI.usageText.contains("--version"))
+    }
+
+    func testVersionWithJSONEmitsAVersionObject() async throws {
+        let result = await invoke("--json", "--version")
+
+        XCTAssertEqual(result.exitCode, .success)
+        XCTAssertEqual(result.standardError, "")
+        let object = try jsonObject(result.standardOutput)
+        XCTAssertEqual(object["version"] as? String, HostflipBuild.version)
     }
 
     func testExitCodeFrameworkPinsTheNumericContract() {

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -56,6 +56,11 @@ echo "$BUILD" | grep -Eq '^[1-9][0-9]*$' || \
 # Dual version source (see ADR 0003): the plist and HostflipBuild.version must agree.
 grep -qF "public static let version = \"$VER\"" Sources/HostflipXPC/ChannelIdentity.swift || \
     { echo "error: HostflipBuild.version disagrees with $VER in $PLIST (the two locations must be updated together)" >&2; exit 1; }
+# Release notes are embedded into the Sparkle update dialog; failing here, before the build
+# investment, keeps "write the notes" a hard part of every release instead of a skipped nicety.
+NOTES="Packaging/ReleaseNotes/$VER.html"
+[ -f "$NOTES" ] || \
+    { echo "error: missing $NOTES (write the user-facing notes for $VER before releasing)" >&2; exit 1; }
 
 # Compare against the highest released tag on the remote: both the semantic
 # version and the build version must strictly increase.
@@ -181,13 +186,18 @@ spctl --assess --type open --context context:primary-signature "$DIST/$NAME.dmg"
     { echo "error: Gatekeeper (open) rejected the DMG" >&2; exit 1; }
 
 echo "==> Appcast (EdDSA-signed enclosure for the Sparkle feed)"
-"$SPARKLE_TOOLS/bin/generate_appcast" --account hostflip \
+# generate_appcast picks up release notes from an HTML file named like the archive.
+cp "$NOTES" "$DIST/$NAME.html"
+"$SPARKLE_TOOLS/bin/generate_appcast" --account hostflip --embed-release-notes \
     --download-url-prefix "https://github.com/heronapp/hostflip/releases/download/v$VER/" \
     -o "$DIST/appcast.xml" "$DIST"
+rm -f "$DIST/$NAME.html" # consumed into the appcast; keep $DIST holding release assets only
 grep -q "<sparkle:shortVersionString>$VER</sparkle:shortVersionString>" "$DIST/appcast.xml" || \
     { echo "error: appcast.xml does not contain version $VER" >&2; exit 1; }
 grep -q "sparkle:edSignature=" "$DIST/appcast.xml" || \
     { echo "error: appcast.xml enclosure carries no EdDSA signature" >&2; exit 1; }
+grep -q "<description>" "$DIST/appcast.xml" || \
+    { echo "error: appcast.xml carries no embedded release notes" >&2; exit 1; }
 
 if [ "$PUBLISH" -eq 0 ]; then
     echo "==> Done (--no-publish, GitHub untouched): $DIST/$NAME.dmg"


### PR DESCRIPTION
Three changes riding the 0.1.8 release:

- **`hostflip --version`**: prints the bundle version (as `{"version":…}` under `--json`), answering the stale-symlink question directly — the CLI ships at the app's version, and release tooling already guards the two version sources against each other.
- **Release notes in the update dialog**: each release now requires hand-written notes at `Packaging/ReleaseNotes/<ver>.html`, guarded before the build investment; `generate_appcast --embed-release-notes` embeds them into the appcast so Sparkle renders them offline. The 0.1.7 and 0.1.8 notes are included.
- **Settings refresh**: the four tabs now share the classic macOS app-settings layout (label column, top-aligned, no in-pane headers duplicating tab titles); the destructive helper-removal flow moved into a control shared by Settings and the toolbar popover so the two homes cannot diverge.