### PR TITLE
build: 0.1.9 release notes and version bump

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.1.8</string>
+	<string>0.1.9</string>
 	<key>CFBundleVersion</key>
-	<string>9</string>
+	<string>10</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Packaging/ReleaseNotes/0.1.9.html
+++ b/Packaging/ReleaseNotes/0.1.9.html
@@ -1,0 +1,5 @@
+<h2>What's New</h2>
+<ul>
+  <li><b>Speaks your language.</b> hostflip now ships in Simplified Chinese, Traditional Chinese, and Japanese. Pick a language in Settings &gt; General — or leave it on System and let macOS decide.</li>
+  <li><b>Appearance, your call.</b> A new Appearance setting forces the whole app light or dark, or follows the system as before.</li>
+</ul>

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -16,5 +16,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.1.8"
+    public static let version = "0.1.9"
 }


### PR DESCRIPTION
Release prep for v0.1.9:

- **build: add the 0.1.9 release notes** — Sparkle dialog copy covering the three localizations and the appearance setting.
- **build: bump version to 0.1.9** — CFBundleShortVersionString 0.1.9, CFBundleVersion 10, HostflipBuild.version in lockstep (the release guard checks they agree).

460 tests green. After merge, the release pipeline runs from a public-repo clone.