### PR TITLE
build: bump version to 0.1.8

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -15,9 +15,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.7</string>
+	<string>0.1.8</string>
 	<key>CFBundleVersion</key>
-	<string>8</string>
+	<string>9</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -16,5 +16,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.1.7"
+    public static let version = "0.1.8"
 }


### PR DESCRIPTION
Release bump for v0.1.8 (#19).