### PR TITLE
feat: appearance setting, in-app language setting, and three localizations

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -56,6 +56,10 @@ _Avoid_: auto-start, boot launch
 The app-wide light/dark preference — Auto (follow the system), Light, or Dark; a forced choice applies to every hostflip window, while the menu bar icon always follows the menu bar itself.
 _Avoid_: theme, dark mode
 
+**Language**:
+The app-wide language preference — System (follow the system) or one of the shipped languages; shares its stored state with macOS's per-app language setting and takes effect after relaunching hostflip.
+_Avoid_: locale (for this setting), translation setting
+
 **Workspace**:
 hostflip's persistence directory; holds Base Hosts, the profile files, the manifest, and the original backup from first capture (hosts.orig).
 _Avoid_: data directory, config directory

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -29,7 +29,7 @@ The current content of the real `/etc/hosts`; shown live and read-only in the ma
 _Avoid_: Base Hosts
 
 **Active**:
-The state of a profile that is selected and participates in the merge.
+The state of a profile that is selected for the merge; it participates whenever hostflip is not Paused, and the selection is preserved — but not applied — while Paused.
 _Avoid_: enabled, turned on
 
 **Merge**:

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -52,6 +52,10 @@ _Avoid_: menu-bar-only mode, menu bar switch
 Whether hostflip registers itself as a login item to start automatically at login; login launches stay silent in the menu bar without opening the main window.
 _Avoid_: auto-start, boot launch
 
+**Appearance**:
+The app-wide light/dark preference — Auto (follow the system), Light, or Dark; a forced choice applies to every hostflip window, while the menu bar icon always follows the menu bar itself.
+_Avoid_: theme, dark mode
+
 **Workspace**:
 hostflip's persistence directory; holds Base Hosts, the profile files, the manifest, and the original backup from first capture (hosts.orig).
 _Avoid_: data directory, config directory

--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -2,10 +2,19 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
 	<key>CFBundleExecutable</key>
 	<string>Hostflip</string>
 	<key>CFBundleIconFile</key>
 	<string>Hostflip.icns</string>
+	<key>CFBundleLocalizations</key>
+	<array>
+		<string>en</string>
+		<string>zh-Hans</string>
+		<string>zh-Hant</string>
+		<string>ja</string>
+	</array>
 	<key>CFBundleIdentifier</key>
 	<string>com.heronapp.hostflip</string>
 	<key>CFBundleInfoDictionaryVersion</key>

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -1,0 +1,206 @@
+/* Menu bar */
+"Enable hostflip" = "hostflip を有効にする";
+"Hosts file changed externally — Review…" = "hosts ファイルが外部で変更されました — 確認…";
+"No profiles yet — create one…" = "プロファイルがまだありません — 作成…";
+"Open hostflip…" = "hostflip を開く…";
+"Settings…" = "設定…";
+"Quit hostflip" = "hostflip を終了";
+"hostflip" = "hostflip";
+"hostflip, paused" = "hostflip、一時停止中";
+"hostflip, hosts drift detected" = "hostflip、外部変更を検出";
+"hostflip, paused, hosts drift detected" = "hostflip、一時停止中、外部変更を検出";
+
+/* Shared buttons */
+"Open System Settings…" = "システム設定を開く…";
+"Later" = "後で";
+"OK" = "OK";
+"Retry" = "再試行";
+"Delete" = "削除";
+
+/* Settings window */
+"General" = "一般";
+"Helper" = "ヘルパー";
+"Command Line" = "コマンドライン";
+"Updates" = "アップデート";
+"Appearance" = "外観";
+"Auto follows the system appearance." = "「自動」はシステムの外観に従います。";
+"Language" = "言語";
+"System" = "システムデフォルト";
+"Takes effect after relaunching hostflip." = "hostflip の再起動後に有効になります。";
+"Relaunch Now" = "今すぐ再起動";
+"Show Dock Icon" = "Dock アイコンを表示";
+"The menu bar icon is always shown." = "メニューバーアイコンは常に表示されます。";
+"Launch at Login" = "ログイン時に起動";
+"hostflip starts silently in the menu bar when you log in." = "ログインすると、hostflip はウインドウを表示せずにメニューバーで起動します。";
+"Current Version" = "現在のバージョン";
+"Automatically check for updates" = "アップデートを自動的に確認";
+"Check for Updates" = "アップデートを確認";
+"Auto" = "自動";
+"Light" = "ライト";
+"Dark" = "ダーク";
+"When Main Window Is Open" = "メインウインドウを開いている間";
+"Always" = "常に";
+"Never" = "しない";
+
+/* Sidebar and creation */
+"System Hosts" = "システム hosts";
+"Base Hosts" = "ベース hosts";
+"Standalone Profiles" = "グループ外のプロファイル";
+"Drag to Move" = "ドラッグして移動";
+"Drag to move" = "ドラッグして移動";
+"No Profiles Yet" = "プロファイルはまだありません";
+"Create a profile to switch hosts without changing Base Hosts." = "プロファイルを作成すると、ベース hosts を変更せずに hosts を切り替えられます。";
+"Create Profile" = "プロファイルを作成";
+"New" = "新規";
+"New Profile" = "新規プロファイル";
+"New Group" = "新規グループ";
+"PROFILE_DEFAULT_NAME" = "新規プロファイル";
+"PROFILE_DEFAULT_NAME_NUMBERED" = "新規プロファイル %lld";
+"GROUP_DEFAULT_NAME" = "新規グループ";
+"GROUP_DEFAULT_NAME_NUMBERED" = "新規グループ %lld";
+"Group Name" = "グループ名";
+"Rename Group…" = "グループの名前を変更…";
+"Move Up" = "上に移動";
+"Move Down" = "下に移動";
+"Delete Group…" = "グループを削除…";
+"Rename Profile…" = "プロファイルの名前を変更…";
+"Move To" = "移動先";
+"Delete Profile…" = "プロファイルを削除…";
+"Profile Actions" = "プロファイルの操作";
+"Group Actions" = "グループの操作";
+"Actions for %@" = "%@ の操作";
+"Expand %@" = "%@ を展開";
+"Collapse %@" = "%@ を折りたたむ";
+"Expand Group" = "グループを展開";
+"Collapse Group" = "グループを折りたたむ";
+"Select for editing. Drag to move." = "選択して編集。ドラッグして移動。";
+"Activate %@" = "%@ を適用する";
+"Deactivate %@" = "%@ の適用を解除する";
+"Active" = "適用中";
+"Inactive" = "未適用";
+"Saved Active" = "選択済み（一時停止中）";
+"Make Active" = "適用する";
+"Delete Profile" = "プロファイルを削除";
+"Group: %@ · One profile active at a time" = "グループ: %@ · 同時に適用できるのは 1 つのプロファイルのみ";
+"Standalone profile · Toggles independently" = "グループ外のプロファイル · 個別に切り替え";
+
+/* Delete confirmations */
+"Delete “%@”?" = "「%@」を削除しますか？";
+"The profile’s content will be removed. Base hosts and other profiles are not affected." = "このプロファイルの内容は削除されます。ベース hosts とほかのプロファイルには影響しません。";
+"Delete Group" = "グループを削除";
+"The empty group will be deleted. Base hosts and other groups are not affected." = "この空のグループは削除されます。ベース hosts とほかのグループには影響しません。";
+"Its profile will move to Standalone Profiles. Its content and active state will be preserved. Base hosts and other groups are not affected." = "グループ内のプロファイルはグループ外のプロファイルへ移動します。内容と適用状態は保持されます。ベース hosts とほかのグループには影響しません。";
+"Its %lld profiles will move to Standalone Profiles in the current order. Their content and active state will be preserved. Base hosts and other groups are not affected." = "グループ内の %lld 個のプロファイルは現在の順序のままグループ外のプロファイルへ移動します。内容と適用状態は保持されます。ベース hosts とほかのグループには影響しません。";
+
+/* Banner and drift review */
+"Paused — selections are saved but not applied to the system hosts file." = "一時停止中 — 選択は保存されていますが、システム hosts ファイルには適用されません。";
+"System hosts changed outside hostflip. Review the drift to continue switching." = "システム hosts が hostflip の外部で変更されました。切り替えを続けるには外部変更を確認してください。";
+"Review Drift" = "外部変更を確認";
+"Helper approval is required before switching profiles." = "プロファイルを切り替えるには、先にヘルパーの承認が必要です。";
+"Dismiss Status" = "ステータスを閉じる";
+"Review Hosts Drift" = "hosts の外部変更を確認";
+"Review what changed outside hostflip before switching profiles again." = "再度切り替える前に、hostflip の外部で行われた変更を確認してください。";
+"+%lld in system hosts" = "システム hosts に %lld 行追加";
+"−%lld expected" = "想定より %lld 行不足";
+"Recommended: add drifted lines to Base Hosts so they are preserved. Discarding replaces the system file with hostflip’s active state." = "推奨: 外部から追加された行をベース hosts に追加して保持します。破棄すると、システム hosts ファイルは hostflip の現在の適用状態で置き換えられます。";
+"Diff Unavailable" = "差分を表示できません";
+"hostflip could not read the current system hosts file." = "hostflip は現在のシステム hosts ファイルを読み込めませんでした。";
+"Reconciling…" = "外部変更を処理中…";
+"Use System Hosts as Base…" = "システム hosts をベースとして使用…";
+"Use System Hosts as Base" = "システム hosts をベースとして使用";
+"Use the current System Hosts as Base Hosts?" = "現在のシステム hosts をベース hosts として使用しますか？";
+"Discard Drift" = "外部変更を破棄";
+"Add to Base Hosts" = "ベース hosts に追加";
+"This replaces the current Base Hosts without creating an undo copy. The original hosts.orig backup and /etc/hosts will not be changed." = "この操作は現在のベース hosts を置き換えます。取り消し用のコピーは作成されません。元の hosts.orig バックアップと /etc/hosts は変更されません。";
+
+/* Editor panes */
+"/etc/hosts · Read Only" = "/etc/hosts · 読み出しのみ";
+"Cannot Read System Hosts" = "システム hosts を読み込めません";
+"The current /etc/hosts content is unavailable." = "現在の /etc/hosts の内容を取得できません。";
+"Protected · Read Only" = "保護済み · 読み出しのみ";
+"Always Active" = "常に適用";
+"Profile Name" = "プロファイル名";
+"Open Maintenance" = "メンテナンスを開く";
+
+/* Switch feedback */
+"System Hosts Updated" = "システム hosts を更新しました";
+"Base Hosts Replaced" = "ベース hosts を置き換えました";
+"Approval Required" = "承認が必要";
+"Helper Unavailable" = "ヘルパーを利用できません";
+"Hosts Drift Detected" = "外部変更を検出";
+"Switch Failed" = "切り替えに失敗";
+"System hosts file updated" = "システム hosts ファイルを更新しました";
+"Base Hosts replaced with the current /etc/hosts content. The system file was not changed." = "ベース hosts を現在の /etc/hosts の内容で置き換えました。システムファイル自体は変更されていません。";
+"Switch blocked: hostflip’s background helper needs system approval" = "切り替えはブロックされました: hostflip のバックグラウンドヘルパーにはシステムの承認が必要です";
+"Helper unavailable: move the app to the Applications folder and reopen it" = "ヘルパーを利用できません: アプリを「アプリケーション」フォルダに移動してから開き直してください";
+"Switch blocked: system hosts contains changes made outside hostflip" = "切り替えはブロックされました: システム hosts に hostflip の外部で行われた変更が含まれています";
+
+/* Workspace errors */
+"Cannot open workspace: %@" = "ワークスペースを開けません: %@";
+"Cannot display /etc/hosts because it is not valid UTF-8." = "/etc/hosts は有効な UTF-8 ではないため表示できません。";
+"Cannot read /etc/hosts: %@" = "/etc/hosts を読み込めません: %@";
+"System hosts was updated, but DNS refresh failed: %@" = "システム hosts は更新されましたが、DNS の更新に失敗しました: %@";
+"Failed to update the system hosts file: %@" = "システム hosts ファイルの更新に失敗しました: %@";
+"Switch failed: %@" = "切り替えに失敗しました: %@";
+"Save failed: %@" = "保存に失敗しました: %@";
+"System hosts changed again. Review the latest diff before retrying." = "システム hosts が再び変更されました。最新の差分を確認してから再試行してください。";
+"Failed to reconcile the system hosts file: %@" = "システム hosts ファイルの外部変更を処理できませんでした: %@";
+"Hosts reconciliation failed: %@" = "hosts の外部変更の処理に失敗しました: %@";
+"Wait for the current hosts operation to finish." = "現在の hosts 操作が完了するまでお待ちください。";
+"No unresolved hosts drift is available to adopt." = "採用できる未処理の外部変更はありません。";
+"Deactivate every active profile before using System Hosts as Base Hosts." = "システム hosts をベース hosts として使用する前に、すべてのプロファイルの適用を解除してください。";
+"System Hosts must be valid UTF-8 before it can replace Base Hosts." = "ベース hosts を置き換えるには、システム hosts が有効な UTF-8 である必要があります。";
+"System Hosts already contains hostflip-generated sections and cannot be used as Base Hosts." = "システム hosts にはすでに hostflip が生成したセクションが含まれているため、ベース hosts として使用できません。";
+"Base Hosts could not be replaced: %@" = "ベース hosts を置き換えられませんでした: %@";
+"System hosts changed while reconciliation was in progress. Review the latest diff before retrying." = "外部変更の処理中にシステム hosts が変更されました。最新の差分を確認してから再試行してください。";
+"System hosts was updated, but the reconciliation could not be saved: %@" = "システム hosts は更新されましたが、外部変更の処理結果を保存できませんでした: %@";
+"Changes were saved locally, but the system hosts file could not be updated: %@" = "変更はローカルに保存されましたが、システム hosts ファイルを更新できませんでした: %@";
+"Changes were saved locally, but this build is not properly signed, so the system hosts file could not be updated." = "変更はローカルに保存されましたが、このビルドは正しく署名されていないため、システム hosts ファイルを更新できませんでした。";
+
+/* Import / export */
+"Import…" = "読み込む…";
+"Export…" = "書き出す…";
+"Import Failed" = "読み込みに失敗";
+"Export Failed" = "書き出しに失敗";
+"Nothing was exported: %@" = "何も書き出されませんでした: %@";
+"Nothing was imported: the workspace is not loaded." = "何も読み込まれませんでした: ワークスペースがまだ開かれていません。";
+"Nothing was imported: %@" = "何も読み込まれませんでした: %@";
+"this file was created by a newer version of hostflip (format version %lld)" = "このファイルは、現在使用している hostflip より新しいバージョンで作成されました（フォーマットバージョン %lld）";
+"this file is JSON but not a valid hostflip export" = "このファイルは JSON ですが、有効な hostflip の書き出しファイルではありません";
+"the export contains a profile or group with an empty name" = "書き出し内容に名前が空のプロファイルまたはグループが含まれています";
+"this file is not UTF-8 text" = "このファイルは UTF-8 テキストではありません";
+"Nothing was imported. %@: %@." = "何も読み込まれませんでした。%@: %@。";
+
+/* Helper maintenance */
+"Helper Ready" = "ヘルパーは準備完了";
+"The helper is approved and ready to update the system hosts file." = "ヘルパーは承認済みで、システム hosts ファイルを更新できます。";
+"Helper Approval Required" = "ヘルパーの承認が必要";
+"The helper is waiting for approval in System Settings. Switching remains blocked until it is approved." = "ヘルパーはシステム設定での承認を待っています。承認されるまで切り替えはブロックされます。";
+"Helper Not Installed" = "ヘルパー未インストール";
+"Switch a profile to install the helper. macOS may ask you to approve it." = "プロファイルを切り替えるとヘルパーがインストールされます。macOS が承認を求める場合があります。";
+"Checking Helper…" = "ヘルパーを確認中…";
+"Checking the helper registration status…" = "ヘルパーの登録状況を確認しています…";
+"Maintenance" = "メンテナンス";
+"Background Helper" = "バックグラウンドヘルパー";
+"Deactivate and Remove Helper?" = "ヘルパーを無効にして削除しますか？";
+"Deactivate and Remove" = "無効にして削除";
+"hostflip will remove its privileged helper. Your profiles and base hosts will stay in the workspace. The helper will be requested again on your next switch.\n\nThe system hosts file keeps its current content — entries from active profiles stay in effect. To leave only Base Hosts applied (e.g. before uninstalling), turn off the master switch first." = "hostflip は特権ヘルパーを削除します。プロファイルとベース hosts はワークスペースに残ります。次回の切り替え時にヘルパーのインストールが再度求められます。\n\nシステム hosts ファイルは現在の内容のまま保持され、適用中のプロファイルのエントリは有効なままです。ベース hosts のみを残したい場合（アンインストール前など）は、先にマスタースイッチをオフにしてください。";
+"Retry Remove Helper…" = "ヘルパーの削除を再試行…";
+"Deactivate and Remove Helper…" = "ヘルパーを無効にして削除…";
+"Helper Removed" = "ヘルパーを削除しました";
+"The helper was deactivated and removed. Your profiles were not changed." = "ヘルパーを無効にして削除しました。プロファイルは変更されていません。";
+"Could Not Remove Helper" = "ヘルパーを削除できませんでした";
+"Could not remove the helper. Try again. Your profiles were not changed. %@" = "ヘルパーを削除できませんでした。もう一度お試しください。プロファイルは変更されていません。%@";
+
+/* Command line tab */
+"Not linked yet" = "まだリンクされていません";
+"Linked at %@" = "%@ にリンク済み";
+"Links elsewhere: %@" = "別の場所へのリンク: %@";
+"Something else occupies %@" = "%@ には別のファイルが存在します";
+"The bundled hostflip command drives the same profiles and helper as the app. Homebrew puts it on your PATH automatically; for a direct download, run this once in Terminal:" = "同梱の hostflip コマンドは、アプリと同じプロファイルとヘルパーを操作します。Homebrew でインストールした場合は自動的に PATH に追加されます。直接ダウンロードした場合は、ターミナルで次のコマンドを一度実行してください:";
+"Copied" = "コピーしました";
+"Copy Command" = "コマンドをコピー";
+
+/* Titlebar switch */
+"Resume hostflip" = "hostflip を再開";
+"Pause hostflip" = "hostflip を一時停止";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -1,0 +1,206 @@
+/* Menu bar */
+"Enable hostflip" = "启用 hostflip";
+"Hosts file changed externally — Review…" = "hosts 文件被外部更改 — 查看…";
+"No profiles yet — create one…" = "还没有方案 — 新建一个…";
+"Open hostflip…" = "打开 hostflip…";
+"Settings…" = "设置…";
+"Quit hostflip" = "退出 hostflip";
+"hostflip" = "hostflip";
+"hostflip, paused" = "hostflip，已暂停";
+"hostflip, hosts drift detected" = "hostflip，检测到外部更改";
+"hostflip, paused, hosts drift detected" = "hostflip，已暂停，检测到外部更改";
+
+/* Shared buttons */
+"Open System Settings…" = "打开系统设置…";
+"Later" = "稍后";
+"OK" = "好";
+"Retry" = "重试";
+"Delete" = "删除";
+
+/* Settings window */
+"General" = "通用";
+"Helper" = "辅助程序";
+"Command Line" = "命令行";
+"Updates" = "更新";
+"Appearance" = "外观";
+"Auto follows the system appearance." = "「自动」跟随系统外观。";
+"Language" = "语言";
+"System" = "跟随系统";
+"Takes effect after relaunching hostflip." = "重新启动 hostflip 后生效。";
+"Relaunch Now" = "立即重新启动";
+"Show Dock Icon" = "显示程序坞图标";
+"The menu bar icon is always shown." = "菜单栏图标始终显示。";
+"Launch at Login" = "登录时启动";
+"hostflip starts silently in the menu bar when you log in." = "登录后 hostflip 在菜单栏静默启动。";
+"Current Version" = "当前版本";
+"Automatically check for updates" = "自动检查更新";
+"Check for Updates" = "检查更新";
+"Auto" = "自动";
+"Light" = "浅色";
+"Dark" = "深色";
+"When Main Window Is Open" = "主窗口打开时";
+"Always" = "总是";
+"Never" = "从不";
+
+/* Sidebar and creation */
+"System Hosts" = "系统 hosts";
+"Base Hosts" = "基础 hosts";
+"Standalone Profiles" = "独立方案";
+"Drag to Move" = "拖动以移动";
+"Drag to move" = "拖动以移动";
+"No Profiles Yet" = "还没有方案";
+"Create a profile to switch hosts without changing Base Hosts." = "新建方案即可在不改动基础 hosts 的情况下切换 hosts。";
+"Create Profile" = "新建方案";
+"New" = "新建";
+"New Profile" = "新建方案";
+"New Group" = "新建分组";
+"PROFILE_DEFAULT_NAME" = "新方案";
+"PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
+"GROUP_DEFAULT_NAME" = "新分组";
+"GROUP_DEFAULT_NAME_NUMBERED" = "新分组 %lld";
+"Group Name" = "分组名称";
+"Rename Group…" = "重命名分组…";
+"Move Up" = "上移";
+"Move Down" = "下移";
+"Delete Group…" = "删除分组…";
+"Rename Profile…" = "重命名方案…";
+"Move To" = "移动到";
+"Delete Profile…" = "删除方案…";
+"Profile Actions" = "方案操作";
+"Group Actions" = "分组操作";
+"Actions for %@" = "%@ 的操作";
+"Expand %@" = "展开 %@";
+"Collapse %@" = "折叠 %@";
+"Expand Group" = "展开分组";
+"Collapse Group" = "折叠分组";
+"Select for editing. Drag to move." = "选中以编辑。拖动以移动。";
+"Activate %@" = "将 %@ 设为生效";
+"Deactivate %@" = "取消 %@ 的生效";
+"Active" = "生效中";
+"Inactive" = "未生效";
+"Saved Active" = "已选用（暂停中）";
+"Make Active" = "设为生效";
+"Delete Profile" = "删除方案";
+"Group: %@ · One profile active at a time" = "分组：%@ · 同一分组内同时只有一个方案生效";
+"Standalone profile · Toggles independently" = "独立方案 · 独立开关";
+
+/* Delete confirmations */
+"Delete “%@”?" = "删除“%@”？";
+"The profile’s content will be removed. Base hosts and other profiles are not affected." = "该方案的内容将被移除。基础 hosts 和其他方案不受影响。";
+"Delete Group" = "删除分组";
+"The empty group will be deleted. Base hosts and other groups are not affected." = "该空分组将被删除。基础 hosts 和其他分组不受影响。";
+"Its profile will move to Standalone Profiles. Its content and active state will be preserved. Base hosts and other groups are not affected." = "分组内的方案将移至独立方案。其内容与生效状态将被保留。基础 hosts 和其他分组不受影响。";
+"Its %lld profiles will move to Standalone Profiles in the current order. Their content and active state will be preserved. Base hosts and other groups are not affected." = "分组内的 %lld 个方案将按当前顺序移至独立方案。其内容与生效状态将被保留。基础 hosts 和其他分组不受影响。";
+
+/* Banner and drift review */
+"Paused — selections are saved but not applied to the system hosts file." = "已暂停 — 选用状态已保存，但不会应用到系统 hosts 文件。";
+"System hosts changed outside hostflip. Review the drift to continue switching." = "系统 hosts 在 hostflip 之外被更改。查看外部更改后才能继续切换。";
+"Review Drift" = "查看外部更改";
+"Helper approval is required before switching profiles." = "切换方案前需要先批准辅助程序。";
+"Dismiss Status" = "关闭状态提示";
+"Review Hosts Drift" = "查看 hosts 的外部更改";
+"Review what changed outside hostflip before switching profiles again." = "查看在 hostflip 之外发生的更改，然后再继续切换方案。";
+"+%lld in system hosts" = "系统 hosts 多出 %lld 行";
+"−%lld expected" = "较预期少 %lld 行";
+"Recommended: add drifted lines to Base Hosts so they are preserved. Discarding replaces the system file with hostflip’s active state." = "建议：将外部新增的行并入基础 hosts 以保留它们。选择丢弃则用 hostflip 的当前生效状态覆盖系统 hosts 文件。";
+"Diff Unavailable" = "无法显示差异";
+"hostflip could not read the current system hosts file." = "hostflip 无法读取当前系统 hosts 文件。";
+"Reconciling…" = "正在处理外部更改…";
+"Use System Hosts as Base…" = "将系统 hosts 用作基础…";
+"Use System Hosts as Base" = "将系统 hosts 用作基础";
+"Use the current System Hosts as Base Hosts?" = "将当前系统 hosts 用作基础 hosts？";
+"Discard Drift" = "丢弃外部更改";
+"Add to Base Hosts" = "并入基础 hosts";
+"This replaces the current Base Hosts without creating an undo copy. The original hosts.orig backup and /etc/hosts will not be changed." = "此操作将替换当前基础 hosts，且不会创建可撤销的副本。最初的 hosts.orig 备份和 /etc/hosts 不会被更改。";
+
+/* Editor panes */
+"/etc/hosts · Read Only" = "/etc/hosts · 只读";
+"Cannot Read System Hosts" = "无法读取系统 hosts";
+"The current /etc/hosts content is unavailable." = "当前 /etc/hosts 内容不可用。";
+"Protected · Read Only" = "受保护 · 只读";
+"Always Active" = "始终生效";
+"Profile Name" = "方案名称";
+"Open Maintenance" = "打开维护面板";
+
+/* Switch feedback */
+"System Hosts Updated" = "系统 hosts 已更新";
+"Base Hosts Replaced" = "基础 hosts 已替换";
+"Approval Required" = "需要批准";
+"Helper Unavailable" = "辅助程序不可用";
+"Hosts Drift Detected" = "检测到外部更改";
+"Switch Failed" = "切换失败";
+"System hosts file updated" = "系统 hosts 文件已更新";
+"Base Hosts replaced with the current /etc/hosts content. The system file was not changed." = "已用当前 /etc/hosts 内容替换基础 hosts。系统文件本身未被更改。";
+"Switch blocked: hostflip’s background helper needs system approval" = "切换被阻止：hostflip 的后台辅助程序需要系统批准";
+"Helper unavailable: move the app to the Applications folder and reopen it" = "辅助程序不可用：请将应用移到「应用程序」文件夹后重新打开";
+"Switch blocked: system hosts contains changes made outside hostflip" = "切换被阻止：系统 hosts 包含在 hostflip 之外所做的更改";
+
+/* Workspace errors */
+"Cannot open workspace: %@" = "无法打开工作区：%@";
+"Cannot display /etc/hosts because it is not valid UTF-8." = "/etc/hosts 不是有效的 UTF-8，无法显示。";
+"Cannot read /etc/hosts: %@" = "无法读取 /etc/hosts：%@";
+"System hosts was updated, but DNS refresh failed: %@" = "系统 hosts 已更新，但 DNS 刷新失败：%@";
+"Failed to update the system hosts file: %@" = "更新系统 hosts 文件失败：%@";
+"Switch failed: %@" = "切换失败：%@";
+"Save failed: %@" = "保存失败：%@";
+"System hosts changed again. Review the latest diff before retrying." = "系统 hosts 再次发生更改。请查看最新差异后重试。";
+"Failed to reconcile the system hosts file: %@" = "处理系统 hosts 文件的外部更改失败：%@";
+"Hosts reconciliation failed: %@" = "处理 hosts 的外部更改失败：%@";
+"Wait for the current hosts operation to finish." = "请等待当前 hosts 操作完成。";
+"No unresolved hosts drift is available to adopt." = "当前没有待处理的外部更改可供采用。";
+"Deactivate every active profile before using System Hosts as Base Hosts." = "将系统 hosts 用作基础 hosts 前，请先取消所有方案的生效。";
+"System Hosts must be valid UTF-8 before it can replace Base Hosts." = "系统 hosts 必须是有效的 UTF-8 才能替换基础 hosts。";
+"System Hosts already contains hostflip-generated sections and cannot be used as Base Hosts." = "系统 hosts 已包含 hostflip 生成的区块，不能用作基础 hosts。";
+"Base Hosts could not be replaced: %@" = "基础 hosts 替换失败：%@";
+"System hosts changed while reconciliation was in progress. Review the latest diff before retrying." = "处理外部更改期间，系统 hosts 发生了更改。请查看最新差异后重试。";
+"System hosts was updated, but the reconciliation could not be saved: %@" = "系统 hosts 已更新，但外部更改的处理结果保存失败：%@";
+"Changes were saved locally, but the system hosts file could not be updated: %@" = "更改已保存到本地，但系统 hosts 文件未能更新：%@";
+"Changes were saved locally, but this build is not properly signed, so the system hosts file could not be updated." = "更改已保存到本地，但此构建未正确签名，系统 hosts 文件未能更新。";
+
+/* Import / export */
+"Import…" = "导入…";
+"Export…" = "导出…";
+"Import Failed" = "导入失败";
+"Export Failed" = "导出失败";
+"Nothing was exported: %@" = "未导出任何内容：%@";
+"Nothing was imported: the workspace is not loaded." = "未导入任何内容：工作区尚未加载。";
+"Nothing was imported: %@" = "未导入任何内容：%@";
+"this file was created by a newer version of hostflip (format version %lld)" = "此文件由更新版本的 hostflip 创建（格式版本 %lld）";
+"this file is JSON but not a valid hostflip export" = "此文件是 JSON，但不是有效的 hostflip 导出文件";
+"the export contains a profile or group with an empty name" = "导出内容中存在名称为空的方案或分组";
+"this file is not UTF-8 text" = "此文件不是 UTF-8 文本";
+"Nothing was imported. %@: %@." = "未导入任何内容。%@：%@。";
+
+/* Helper maintenance */
+"Helper Ready" = "辅助程序就绪";
+"The helper is approved and ready to update the system hosts file." = "辅助程序已获批准，可以更新系统 hosts 文件。";
+"Helper Approval Required" = "辅助程序需要批准";
+"The helper is waiting for approval in System Settings. Switching remains blocked until it is approved." = "辅助程序正在等待「系统设置」中的批准。批准前切换将保持被阻止。";
+"Helper Not Installed" = "辅助程序未安装";
+"Switch a profile to install the helper. macOS may ask you to approve it." = "切换任一方案即可安装辅助程序。macOS 可能会要求你批准。";
+"Checking Helper…" = "正在检查辅助程序…";
+"Checking the helper registration status…" = "正在检查辅助程序的注册状态…";
+"Maintenance" = "维护";
+"Background Helper" = "后台辅助程序";
+"Deactivate and Remove Helper?" = "停用并移除辅助程序？";
+"Deactivate and Remove" = "停用并移除";
+"hostflip will remove its privileged helper. Your profiles and base hosts will stay in the workspace. The helper will be requested again on your next switch.\n\nThe system hosts file keeps its current content — entries from active profiles stay in effect. To leave only Base Hosts applied (e.g. before uninstalling), turn off the master switch first." = "hostflip 将移除其特权辅助程序。你的方案和基础 hosts 会保留在工作区中。下次切换时会重新请求安装辅助程序。\n\n系统 hosts 文件保持当前内容 — 生效方案的条目继续有效。若只想保留基础 hosts（例如卸载前），请先关闭总开关。";
+"Retry Remove Helper…" = "重试移除辅助程序…";
+"Deactivate and Remove Helper…" = "停用并移除辅助程序…";
+"Helper Removed" = "辅助程序已移除";
+"The helper was deactivated and removed. Your profiles were not changed." = "辅助程序已停用并移除。你的方案未受影响。";
+"Could Not Remove Helper" = "无法移除辅助程序";
+"Could not remove the helper. Try again. Your profiles were not changed. %@" = "无法移除辅助程序。请重试。你的方案未受影响。%@";
+
+/* Command line tab */
+"Not linked yet" = "尚未链接";
+"Linked at %@" = "已链接于 %@";
+"Links elsewhere: %@" = "链接指向其他位置：%@";
+"Something else occupies %@" = "%@ 已被其他文件占用";
+"The bundled hostflip command drives the same profiles and helper as the app. Homebrew puts it on your PATH automatically; for a direct download, run this once in Terminal:" = "随附的 hostflip 命令与应用共用同一套方案和辅助程序。Homebrew 安装会自动将其加入 PATH；直接下载的用户请在终端中运行一次：";
+"Copied" = "已拷贝";
+"Copy Command" = "拷贝命令";
+
+/* Titlebar switch */
+"Resume hostflip" = "恢复 hostflip";
+"Pause hostflip" = "暂停 hostflip";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -1,0 +1,206 @@
+/* Menu bar */
+"Enable hostflip" = "啟用 hostflip";
+"Hosts file changed externally — Review…" = "hosts 檔案已被外部更改 — 檢視…";
+"No profiles yet — create one…" = "尚無方案 — 新增一個…";
+"Open hostflip…" = "開啟 hostflip…";
+"Settings…" = "設定…";
+"Quit hostflip" = "結束 hostflip";
+"hostflip" = "hostflip";
+"hostflip, paused" = "hostflip，已暫停";
+"hostflip, hosts drift detected" = "hostflip，偵測到外部更改";
+"hostflip, paused, hosts drift detected" = "hostflip，已暫停，偵測到外部更改";
+
+/* Shared buttons */
+"Open System Settings…" = "開啟系統設定…";
+"Later" = "稍後";
+"OK" = "好";
+"Retry" = "重試";
+"Delete" = "刪除";
+
+/* Settings window */
+"General" = "一般";
+"Helper" = "輔助程式";
+"Command Line" = "命令列";
+"Updates" = "更新";
+"Appearance" = "外觀";
+"Auto follows the system appearance." = "「自動」跟隨系統外觀。";
+"Language" = "語言";
+"System" = "跟隨系統";
+"Takes effect after relaunching hostflip." = "重新啟動 hostflip 後生效。";
+"Relaunch Now" = "立即重新啟動";
+"Show Dock Icon" = "顯示 Dock 圖像";
+"The menu bar icon is always shown." = "選單列圖像會一直顯示。";
+"Launch at Login" = "登入時啟動";
+"hostflip starts silently in the menu bar when you log in." = "登入後，hostflip 會在選單列啟動，且不會開啟主視窗。";
+"Current Version" = "目前版本";
+"Automatically check for updates" = "自動檢查更新";
+"Check for Updates" = "檢查更新";
+"Auto" = "自動";
+"Light" = "淺色";
+"Dark" = "深色";
+"When Main Window Is Open" = "主視窗開啟時";
+"Always" = "總是";
+"Never" = "永不";
+
+/* Sidebar and creation */
+"System Hosts" = "系統 hosts";
+"Base Hosts" = "基礎 hosts";
+"Standalone Profiles" = "獨立方案";
+"Drag to Move" = "拖移以移動";
+"Drag to move" = "拖移以移動";
+"No Profiles Yet" = "尚無方案";
+"Create a profile to switch hosts without changing Base Hosts." = "新增方案即可在不更動基礎 hosts 的情況下切換 hosts。";
+"Create Profile" = "新增方案";
+"New" = "新增";
+"New Profile" = "新增方案";
+"New Group" = "新增群組";
+"PROFILE_DEFAULT_NAME" = "新方案";
+"PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
+"GROUP_DEFAULT_NAME" = "新群組";
+"GROUP_DEFAULT_NAME_NUMBERED" = "新群組 %lld";
+"Group Name" = "群組名稱";
+"Rename Group…" = "重新命名群組…";
+"Move Up" = "上移";
+"Move Down" = "下移";
+"Delete Group…" = "刪除群組…";
+"Rename Profile…" = "重新命名方案…";
+"Move To" = "移至";
+"Delete Profile…" = "刪除方案…";
+"Profile Actions" = "方案操作";
+"Group Actions" = "群組操作";
+"Actions for %@" = "%@ 的操作";
+"Expand %@" = "展開 %@";
+"Collapse %@" = "收合 %@";
+"Expand Group" = "展開群組";
+"Collapse Group" = "收合群組";
+"Select for editing. Drag to move." = "選取以編輯。拖移以移動。";
+"Activate %@" = "將 %@ 設為生效";
+"Deactivate %@" = "取消 %@ 的生效";
+"Active" = "生效中";
+"Inactive" = "未生效";
+"Saved Active" = "已選用（暫停中）";
+"Make Active" = "設為生效";
+"Delete Profile" = "刪除方案";
+"Group: %@ · One profile active at a time" = "群組：%@ · 同一群組內同時只有一個方案生效";
+"Standalone profile · Toggles independently" = "獨立方案 · 獨立開關";
+
+/* Delete confirmations */
+"Delete “%@”?" = "刪除「%@」？";
+"The profile’s content will be removed. Base hosts and other profiles are not affected." = "此方案的內容將被移除。基礎 hosts 和其他方案不受影響。";
+"Delete Group" = "刪除群組";
+"The empty group will be deleted. Base hosts and other groups are not affected." = "此空群組將被刪除。基礎 hosts 和其他群組不受影響。";
+"Its profile will move to Standalone Profiles. Its content and active state will be preserved. Base hosts and other groups are not affected." = "群組內的方案將移至獨立方案。其內容與生效狀態將被保留。基礎 hosts 和其他群組不受影響。";
+"Its %lld profiles will move to Standalone Profiles in the current order. Their content and active state will be preserved. Base hosts and other groups are not affected." = "群組內的 %lld 個方案將依目前順序移至獨立方案。其內容與生效狀態將被保留。基礎 hosts 和其他群組不受影響。";
+
+/* Banner and drift review */
+"Paused — selections are saved but not applied to the system hosts file." = "已暫停 — 選用狀態已儲存，但不會套用到系統 hosts 檔案。";
+"System hosts changed outside hostflip. Review the drift to continue switching." = "系統 hosts 在 hostflip 之外被更改。檢視外部更改後才能繼續切換。";
+"Review Drift" = "檢視外部更改";
+"Helper approval is required before switching profiles." = "切換方案前需要先核准輔助程式。";
+"Dismiss Status" = "關閉狀態提示";
+"Review Hosts Drift" = "檢視 hosts 的外部更改";
+"Review what changed outside hostflip before switching profiles again." = "檢視在 hostflip 之外發生的更改，然後再繼續切換方案。";
+"+%lld in system hosts" = "系統 hosts 多出 %lld 行";
+"−%lld expected" = "較預期少 %lld 行";
+"Recommended: add drifted lines to Base Hosts so they are preserved. Discarding replaces the system file with hostflip’s active state." = "建議：將外部新增的行併入基礎 hosts 以保留它們。選擇捨棄則會以 hostflip 目前的生效狀態覆寫系統 hosts 檔案。";
+"Diff Unavailable" = "無法顯示差異";
+"hostflip could not read the current system hosts file." = "hostflip 無法讀取目前的系統 hosts 檔案。";
+"Reconciling…" = "正在處理外部更改…";
+"Use System Hosts as Base…" = "將系統 hosts 用作基礎…";
+"Use System Hosts as Base" = "將系統 hosts 用作基礎";
+"Use the current System Hosts as Base Hosts?" = "將目前的系統 hosts 用作基礎 hosts？";
+"Discard Drift" = "捨棄外部更改";
+"Add to Base Hosts" = "併入基礎 hosts";
+"This replaces the current Base Hosts without creating an undo copy. The original hosts.orig backup and /etc/hosts will not be changed." = "此操作將取代目前的基礎 hosts，且不會建立可還原的副本。最初的 hosts.orig 備份和 /etc/hosts 不會被更改。";
+
+/* Editor panes */
+"/etc/hosts · Read Only" = "/etc/hosts · 唯讀";
+"Cannot Read System Hosts" = "無法讀取系統 hosts";
+"The current /etc/hosts content is unavailable." = "目前的 /etc/hosts 內容無法取得。";
+"Protected · Read Only" = "受保護 · 唯讀";
+"Always Active" = "始終生效";
+"Profile Name" = "方案名稱";
+"Open Maintenance" = "開啟維護面板";
+
+/* Switch feedback */
+"System Hosts Updated" = "系統 hosts 已更新";
+"Base Hosts Replaced" = "基礎 hosts 已取代";
+"Approval Required" = "需要核准";
+"Helper Unavailable" = "輔助程式無法使用";
+"Hosts Drift Detected" = "偵測到外部更改";
+"Switch Failed" = "切換失敗";
+"System hosts file updated" = "系統 hosts 檔案已更新";
+"Base Hosts replaced with the current /etc/hosts content. The system file was not changed." = "已用目前的 /etc/hosts 內容取代基礎 hosts。系統檔案本身未被更改。";
+"Switch blocked: hostflip’s background helper needs system approval" = "切換被阻擋：hostflip 的背景輔助程式需要系統核准";
+"Helper unavailable: move the app to the Applications folder and reopen it" = "輔助程式無法使用：請將 App 移到「應用程式」檔案夾後重新開啟";
+"Switch blocked: system hosts contains changes made outside hostflip" = "切換被阻擋：系統 hosts 包含在 hostflip 之外所做的更改";
+
+/* Workspace errors */
+"Cannot open workspace: %@" = "無法開啟工作區：%@";
+"Cannot display /etc/hosts because it is not valid UTF-8." = "/etc/hosts 不是有效的 UTF-8，無法顯示。";
+"Cannot read /etc/hosts: %@" = "無法讀取 /etc/hosts：%@";
+"System hosts was updated, but DNS refresh failed: %@" = "系統 hosts 已更新，但 DNS 重新整理失敗：%@";
+"Failed to update the system hosts file: %@" = "更新系統 hosts 檔案失敗：%@";
+"Switch failed: %@" = "切換失敗：%@";
+"Save failed: %@" = "儲存失敗：%@";
+"System hosts changed again. Review the latest diff before retrying." = "系統 hosts 再次發生更改。請檢視最新差異後重試。";
+"Failed to reconcile the system hosts file: %@" = "處理系統 hosts 檔案的外部更改失敗：%@";
+"Hosts reconciliation failed: %@" = "處理 hosts 的外部更改失敗：%@";
+"Wait for the current hosts operation to finish." = "請等待目前的 hosts 操作完成。";
+"No unresolved hosts drift is available to adopt." = "目前沒有待處理的外部更改可供採用。";
+"Deactivate every active profile before using System Hosts as Base Hosts." = "將系統 hosts 用作基礎 hosts 前，請先取消所有方案的生效。";
+"System Hosts must be valid UTF-8 before it can replace Base Hosts." = "系統 hosts 必須是有效的 UTF-8 才能取代基礎 hosts。";
+"System Hosts already contains hostflip-generated sections and cannot be used as Base Hosts." = "系統 hosts 已包含 hostflip 產生的區塊，不能用作基礎 hosts。";
+"Base Hosts could not be replaced: %@" = "基礎 hosts 取代失敗：%@";
+"System hosts changed while reconciliation was in progress. Review the latest diff before retrying." = "處理外部更改期間，系統 hosts 發生了更改。請檢視最新差異後重試。";
+"System hosts was updated, but the reconciliation could not be saved: %@" = "系統 hosts 已更新，但外部更改的處理結果儲存失敗：%@";
+"Changes were saved locally, but the system hosts file could not be updated: %@" = "更改已儲存到本機，但系統 hosts 檔案未能更新：%@";
+"Changes were saved locally, but this build is not properly signed, so the system hosts file could not be updated." = "更改已儲存到本機，但此建置版本未正確簽署，因此無法更新系統 hosts 檔案。";
+
+/* Import / export */
+"Import…" = "匯入…";
+"Export…" = "匯出…";
+"Import Failed" = "匯入失敗";
+"Export Failed" = "匯出失敗";
+"Nothing was exported: %@" = "未匯出任何內容：%@";
+"Nothing was imported: the workspace is not loaded." = "未匯入任何內容：工作區尚未載入。";
+"Nothing was imported: %@" = "未匯入任何內容：%@";
+"this file was created by a newer version of hostflip (format version %lld)" = "此檔案由較新版本的 hostflip 建立（格式版本 %lld）";
+"this file is JSON but not a valid hostflip export" = "此檔案是 JSON，但不是有效的 hostflip 匯出檔案";
+"the export contains a profile or group with an empty name" = "匯出內容中存在名稱為空的方案或群組";
+"this file is not UTF-8 text" = "此檔案不是 UTF-8 文字";
+"Nothing was imported. %@: %@." = "未匯入任何內容。%@：%@。";
+
+/* Helper maintenance */
+"Helper Ready" = "輔助程式已就緒";
+"The helper is approved and ready to update the system hosts file." = "輔助程式已獲核准，可以更新系統 hosts 檔案。";
+"Helper Approval Required" = "輔助程式需要核准";
+"The helper is waiting for approval in System Settings. Switching remains blocked until it is approved." = "輔助程式正在等待你在「系統設定」中核准。獲得核准前皆無法切換。";
+"Helper Not Installed" = "輔助程式未安裝";
+"Switch a profile to install the helper. macOS may ask you to approve it." = "切換任一方案即可安裝輔助程式。macOS 可能會要求你核准。";
+"Checking Helper…" = "正在檢查輔助程式…";
+"Checking the helper registration status…" = "正在檢查輔助程式的註冊狀態…";
+"Maintenance" = "維護";
+"Background Helper" = "背景輔助程式";
+"Deactivate and Remove Helper?" = "停用並移除輔助程式？";
+"Deactivate and Remove" = "停用並移除";
+"hostflip will remove its privileged helper. Your profiles and base hosts will stay in the workspace. The helper will be requested again on your next switch.\n\nThe system hosts file keeps its current content — entries from active profiles stay in effect. To leave only Base Hosts applied (e.g. before uninstalling), turn off the master switch first." = "hostflip 將移除其特權輔助程式。你的方案和基礎 hosts 會保留在工作區中。下次切換時會重新要求安裝輔助程式。\n\n系統 hosts 檔案保持目前內容 — 生效方案的項目繼續有效。若只想保留基礎 hosts（例如解除安裝前），請先關閉總開關。";
+"Retry Remove Helper…" = "重試移除輔助程式…";
+"Deactivate and Remove Helper…" = "停用並移除輔助程式…";
+"Helper Removed" = "輔助程式已移除";
+"The helper was deactivated and removed. Your profiles were not changed." = "輔助程式已停用並移除。你的方案未受影響。";
+"Could Not Remove Helper" = "無法移除輔助程式";
+"Could not remove the helper. Try again. Your profiles were not changed. %@" = "無法移除輔助程式。請重試。你的方案未受影響。%@";
+
+/* Command line tab */
+"Not linked yet" = "尚未連結";
+"Linked at %@" = "已連結於 %@";
+"Links elsewhere: %@" = "連結指向其他位置：%@";
+"Something else occupies %@" = "%@ 已被其他檔案佔用";
+"The bundled hostflip command drives the same profiles and helper as the app. Homebrew puts it on your PATH automatically; for a direct download, run this once in Terminal:" = "隨附的 hostflip 命令與 App 共用同一套方案和輔助程式。Homebrew 安裝會自動將其加入 PATH；直接下載的使用者請在終端機中執行一次：";
+"Copied" = "已拷貝";
+"Copy Command" = "拷貝指令";
+
+/* Titlebar switch */
+"Resume hostflip" = "恢復 hostflip";
+"Pause hostflip" = "暫停 hostflip";

--- a/Sources/Hostflip/AppearancePreferenceStore.swift
+++ b/Sources/Hostflip/AppearancePreferenceStore.swift
@@ -12,11 +12,11 @@ enum AppearancePreference: String, CaseIterable, Equatable {
     var title: String {
         switch self {
         case .auto:
-            "Auto"
+            String(localized: "Auto")
         case .light:
-            "Light"
+            String(localized: "Light")
         case .dark:
-            "Dark"
+            String(localized: "Dark")
         }
     }
 

--- a/Sources/Hostflip/AppearancePreferenceStore.swift
+++ b/Sources/Hostflip/AppearancePreferenceStore.swift
@@ -1,0 +1,76 @@
+import AppKit
+import Foundation
+import Observation
+
+enum AppearancePreference: String, CaseIterable, Equatable {
+    case auto
+    case light
+    case dark
+
+    static let `default`: Self = .auto
+
+    var title: String {
+        switch self {
+        case .auto:
+            "Auto"
+        case .light:
+            "Light"
+        case .dark:
+            "Dark"
+        }
+    }
+
+    /// `nil` means no override: the app follows the system appearance.
+    var appearanceName: NSAppearance.Name? {
+        switch self {
+        case .auto:
+            nil
+        case .light:
+            .aqua
+        case .dark:
+            .darkAqua
+        }
+    }
+}
+
+@MainActor
+@Observable
+final class AppearancePreferenceStore {
+    private static let preferenceKey = "appearancePreference"
+
+    private(set) var preference: AppearancePreference
+
+    private let savePreference: (String) -> Void
+    private let applyAppearance: (NSAppearance.Name?) -> Void
+
+    convenience init() {
+        let defaults = UserDefaults.standard
+        self.init(
+            loadPreference: { defaults.string(forKey: Self.preferenceKey) },
+            savePreference: { defaults.set($0, forKey: Self.preferenceKey) },
+            applyAppearance: { name in
+                DispatchQueue.main.async {
+                    NSApp.appearance = name.flatMap(NSAppearance.init(named:))
+                }
+            }
+        )
+    }
+
+    init(
+        loadPreference: () -> String?,
+        savePreference: @escaping (String) -> Void,
+        applyAppearance: @escaping (NSAppearance.Name?) -> Void
+    ) {
+        let preference = loadPreference().flatMap(AppearancePreference.init(rawValue:)) ?? .default
+        self.preference = preference
+        self.savePreference = savePreference
+        self.applyAppearance = applyAppearance
+        applyAppearance(preference.appearanceName)
+    }
+
+    func setPreference(_ preference: AppearancePreference) {
+        self.preference = preference
+        savePreference(preference.rawValue)
+        applyAppearance(preference.appearanceName)
+    }
+}

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -7,21 +7,23 @@ struct ApplicationSettingsView: View {
     let maintenanceStore: MaintenanceStore
     let dockIconStore: DockIconVisibilityStore
     let launchAtLoginStore: LaunchAtLoginStore
+    let appearanceStore: AppearancePreferenceStore
     let updater: SPUUpdater
 
     // All four tabs share the classic settings-form look of Apple's own app
     // settings windows (right-aligned label column, controls left-aligned,
     // captions under their controls) — the app-settings convention, distinct
     // from the System Settings grouped cards. Top-aligned so switching tabs
-    // never jumps; growth goes in as new rows — e.g. a future appearance
-    // picker joins General.
+    // never jumps; growth goes in as new rows — e.g. the appearance picker
+    // in General.
     var body: some View {
         TabView {
             GeneralSettingsView(
                 dockIconStore: dockIconStore,
-                launchAtLoginStore: launchAtLoginStore
+                launchAtLoginStore: launchAtLoginStore,
+                appearanceStore: appearanceStore
             )
-            .frame(width: 500, height: 170, alignment: .top)
+            .frame(width: 500, height: 220, alignment: .top)
             .tabItem {
                 Label("General", systemImage: "gearshape")
             }
@@ -50,13 +52,29 @@ struct ApplicationSettingsView: View {
     }
 }
 
-/// Everyday preferences; future rows (an appearance picker, say) join as more rows.
+/// Everyday preferences; future rows join as more rows.
 private struct GeneralSettingsView: View {
     let dockIconStore: DockIconVisibilityStore
     let launchAtLoginStore: LaunchAtLoginStore
+    let appearanceStore: AppearancePreferenceStore
 
     var body: some View {
         Form {
+            Picker(
+                "Appearance",
+                selection: Binding(
+                    get: { appearanceStore.preference },
+                    set: { appearanceStore.setPreference($0) }
+                )
+            ) {
+                ForEach(AppearancePreference.allCases, id: \.rawValue) { preference in
+                    Text(preference.title).tag(preference)
+                }
+            }
+            Text("Auto follows the system appearance.")
+                .font(.callout)
+                .foregroundStyle(.secondary)
+
             Picker(
                 "Show Dock Icon",
                 selection: Binding(

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -1,3 +1,4 @@
+import AppKit
 import HostflipXPC
 import Sparkle
 import SwiftUI
@@ -23,7 +24,7 @@ struct ApplicationSettingsView: View {
                 launchAtLoginStore: launchAtLoginStore,
                 appearanceStore: appearanceStore
             )
-            .frame(width: 500, height: 220, alignment: .top)
+            .frame(width: 500, height: 280, alignment: .top)
             .tabItem {
                 Label("General", systemImage: "gearshape")
             }
@@ -58,6 +59,9 @@ private struct GeneralSettingsView: View {
     let launchAtLoginStore: LaunchAtLoginStore
     let appearanceStore: AppearancePreferenceStore
 
+    @Environment(\.locale) private var locale
+    @State private var languageSelection = GeneralSettingsView.storedLanguageSelection()
+
     var body: some View {
         Form {
             Picker(
@@ -74,6 +78,31 @@ private struct GeneralSettingsView: View {
             Text("Auto follows the system appearance.")
                 .font(.callout)
                 .foregroundStyle(.secondary)
+
+            // Languages name themselves and are deliberately untranslated;
+            // only "System" localizes.
+            Picker("Language", selection: $languageSelection) {
+                Text("System").tag(LanguagePreference.system)
+                Text(verbatim: "English").tag(LanguagePreference.english)
+                Text(verbatim: "简体中文").tag(LanguagePreference.simplifiedChinese)
+                Text(verbatim: "繁體中文").tag(LanguagePreference.traditionalChinese)
+                Text(verbatim: "日本語").tag(LanguagePreference.japanese)
+            }
+            .onChange(of: languageSelection) { _, selection in
+                if let languages = selection.overrideLanguages {
+                    UserDefaults.standard.set(languages, forKey: "AppleLanguages")
+                } else {
+                    UserDefaults.standard.removeObject(forKey: "AppleLanguages")
+                }
+            }
+            if needsRestart {
+                HStack(spacing: 12) {
+                    Text("Takes effect after relaunching hostflip.")
+                        .font(.callout)
+                        .foregroundStyle(.secondary)
+                    Button("Relaunch Now") { relaunch() }
+                }
+            }
 
             Picker(
                 "Show Dock Icon",
@@ -99,6 +128,61 @@ private struct GeneralSettingsView: View {
                 .foregroundStyle(.secondary)
         }
         .padding(20)
+        .onAppear {
+            // Reread on every window open — System Settings' per-app language
+            // writes the same key and must be reflected here.
+            languageSelection = Self.storedLanguageSelection()
+        }
+    }
+
+    /// Reads the app-domain override via persistentDomain: array(forKey:) walks the
+    /// search list and inherits the global language order, so it can never
+    /// distinguish "follow system" from an override.
+    private static func storedLanguageSelection() -> LanguagePreference {
+        let domain = Bundle.main.bundleIdentifier
+            .flatMap { UserDefaults.standard.persistentDomain(forName: $0) }
+        return LanguagePreference(override: domain?["AppleLanguages"] as? [String])
+    }
+
+    /// Only prompts when the selection's post-relaunch language differs from this
+    /// launch's — flipping between "System" and the language the system already
+    /// resolves to stays quiet.
+    private var needsRestart: Bool {
+        let launchLanguage = LanguagePreference.match(locale) ?? "en"
+        return languageSelection.effectiveLanguage(
+            systemLanguages: systemLanguages(fallbackLanguage: launchLanguage)
+        ) != launchLanguage
+    }
+
+    /// The full system language list, read from the global domain (the app domain's
+    /// own override would shadow it); unreadable → this launch's language.
+    private func systemLanguages(fallbackLanguage: String) -> [String] {
+        let raw = CFPreferencesCopyValue(
+            "AppleLanguages" as CFString,
+            kCFPreferencesAnyApplication,
+            kCFPreferencesCurrentUser,
+            kCFPreferencesAnyHost
+        )
+        return raw as? [String] ?? [fallbackLanguage]
+    }
+
+    /// A detached shell waits for this process to exit, then reopens the bundle —
+    /// the relaunch survives NSApp.terminate tearing this process down.
+    private func relaunch() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = [
+            "-c",
+            #"while /bin/kill -0 "$1" 2>/dev/null; do /bin/sleep 0.1; done; /usr/bin/open "$2""#,
+            "hostflip-relaunch",
+            String(ProcessInfo.processInfo.processIdentifier),
+            Bundle.main.bundlePath
+        ]
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try? process.run()
+        NSApp.terminate(nil)
     }
 }
 

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -200,7 +200,7 @@ private struct UpdatesSettingsView: View {
     var body: some View {
         Form {
             LabeledContent("Current Version") {
-                Text("v\(HostflipBuild.version)")
+                Text(verbatim: "v\(HostflipBuild.version)")
                     .foregroundStyle(.secondary)
             }
 

--- a/Sources/Hostflip/CLIInstallView.swift
+++ b/Sources/Hostflip/CLIInstallView.swift
@@ -38,16 +38,16 @@ struct CLIInstallPresentation {
             """
         switch linkState {
         case .absent:
-            statusTitle = "Not linked yet"
+            statusTitle = String(localized: "Not linked yet")
             statusColor = .secondary
         case .linked(let destination) where destination == cliPath:
-            statusTitle = "Linked at \(Self.linkPath)"
+            statusTitle = String(localized: "Linked at \(Self.linkPath)")
             statusColor = .green
         case .linked(let destination):
-            statusTitle = "Links elsewhere: \(destination)"
+            statusTitle = String(localized: "Links elsewhere: \(destination)")
             statusColor = .orange
         case .occupiedByFile:
-            statusTitle = "Something else occupies \(Self.linkPath)"
+            statusTitle = String(localized: "Something else occupies \(Self.linkPath)")
             statusColor = .orange
         }
     }

--- a/Sources/Hostflip/DockIconVisibilityStore.swift
+++ b/Sources/Hostflip/DockIconVisibilityStore.swift
@@ -12,11 +12,11 @@ enum DockIconVisibilityPolicy: String, CaseIterable, Equatable {
     var title: String {
         switch self {
         case .whenMainWindowIsOpen:
-            "When Main Window Is Open"
+            String(localized: "When Main Window Is Open")
         case .always:
-            "Always"
+            String(localized: "Always")
         case .never:
-            "Never"
+            String(localized: "Never")
         }
     }
 

--- a/Sources/Hostflip/HelperMaintenanceView.swift
+++ b/Sources/Hostflip/HelperMaintenanceView.swift
@@ -11,14 +11,14 @@ struct HelperStatusPresentation {
     init(_ status: DaemonRegistrationStatus?) {
         switch status {
         case .enabled:
-            title = "Helper Ready"
-            description = "The helper is approved and ready to update the system hosts file."
+            title = String(localized: "Helper Ready")
+            description = String(localized: "The helper is approved and ready to update the system hosts file.")
             color = .green
             canRemove = true
             canOpenApprovalSettings = false
         case .requiresApproval:
-            title = "Helper Approval Required"
-            description = "The helper is waiting for approval in System Settings. Switching remains blocked until it is approved."
+            title = String(localized: "Helper Approval Required")
+            description = String(localized: "The helper is waiting for approval in System Settings. Switching remains blocked until it is approved.")
             color = .orange
             canRemove = true
             canOpenApprovalSettings = true
@@ -29,14 +29,14 @@ struct HelperStatusPresentation {
             // registration is lazily triggered by the first switch (ADR-0002).
             // A genuinely broken install (wrong location, policy block) surfaces
             // through switch feedback, not through this passive light.
-            title = "Helper Not Installed"
-            description = "Switch a profile to install the helper. macOS may ask you to approve it."
+            title = String(localized: "Helper Not Installed")
+            description = String(localized: "Switch a profile to install the helper. macOS may ask you to approve it.")
             color = .secondary
             canRemove = false
             canOpenApprovalSettings = false
         case nil:
-            title = "Checking Helper…"
-            description = "Checking the helper registration status…"
+            title = String(localized: "Checking Helper…")
+            description = String(localized: "Checking the helper registration status…")
             color = .secondary
             canRemove = false
             canOpenApprovalSettings = false
@@ -219,9 +219,9 @@ struct HelperRemovalButton: View {
 
     private var title: String {
         if case .helperRemovalFailed = maintenanceStore.feedback {
-            return "Retry Remove Helper…"
+            return String(localized: "Retry Remove Helper…")
         }
-        return "Deactivate and Remove Helper…"
+        return String(localized: "Deactivate and Remove Helper…")
     }
 }
 

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -99,10 +99,18 @@ private struct MenuBarLabel: View {
     }
 
     private var accessibilityLabelText: String {
-        var label = "Hostflip"
-        if store.isPaused { label += ", paused" }
-        if store.hasHostsDrift { label += ", hosts drift detected" }
-        return label
+        // Whole localized variants instead of concatenation: word order is not
+        // universal across languages.
+        switch (store.isPaused, store.hasHostsDrift) {
+        case (false, false):
+            String(localized: "Hostflip")
+        case (true, false):
+            String(localized: "Hostflip, paused")
+        case (false, true):
+            String(localized: "Hostflip, hosts drift detected")
+        case (true, true):
+            String(localized: "Hostflip, paused, hosts drift detected")
+        }
     }
 }
 
@@ -233,10 +241,10 @@ private struct MenuBarContent: View {
         alert.alertStyle = feedback.isFailure ? .critical : .warning
 
         if feedback == .needsApproval {
-            alert.addButton(withTitle: "Open System Settings…")
-            alert.addButton(withTitle: "Later")
+            alert.addButton(withTitle: String(localized: "Open System Settings…"))
+            alert.addButton(withTitle: String(localized: "Later"))
         } else {
-            alert.addButton(withTitle: "OK")
+            alert.addButton(withTitle: String(localized: "OK"))
         }
 
         NSApp.activate()

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -103,13 +103,13 @@ private struct MenuBarLabel: View {
         // universal across languages.
         switch (store.isPaused, store.hasHostsDrift) {
         case (false, false):
-            String(localized: "Hostflip")
+            String(localized: "hostflip")
         case (true, false):
-            String(localized: "Hostflip, paused")
+            String(localized: "hostflip, paused")
         case (false, true):
-            String(localized: "Hostflip, hosts drift detected")
+            String(localized: "hostflip, hosts drift detected")
         case (true, true):
-            String(localized: "Hostflip, paused, hosts drift detected")
+            String(localized: "hostflip, paused, hosts drift detected")
         }
     }
 }

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -13,6 +13,8 @@ struct HostflipApp: App {
     private let maintenanceStore: MaintenanceStore
     private let dockIconStore: DockIconVisibilityStore
     private let launchAtLoginStore = LaunchAtLoginStore()
+    /// Created at launch so a persisted Light/Dark override applies before any window shows.
+    private let appearanceStore = AppearancePreferenceStore()
     /// Sparkle owns the whole update pipeline (scheduled checks, download, install, relaunch); see ADR-0007.
     private let updaterController: SPUStandardUpdaterController
 
@@ -71,6 +73,7 @@ struct HostflipApp: App {
                 maintenanceStore: maintenanceStore,
                 dockIconStore: dockIconStore,
                 launchAtLoginStore: launchAtLoginStore,
+                appearanceStore: appearanceStore,
                 updater: updaterController.updater
             )
         }

--- a/Sources/Hostflip/ImportExportCommands.swift
+++ b/Sources/Hostflip/ImportExportCommands.swift
@@ -29,7 +29,7 @@ struct ImportExportCommands: Commands {
         NSApp.activate()
         guard panel.runModal() == .OK, !panel.urls.isEmpty else { return }
         if case .failed(let message) = store.importFiles(at: panel.urls) {
-            presentError(title: "Import Failed", message: message)
+            presentError(title: String(localized: "Import Failed"), message: message)
         }
     }
 
@@ -45,7 +45,10 @@ struct ImportExportCommands: Commands {
             guard let data = try store.exportSnapshotData() else { return }
             try data.write(to: url, options: .atomic)
         } catch {
-            presentError(title: "Export Failed", message: "Nothing was exported: \(error)")
+            presentError(
+                title: String(localized: "Export Failed"),
+                message: String(localized: "Nothing was exported: \(String(describing: error))")
+            )
         }
     }
 
@@ -62,7 +65,7 @@ struct ImportExportCommands: Commands {
         alert.messageText = title
         alert.informativeText = message
         alert.alertStyle = .warning
-        alert.addButton(withTitle: "OK")
+        alert.addButton(withTitle: String(localized: "OK"))
         alert.runModal()
     }
 }

--- a/Sources/Hostflip/LanguagePreference.swift
+++ b/Sources/Hostflip/LanguagePreference.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// In-app language selection, mapped both ways onto the app-domain AppleLanguages
+/// override — the same key and domain macOS's per-app language setting writes, so
+/// the two entry points stay interchangeable (ADR-0011). Pure logic only; reading
+/// and writing UserDefaults is the caller's job.
+enum LanguagePreference: String, CaseIterable, Equatable {
+    case system
+    case english = "en"
+    case simplifiedChinese = "zh-Hans"
+    case traditionalChinese = "zh-Hant"
+    case japanese = "ja"
+
+    /// Languages the app ships strings for; extend together with Packaging/Localization/.
+    static let supportedLanguages = ["en", "zh-Hans", "zh-Hant", "ja"]
+
+    /// The AppleLanguages override this selection stands for; system → nil (the
+    /// caller deletes the key to fall back to the system language order).
+    var overrideLanguages: [String]? {
+        switch self {
+        case .system:
+            nil
+        default:
+            [rawValue]
+        }
+    }
+
+    /// Resolves an existing app-domain override back to a selection; nil or empty
+    /// means no override (system), an unsupported persisted language falls back to
+    /// English rather than misreporting "system".
+    init(override: [String]?) {
+        guard let first = override?.first, !first.isEmpty else {
+            self = .system
+            return
+        }
+        self = Self.match(Locale(identifier: first))
+            .flatMap(LanguagePreference.init(rawValue:)) ?? .english
+    }
+
+    /// The UI language this selection resolves to after a relaunch. For system,
+    /// walks the full preference list for the first supported language (mirroring
+    /// bundle resolution — never just the first entry); nothing matches → English.
+    func effectiveLanguage(systemLanguages: [String]) -> String {
+        switch self {
+        case .system:
+            for tag in systemLanguages {
+                if let hit = Self.match(Locale(identifier: tag)) { return hit }
+            }
+            return "en"
+        default:
+            return rawValue
+        }
+    }
+
+    /// Locale → supported canonical language, nil when unsupported. Chinese splits
+    /// by script; Locale fills likely subtags (zh-TW → Hant, bare zh → Hans).
+    static func match(_ locale: Locale) -> String? {
+        guard let code = locale.language.languageCode?.identifier else { return nil }
+        if code == "zh" {
+            return locale.language.script?.identifier == "Hant" ? "zh-Hant" : "zh-Hans"
+        }
+        return supportedLanguages.contains(code) ? code : nil
+    }
+}

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -338,8 +338,12 @@ struct MainWindowView: View {
             if let group = groupPendingDeletion {
                 if group.profiles.isEmpty {
                     Text("The empty group will be deleted. Base hosts and other groups are not affected.")
+                } else if group.profiles.count == 1 {
+                    // Singular/plural as whole keys: languages disagree on plural
+                    // rules, so a spliced "s" cannot localize.
+                    Text("Its profile will move to Standalone Profiles. Its content and active state will be preserved. Base hosts and other groups are not affected.")
                 } else {
-                    Text("Its \(group.profiles.count) profile\(group.profiles.count == 1 ? "" : "s") will move to Standalone Profiles in the current order. Their content and active state will be preserved. Base hosts and other groups are not affected.")
+                    Text("Its \(group.profiles.count) profiles will move to Standalone Profiles in the current order. Their content and active state will be preserved. Base hosts and other groups are not affected.")
                 }
             }
         }
@@ -1188,11 +1192,11 @@ private struct HostsDriftReviewSheet: View {
                     VStack(alignment: .leading, spacing: 10) {
                         HStack(spacing: 8) {
                             diffCountLabel(
-                                "+\(comparison.diffSummary.additions) in system hosts",
+                                String(localized: "+\(comparison.diffSummary.additions) in system hosts"),
                                 color: .green
                             )
                             diffCountLabel(
-                                "−\(comparison.diffSummary.removals) expected",
+                                String(localized: "−\(comparison.diffSummary.removals) expected"),
                                 color: .red
                             )
                             Spacer()
@@ -1360,7 +1364,10 @@ private struct SystemHostsViewerPane: View {
                 ContentUnavailableView {
                     Label("Cannot Read System Hosts", systemImage: "exclamationmark.triangle")
                 } description: {
-                    Text(store.systemHostsReadError ?? "The current /etc/hosts content is unavailable.")
+                    Text(
+                        store.systemHostsReadError
+                            ?? String(localized: "The current /etc/hosts content is unavailable.")
+                    )
                 } actions: {
                     Button("Retry") {
                         store.refreshSystemHosts()
@@ -1491,9 +1498,9 @@ private struct ProfileEditorHeader: View {
 
     private var locationDescription: String {
         if let group = store.group(containing: profile.id) {
-            return "Group: \(group.name) · One profile active at a time"
+            return String(localized: "Group: \(group.name) · One profile active at a time")
         }
-        return "Standalone profile · Toggles independently"
+        return String(localized: "Standalone profile · Toggles independently")
     }
 
     private func commitRename() {

--- a/Sources/Hostflip/MaintenanceStore.swift
+++ b/Sources/Hostflip/MaintenanceStore.swift
@@ -16,12 +16,16 @@ enum MaintenanceFeedback: Equatable {
         switch self {
         case .helperRemoved:
             Presentation(
-                title: "Helper Removed",
-                message: "The helper was deactivated and removed. Your profiles were not changed.",
+                title: String(localized: "Helper Removed"),
+                message: String(localized: "The helper was deactivated and removed. Your profiles were not changed."),
                 isFailure: false
             )
         case .helperRemovalFailed(let message):
-            Presentation(title: "Could Not Remove Helper", message: message, isFailure: true)
+            Presentation(
+                title: String(localized: "Could Not Remove Helper"),
+                message: message,
+                isFailure: true
+            )
         }
     }
 }
@@ -94,7 +98,7 @@ final class MaintenanceStore {
         } catch {
             helperStatus = await loadHelperStatus()
             feedback = .helperRemovalFailed(
-                "Could not remove the helper. Try again. Your profiles were not changed. \(error.localizedDescription)"
+                String(localized: "Could not remove the helper. Try again. Your profiles were not changed. \(error.localizedDescription)")
             )
         }
         updateApprovalPolling()

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -20,27 +20,27 @@ enum SwitchFeedback: Equatable {
 
     var title: String {
         switch self {
-        case .merged: "System Hosts Updated"
-        case .baseHostsReplaced: "Base Hosts Replaced"
-        case .needsApproval: "Approval Required"
-        case .unavailable: "Helper Unavailable"
-        case .hostsDrift: "Hosts Drift Detected"
-        case .failed: "Switch Failed"
+        case .merged: String(localized: "System Hosts Updated")
+        case .baseHostsReplaced: String(localized: "Base Hosts Replaced")
+        case .needsApproval: String(localized: "Approval Required")
+        case .unavailable: String(localized: "Helper Unavailable")
+        case .hostsDrift: String(localized: "Hosts Drift Detected")
+        case .failed: String(localized: "Switch Failed")
         }
     }
 
     var message: String {
         switch self {
         case .merged:
-            "System hosts file updated"
+            String(localized: "System hosts file updated")
         case .baseHostsReplaced:
-            "Base Hosts replaced with the current /etc/hosts content. The system file was not changed."
+            String(localized: "Base Hosts replaced with the current /etc/hosts content. The system file was not changed.")
         case .needsApproval:
-            "Switch blocked: hostflip’s background helper needs system approval"
+            String(localized: "Switch blocked: hostflip’s background helper needs system approval")
         case .unavailable:
-            "Helper unavailable: move the app to the Applications folder and reopen it"
+            String(localized: "Helper unavailable: move the app to the Applications folder and reopen it")
         case .hostsDrift:
-            "Switch blocked: system hosts contains changes made outside hostflip"
+            String(localized: "Switch blocked: system hosts contains changes made outside hostflip")
         case .failed(let message):
             message
         }
@@ -187,7 +187,7 @@ final class WorkspaceStore {
                 }
             }
         } catch {
-            loadError = "Cannot open workspace: \(error)"
+            loadError = String(localized: "Cannot open workspace: \(String(describing: error))")
         }
     }
 
@@ -200,14 +200,14 @@ final class WorkspaceStore {
             let data = try readSystemHosts()
             guard let content = String(data: data, encoding: .utf8) else {
                 systemHostsContent = nil
-                systemHostsReadError = "Cannot display /etc/hosts because it is not valid UTF-8."
+                systemHostsReadError = String(localized: "Cannot display /etc/hosts because it is not valid UTF-8.")
                 return
             }
             systemHostsContent = content
             systemHostsReadError = nil
         } catch {
             systemHostsContent = nil
-            systemHostsReadError = "Cannot read /etc/hosts: \(error)"
+            systemHostsReadError = String(localized: "Cannot read /etc/hosts: \(String(describing: error))")
         }
     }
 
@@ -324,10 +324,10 @@ final class WorkspaceStore {
     private func defaultProfileName() -> String {
         let existing = Set((model?.standaloneProfiles ?? []).map(\.name)
             + (model?.groups ?? []).flatMap { $0.profiles.map(\.name) })
-        var candidate = "New Profile"
+        var candidate = String(localized: "New Profile")
         var counter = 2
         while existing.contains(candidate) {
-            candidate = "New Profile \(counter)"
+            candidate = String(localized: "New Profile \(counter)")
             counter += 1
         }
         return candidate
@@ -415,10 +415,10 @@ final class WorkspaceStore {
 
     private func defaultGroupName() -> String {
         let existing = Set(groups.map(\.name))
-        var candidate = "New Group"
+        var candidate = String(localized: "New Group")
         var counter = 2
         while existing.contains(candidate) {
-            candidate = "New Group \(counter)"
+            candidate = String(localized: "New Group \(counter)")
             counter += 1
         }
         return candidate
@@ -488,13 +488,15 @@ final class WorkspaceStore {
                     // file until an unrelated merge.
                     commitSwitched(change)
                     switchFeedback = .failed(
-                        "System hosts was updated, but DNS refresh failed: \(failure.message)"
+                        String(localized: "System hosts was updated, but DNS refresh failed: \(failure.message)")
                     )
                 case .failed(let error):
-                    switchFeedback = .failed("Failed to update the system hosts file: \(error)")
+                    switchFeedback = .failed(
+                        String(localized: "Failed to update the system hosts file: \(String(describing: error))")
+                    )
                 }
             } catch {
-                switchFeedback = .failed("Switch failed: \(error)")
+                switchFeedback = .failed(String(localized: "Switch failed: \(String(describing: error))"))
             }
         }
     }
@@ -531,7 +533,7 @@ final class WorkspaceStore {
             backgroundSyncError = nil
         } catch {
             // The change stays committed in memory (persistByReplaying); only the disk write failed
-            saveError = "Save failed: \(error)"
+            saveError = String(localized: "Save failed: \(String(describing: error))")
         }
         switchFeedback = .merged
     }
@@ -608,20 +610,28 @@ final class WorkspaceStore {
                     else { return }
                     hasHostsDrift = false
                     hostsDriftComparison = nil
-                    let message = "System hosts was updated, but DNS refresh failed: \(failure.message)"
+                    let message = String(
+                        localized: "System hosts was updated, but DNS refresh failed: \(failure.message)"
+                    )
                     reconciliationError = message
                     switchFeedback = .failed(message)
                 case .hostsDrift:
                     refreshHostsDriftComparison()
-                    reconciliationError = "System hosts changed again. Review the latest diff before retrying."
+                    reconciliationError = String(
+                        localized: "System hosts changed again. Review the latest diff before retrying."
+                    )
                     switchFeedback = .hostsDrift
                 case .failed(let error):
-                    let message = "Failed to reconcile the system hosts file: \(error)"
+                    let message = String(
+                        localized: "Failed to reconcile the system hosts file: \(String(describing: error))"
+                    )
                     reconciliationError = message
                     switchFeedback = .failed(message)
                 }
             } catch {
-                let message = "Hosts reconciliation failed: \(error)"
+                let message = String(
+                    localized: "Hosts reconciliation failed: \(String(describing: error))"
+                )
                 reconciliationError = message
                 switchFeedback = .failed(message)
             }
@@ -630,19 +640,19 @@ final class WorkspaceStore {
 
     var useSystemHostsAsBaseUnavailableReason: String? {
         guard !isSwitching, !isReconciling else {
-            return "Wait for the current hosts operation to finish."
+            return String(localized: "Wait for the current hosts operation to finish.")
         }
         guard hasHostsDrift, let comparison = hostsDriftComparison else {
-            return "No unresolved hosts drift is available to adopt."
+            return String(localized: "No unresolved hosts drift is available to adopt.")
         }
         guard model?.activeProfileIDs.isEmpty == true else {
-            return "Deactivate every active profile before using System Hosts as Base Hosts."
+            return String(localized: "Deactivate every active profile before using System Hosts as Base Hosts.")
         }
         guard comparison.actualContent != nil else {
-            return "System Hosts must be valid UTF-8 before it can replace Base Hosts."
+            return String(localized: "System Hosts must be valid UTF-8 before it can replace Base Hosts.")
         }
         guard !comparison.containsGeneratedHostflipOutput else {
-            return "System Hosts already contains hostflip-generated sections and cannot be used as Base Hosts."
+            return String(localized: "System Hosts already contains hostflip-generated sections and cannot be used as Base Hosts.")
         }
         return nil
     }
@@ -662,13 +672,17 @@ final class WorkspaceStore {
             guard latestHash == comparison.observedActualHash else {
                 refreshSystemHosts()
                 refreshHostsDriftComparison()
-                reconciliationError = "System hosts changed again. Review the latest diff before retrying."
+                reconciliationError = String(
+                    localized: "System hosts changed again. Review the latest diff before retrying."
+                )
                 switchFeedback = .hostsDrift
                 return
             }
             guard let latestContent = String(data: latestData, encoding: .utf8) else {
                 refreshSystemHosts()
-                reconciliationError = "System Hosts must be valid UTF-8 before it can replace Base Hosts."
+                reconciliationError = String(
+                    localized: "System Hosts must be valid UTF-8 before it can replace Base Hosts."
+                )
                 switchFeedback = .hostsDrift
                 return
             }
@@ -690,7 +704,7 @@ final class WorkspaceStore {
             backgroundSyncError = nil
             switchFeedback = .baseHostsReplaced
         } catch {
-            let message = "Base Hosts could not be replaced: \(error)"
+            let message = String(localized: "Base Hosts could not be replaced: \(String(describing: error))")
             reconciliationError = message
             switchFeedback = .failed(message)
         }
@@ -701,7 +715,9 @@ final class WorkspaceStore {
             reconciliationNeedsAttention = true
             hasHostsDrift = true
             refreshHostsDriftComparison()
-            reconciliationError = "System hosts changed while reconciliation was in progress. Review the latest diff before retrying."
+            reconciliationError = String(
+                localized: "System hosts changed while reconciliation was in progress. Review the latest diff before retrying."
+            )
             switchFeedback = .hostsDrift
             return false
         }
@@ -726,11 +742,13 @@ final class WorkspaceStore {
             return true
         } catch {
             // The change stays committed in memory (persistByReplaying); only the disk write failed
-            saveError = "Save failed: \(error)"
+            saveError = String(localized: "Save failed: \(String(describing: error))")
             reconciliationNeedsAttention = true
             hasHostsDrift = true
             refreshHostsDriftComparison()
-            let message = "System hosts was updated, but the reconciliation could not be saved: \(error)"
+            let message = String(
+                localized: "System hosts was updated, but the reconciliation could not be saved: \(String(describing: error))"
+            )
             reconciliationError = message
             switchFeedback = .failed(message)
             return false
@@ -756,7 +774,7 @@ final class WorkspaceStore {
     /// is committed only after the workspace save succeeds.
     func importFiles(at urls: [URL]) -> ImportOutcome {
         guard model != nil else {
-            return .failed("Nothing was imported: the workspace is not loaded.")
+            return .failed(String(localized: "Nothing was imported: the workspace is not loaded."))
         }
         do {
             let contents = try urls.map { url in
@@ -791,7 +809,7 @@ final class WorkspaceStore {
                 }
             } else {
                 guard var updated = model else {
-                    return .failed("Nothing was imported: the workspace is not loaded.")
+                    return .failed(String(localized: "Nothing was imported: the workspace is not loaded."))
                 }
                 try applyImports(&updated)
                 try workspace.save(updated)
@@ -818,21 +836,21 @@ final class WorkspaceStore {
 
     private static func importFailureMessage(for error: any Error) -> String {
         guard let failure = error as? ImportFileFailure else {
-            return "Nothing was imported: \(error)"
+            return String(localized: "Nothing was imported: \(String(describing: error))")
         }
         let reason = switch failure.underlying as? ImportError {
         case .unsupportedVersion(let version):
-            "this file was created by a newer version of hostflip (format version \(version))"
+            String(localized: "this file was created by a newer version of hostflip (format version \(version))")
         case .malformedSnapshot:
-            "this file is JSON but not a valid hostflip export"
+            String(localized: "this file is JSON but not a valid hostflip export")
         case .blankName:
-            "the export contains a profile or group with an empty name"
+            String(localized: "the export contains a profile or group with an empty name")
         case .invalidTextEncoding:
-            "this file is not UTF-8 text"
+            String(localized: "this file is not UTF-8 text")
         case nil:
             "\(failure.underlying)"
         }
-        return "Nothing was imported. \(failure.fileName): \(reason)."
+        return String(localized: "Nothing was imported. \(failure.fileName): \(reason).")
     }
 
     // MARK: - Persisting and follow-up merging
@@ -859,7 +877,7 @@ final class WorkspaceStore {
                 return
             }
         } catch {
-            saveError = "Save failed: \(error)"
+            saveError = String(localized: "Save failed: \(String(describing: error))")
             return
         }
         scheduleFollowUpMerge()
@@ -947,13 +965,19 @@ final class WorkspaceStore {
         if let channelError = error as? DaemonChannelError {
             return backgroundSyncFailureMessage(for: channelError)
         }
-        return "Changes were saved locally, but the system hosts file could not be updated: \(error)"
+        return String(
+            localized: "Changes were saved locally, but the system hosts file could not be updated: \(String(describing: error))"
+        )
     }
 
     private func backgroundSyncFailureMessage(for error: DaemonChannelError) -> String {
         if error == .selfSigningUnavailable {
-            return "Changes were saved locally, but this build is not properly signed, so the system hosts file could not be updated."
+            return String(
+                localized: "Changes were saved locally, but this build is not properly signed, so the system hosts file could not be updated."
+            )
         }
-        return "Changes were saved locally, but the system hosts file could not be updated: \(error)"
+        return String(
+            localized: "Changes were saved locally, but the system hosts file could not be updated: \(String(describing: error))"
+        )
     }
 }

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -324,10 +324,14 @@ final class WorkspaceStore {
     private func defaultProfileName() -> String {
         let existing = Set((model?.standaloneProfiles ?? []).map(\.name)
             + (model?.groups ?? []).flatMap { $0.profiles.map(\.name) })
-        var candidate = String(localized: "New Profile")
+        // Semantic keys: the literal "New Profile" is already the menu command's
+        // key, and a command phrasing makes a poor default name in translation.
+        var candidate = String(localized: "PROFILE_DEFAULT_NAME", defaultValue: "New Profile")
         var counter = 2
         while existing.contains(candidate) {
-            candidate = String(localized: "New Profile \(counter)")
+            candidate = String(
+                localized: "PROFILE_DEFAULT_NAME_NUMBERED", defaultValue: "New Profile \(counter)"
+            )
             counter += 1
         }
         return candidate
@@ -415,10 +419,12 @@ final class WorkspaceStore {
 
     private func defaultGroupName() -> String {
         let existing = Set(groups.map(\.name))
-        var candidate = String(localized: "New Group")
+        var candidate = String(localized: "GROUP_DEFAULT_NAME", defaultValue: "New Group")
         var counter = 2
         while existing.contains(candidate) {
-            candidate = String(localized: "New Group \(counter)")
+            candidate = String(
+                localized: "GROUP_DEFAULT_NAME_NUMBERED", defaultValue: "New Group \(counter)"
+            )
             counter += 1
         }
         return candidate

--- a/Tests/HostflipTests/AppearancePreferenceStoreTests.swift
+++ b/Tests/HostflipTests/AppearancePreferenceStoreTests.swift
@@ -1,0 +1,68 @@
+import AppKit
+import XCTest
+@testable import Hostflip
+
+@MainActor
+final class AppearancePreferenceStoreTests: XCTestCase {
+    func testDefaultPreferenceIsAuto() {
+        XCTAssertEqual(AppearancePreference.default, .auto)
+    }
+
+    func testAppearanceNameMapping() {
+        XCTAssertNil(AppearancePreference.auto.appearanceName)
+        XCTAssertEqual(AppearancePreference.light.appearanceName, .aqua)
+        XCTAssertEqual(AppearancePreference.dark.appearanceName, .darkAqua)
+    }
+
+    func testStoreUsesDefaultPreferenceWhenNoPreferenceExists() {
+        var appliedAppearances: [NSAppearance.Name?] = []
+
+        let store = AppearancePreferenceStore(
+            loadPreference: { nil },
+            savePreference: { _ in },
+            applyAppearance: { appliedAppearances.append($0) }
+        )
+
+        XCTAssertEqual(store.preference, .auto)
+        XCTAssertEqual(appliedAppearances, [nil])
+    }
+
+    func testStoreRestoresPersistedPreference() {
+        var appliedAppearances: [NSAppearance.Name?] = []
+
+        let store = AppearancePreferenceStore(
+            loadPreference: { AppearancePreference.dark.rawValue },
+            savePreference: { _ in },
+            applyAppearance: { appliedAppearances.append($0) }
+        )
+
+        XCTAssertEqual(store.preference, .dark)
+        XCTAssertEqual(appliedAppearances, [.darkAqua])
+    }
+
+    func testStoreFallsBackToDefaultForUnknownPersistedValue() {
+        let store = AppearancePreferenceStore(
+            loadPreference: { "solarized" },
+            savePreference: { _ in },
+            applyAppearance: { _ in }
+        )
+
+        XCTAssertEqual(store.preference, .auto)
+    }
+
+    func testChangingPreferencePersistsAndAppliesAppearance() {
+        var savedPreferences: [String] = []
+        var appliedAppearances: [NSAppearance.Name?] = []
+        let store = AppearancePreferenceStore(
+            loadPreference: { nil },
+            savePreference: { savedPreferences.append($0) },
+            applyAppearance: { appliedAppearances.append($0) }
+        )
+
+        store.setPreference(.dark)
+
+        XCTAssertEqual(store.preference, .dark)
+        XCTAssertEqual(savedPreferences, [AppearancePreference.dark.rawValue])
+        XCTAssertEqual(appliedAppearances, [nil, .darkAqua])
+    }
+}

--- a/Tests/HostflipTests/LanguagePreferenceTests.swift
+++ b/Tests/HostflipTests/LanguagePreferenceTests.swift
@@ -1,0 +1,62 @@
+import XCTest
+@testable import Hostflip
+
+final class LanguagePreferenceTests: XCTestCase {
+    func testNoOverrideMeansSystem() {
+        XCTAssertEqual(LanguagePreference(override: nil), .system)
+        XCTAssertEqual(LanguagePreference(override: []), .system)
+        XCTAssertEqual(LanguagePreference(override: [""]), .system)
+    }
+
+    func testOverrideResolvesToCanonicalSelection() {
+        XCTAssertEqual(LanguagePreference(override: ["en"]), .english)
+        XCTAssertEqual(LanguagePreference(override: ["en-US", "ja"]), .english)
+        XCTAssertEqual(LanguagePreference(override: ["zh-Hans"]), .simplifiedChinese)
+        XCTAssertEqual(LanguagePreference(override: ["zh-Hans-CN"]), .simplifiedChinese)
+        XCTAssertEqual(LanguagePreference(override: ["zh"]), .simplifiedChinese)
+        XCTAssertEqual(LanguagePreference(override: ["zh-Hant"]), .traditionalChinese)
+        XCTAssertEqual(LanguagePreference(override: ["zh-TW"]), .traditionalChinese)
+        XCTAssertEqual(LanguagePreference(override: ["zh-Hant-HK"]), .traditionalChinese)
+        XCTAssertEqual(LanguagePreference(override: ["ja-JP"]), .japanese)
+    }
+
+    func testUnsupportedOverrideFallsBackToEnglish() {
+        XCTAssertEqual(LanguagePreference(override: ["fr"]), .english)
+        XCTAssertEqual(LanguagePreference(override: ["ko-KR"]), .english)
+    }
+
+    func testOverrideLanguagesRoundTrip() {
+        XCTAssertNil(LanguagePreference.system.overrideLanguages)
+        XCTAssertEqual(LanguagePreference.english.overrideLanguages, ["en"])
+        XCTAssertEqual(LanguagePreference.simplifiedChinese.overrideLanguages, ["zh-Hans"])
+        XCTAssertEqual(LanguagePreference.traditionalChinese.overrideLanguages, ["zh-Hant"])
+        XCTAssertEqual(LanguagePreference.japanese.overrideLanguages, ["ja"])
+    }
+
+    func testEffectiveLanguageForExplicitSelectionIsItself() {
+        XCTAssertEqual(LanguagePreference.japanese.effectiveLanguage(systemLanguages: ["zh-Hans-CN"]), "ja")
+        XCTAssertEqual(LanguagePreference.english.effectiveLanguage(systemLanguages: []), "en")
+    }
+
+    func testEffectiveLanguageForSystemWalksThePreferenceList() {
+        XCTAssertEqual(
+            LanguagePreference.system.effectiveLanguage(systemLanguages: ["fr-FR", "ja-JP", "en"]),
+            "ja"
+        )
+        XCTAssertEqual(
+            LanguagePreference.system.effectiveLanguage(systemLanguages: ["zh-Hant-TW", "zh-Hans-CN"]),
+            "zh-Hant"
+        )
+        XCTAssertEqual(
+            LanguagePreference.system.effectiveLanguage(systemLanguages: ["fr-FR", "ko-KR"]),
+            "en"
+        )
+    }
+
+    func testSupportedLanguagesMatchTheSelectableCases() {
+        XCTAssertEqual(
+            Set(LanguagePreference.allCases.compactMap { $0.overrideLanguages?.first }),
+            Set(LanguagePreference.supportedLanguages)
+        )
+    }
+}

--- a/Tests/HostflipTests/LocalizationCatalogTests.swift
+++ b/Tests/HostflipTests/LocalizationCatalogTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import XCTest
+
+/// Guards the shipped .strings catalogs (ADR-0011): the three languages must
+/// agree on keys, every value must keep the key's format specifiers, and every
+/// non-interpolated String(localized:) literal in the GUI sources must have a
+/// row in each catalog. SwiftUI literal keys are covered by release visual QA.
+final class LocalizationCatalogTests: XCTestCase {
+    private static let languages = ["zh-Hans", "zh-Hant", "ja"]
+    private static let semanticKeys: Set<String> = [
+        "PROFILE_DEFAULT_NAME", "PROFILE_DEFAULT_NAME_NUMBERED",
+        "GROUP_DEFAULT_NAME", "GROUP_DEFAULT_NAME_NUMBERED",
+    ]
+
+    private static var repoRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    private static func catalog(for language: String) throws -> [String: String] {
+        let url = repoRoot.appendingPathComponent(
+            "Packaging/Localization/\(language).lproj/Localizable.strings"
+        )
+        let data = try Data(contentsOf: url)
+        let plist = try PropertyListSerialization.propertyList(from: data, format: nil)
+        return try XCTUnwrap(plist as? [String: String], "\(language) is not a string table")
+    }
+
+    private func specifierCounts(_ text: String) -> [String: Int] {
+        [
+            "%@": text.components(separatedBy: "%@").count - 1,
+            "%lld": text.components(separatedBy: "%lld").count - 1,
+        ]
+    }
+
+    func testKeySetsMatchAcrossLanguages() throws {
+        let catalogs = try Self.languages.map { try Self.catalog(for: $0) }
+        let reference = Set(catalogs[0].keys)
+        for (language, catalog) in zip(Self.languages.dropFirst(), catalogs.dropFirst()) {
+            let keys = Set(catalog.keys)
+            XCTAssertEqual(
+                keys.symmetricDifference(reference), [],
+                "\(language) key set differs from \(Self.languages[0])"
+            )
+        }
+    }
+
+    func testValuesKeepTheKeysFormatSpecifiers() throws {
+        for language in Self.languages {
+            for (key, value) in try Self.catalog(for: language)
+            where !Self.semanticKeys.contains(key) {
+                XCTAssertEqual(
+                    specifierCounts(value), specifierCounts(key),
+                    "\(language): format specifiers of “\(key)” diverge"
+                )
+            }
+        }
+    }
+
+    func testSemanticDefaultNameKeysCarryTheCounter() throws {
+        for language in Self.languages {
+            let catalog = try Self.catalog(for: language)
+            for key in Self.semanticKeys {
+                let value = try XCTUnwrap(catalog[key], "\(language) misses \(key)")
+                let expectsCounter = key.hasSuffix("_NUMBERED")
+                XCTAssertEqual(
+                    value.contains("%lld"), expectsCounter,
+                    "\(language): \(key) placeholder mismatch"
+                )
+            }
+        }
+    }
+
+    /// Every plain (non-interpolated) String(localized:) literal in the GUI target
+    /// must exist in all catalogs — a missing row silently falls back to English.
+    func testSourceLocalizedLiteralsHaveTranslations() throws {
+        let sourcesDirectory = Self.repoRoot.appendingPathComponent("Sources/Hostflip")
+        let sourceFiles = try FileManager.default
+            .contentsOfDirectory(at: sourcesDirectory, includingPropertiesForKeys: nil)
+            .filter { $0.pathExtension == "swift" }
+        XCTAssertFalse(sourceFiles.isEmpty)
+
+        let pattern = #"String\(\s*localized:\s*"((?:[^"\\]|\\.)*)""#
+        let regex = try NSRegularExpression(
+            pattern: pattern, options: [.dotMatchesLineSeparators]
+        )
+        var keys: Set<String> = []
+        for file in sourceFiles {
+            let source = try String(contentsOf: file, encoding: .utf8)
+            let range = NSRange(source.startIndex..., in: source)
+            for match in regex.matches(in: source, range: range) {
+                guard let keyRange = Range(match.range(at: 1), in: source) else { continue }
+                let key = String(source[keyRange])
+                guard !key.contains(#"\("#) else { continue }
+                keys.insert(key)
+            }
+        }
+        XCTAssertGreaterThan(keys.count, 40, "extraction regex looks broken")
+
+        for language in Self.languages {
+            let catalog = try Self.catalog(for: language)
+            for key in keys.sorted() {
+                XCTAssertNotNil(catalog[key], "\(language) misses “\(key)”")
+            }
+        }
+    }
+}

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -26,6 +26,9 @@ cp "$BIN/hostflipd" "$APP/Contents/MacOS/hostflipd"
 cp "$BIN/hostflip" "$APP/Contents/Helpers/hostflip"
 cp Packaging/HostflipApp-Info.plist "$APP/Contents/Info.plist"
 cp Packaging/Hostflip.icns "$APP/Contents/Resources/Hostflip.icns"
+# Raw .strings ship as-is (Foundation reads uncompiled tables); Bundle.main
+# lookup needs the .lproj dirs inside Contents/Resources (ADR-0011).
+cp -R Packaging/Localization/*.lproj "$APP/Contents/Resources/"
 cp Packaging/com.heronapp.hostflip.daemon.plist "$APP/Contents/Library/LaunchDaemons/"
 # SwiftPM places the Sparkle binary artifact next to the built products; the app
 # links it via @rpath, which only resolves once Contents/Frameworks is on the path.


### PR DESCRIPTION
## What

Six commits syncing the appearance and localization work from the internal tree:

- **feat: add appearance setting (auto/light/dark)** — Settings > General gains an Appearance picker; Light/Dark force the whole app through `NSApp.appearance`, Auto leaves the system in charge.
- **feat: add in-app language setting** — a Language row (System / English / 简体中文 / 繁體中文 / 日本語) that writes the app-domain `AppleLanguages` override — the same state macOS's per-app language setting uses — with a conditional Relaunch Now row.
- **refactor: route string-typed ui copy through localized lookup** — copy stored in String properties now goes through `String(localized:)`; whole-variant accessibility labels; singular/plural split for the delete-group confirmation.
- **docs: sharpen the Active glossary entry for the paused state** — CONTEXT.md wording fix.
- **fix: lowercase the hostflip brand in accessibility labels**.
- **feat: ship simplified chinese, traditional chinese, and japanese localizations** — raw `.strings` catalogs under `Packaging/Localization/`, copied into `Contents/Resources` at packaging time and resolved via `Bundle.main`; a catalog test guards key-set equality, format-specifier parity, and literal coverage.

## Verification

- 460 tests green on the branch (includes the new preference-store, language-preference, and localization-catalog tests).
- Packaged build smoke-tested: language negotiation (`zh-Hans-CN` → `zh-Hans`, `zh-TW` → `zh-Hant`) and table lookups resolve; settings switching verified by hand in all four languages.
- gitleaks scan clean.