### PR TITLE
feat: add one-click switchhosts import across v3/v4/v5 formats

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.2.0</string>
+	<string>0.3.0</string>
 	<key>CFBundleVersion</key>
-	<string>11</string>
+	<string>12</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -178,6 +178,34 @@
 "Imported %lld profiles." = "%lld 件のプロファイルを読み込みました。";
 "Remote profiles will fetch content from these URLs:" = "リモートプロファイルの内容は次の URL から取得されます:";
 
+/* SwitchHosts import */
+"Import from SwitchHosts…" = "SwitchHosts から読み込む…";
+"SwitchHosts Import Complete" = "SwitchHosts の読み込み完了";
+"Imported 1 profile from SwitchHosts." = "SwitchHosts から 1 件のプロファイルを読み込みました。";
+"Imported %lld profiles from SwitchHosts." = "SwitchHosts から %lld 件のプロファイルを読み込みました。";
+"Created 1 group." = "1 件のグループを作成しました。";
+"Created %lld groups." = "%lld 件のグループを作成しました。";
+"1 remote rule became a Remote Profile and will fetch content from this URL:" = "1 件のリモートルールがリモートプロファイルに変換され、次の URL から内容を取得します:";
+"%lld remote rules became Remote Profiles and will fetch content from these URLs:" = "%lld 件のリモートルールがリモートプロファイルに変換され、次の URL から内容を取得します:";
+"Skipped:" = "スキップした項目:";
+"System hosts entries: %lld" = "システム hosts の項目: %lld";
+"History snapshots: %lld" = "履歴スナップショット: %lld";
+"Trashed items: %lld" = "ゴミ箱の項目: %lld";
+"Notes:" = "注意:";
+"Profiles in “%@” are now mutually exclusive; move a profile out of the group to stack it." = "「%@」内のプロファイルは今後互いに排他になります。重ねて適用するには、プロファイルをグループの外に移動してください。";
+"“%@” was expanded to a snapshot of its members and will no longer update with them." = "「%@」はメンバーの内容のスナップショットに展開され、今後メンバーに追随しません。";
+"“%@” will refresh every %@ instead of every %@." = "「%@」は今後 %@ ごとに更新されます（元は %@ ごと）。";
+"“%@” was imported as a local profile: %@ is not an HTTPS URL." = "「%@」はローカルプロファイルとして読み込まれました: %@ は HTTPS の URL ではありません。";
+"Nothing was imported: no SwitchHosts data was found in that folder." = "何も読み込まれませんでした: そのフォルダに SwitchHosts のデータが見つかりません。";
+"Nothing was imported: the SwitchHosts data could not be read (%@)." = "何も読み込まれませんでした: SwitchHosts のデータを読み取れません（%@）。";
+"Detected SwitchHosts v%lld data." = "SwitchHosts v%lld のデータを検出しました。";
+"Import from SwitchHosts?" = "SwitchHosts から読み込みますか？";
+"hostflip found existing SwitchHosts data on this Mac. Imported profiles arrive inactive, so nothing changes until you activate them. This suggestion appears only once; the File menu keeps an import entry." = "hostflip はこの Mac で SwitchHosts のデータを見つけました。読み込まれたプロファイルはすべて未適用の状態で追加されるため、適用するまで何も変わりません。この案内は一度だけ表示されます。以後も「ファイル」メニューから読み込めます。";
+"Import" = "読み込む";
+"Don’t Import" = "読み込まない";
+"Select your SwitchHosts data folder" = "SwitchHosts のデータフォルダを選択してください";
+"Choose Folder…" = "フォルダを選択…";
+
 /* Helper maintenance */
 "Helper Ready" = "ヘルパーは準備完了";
 "The helper is approved and ready to update the system hosts file." = "ヘルパーは承認済みで、システム hosts ファイルを更新できます。";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -178,6 +178,34 @@
 "Imported %lld profiles." = "已导入 %lld 个方案。";
 "Remote profiles will fetch content from these URLs:" = "远程方案将从以下 URL 获取内容：";
 
+/* SwitchHosts import */
+"Import from SwitchHosts…" = "从 SwitchHosts 导入…";
+"SwitchHosts Import Complete" = "SwitchHosts 导入完成";
+"Imported 1 profile from SwitchHosts." = "已从 SwitchHosts 导入 1 个方案。";
+"Imported %lld profiles from SwitchHosts." = "已从 SwitchHosts 导入 %lld 个方案。";
+"Created 1 group." = "创建了 1 个分组。";
+"Created %lld groups." = "创建了 %lld 个分组。";
+"1 remote rule became a Remote Profile and will fetch content from this URL:" = "1 条远程规则已转为远程方案，将从以下 URL 获取内容：";
+"%lld remote rules became Remote Profiles and will fetch content from these URLs:" = "%lld 条远程规则已转为远程方案，将从以下 URL 获取内容：";
+"Skipped:" = "已跳过：";
+"System hosts entries: %lld" = "系统 hosts 条目：%lld";
+"History snapshots: %lld" = "历史快照：%lld";
+"Trashed items: %lld" = "回收站条目：%lld";
+"Notes:" = "请注意：";
+"Profiles in “%@” are now mutually exclusive; move a profile out of the group to stack it." = "「%@」分组内的方案现为互斥；如需叠加生效，请将方案移出分组。";
+"“%@” was expanded to a snapshot of its members and will no longer update with them." = "「%@」已展开为其成员内容的快照，不再随成员更新。";
+"“%@” will refresh every %@ instead of every %@." = "「%@」将改为每 %@ 刷新一次（原为每 %@）。";
+"“%@” was imported as a local profile: %@ is not an HTTPS URL." = "「%@」已作为本地方案导入：%@ 不是 HTTPS URL。";
+"Nothing was imported: no SwitchHosts data was found in that folder." = "未导入任何内容：该文件夹中未找到 SwitchHosts 数据。";
+"Nothing was imported: the SwitchHosts data could not be read (%@)." = "未导入任何内容：SwitchHosts 数据无法读取（%@）。";
+"Detected SwitchHosts v%lld data." = "检测到 SwitchHosts v%lld 数据。";
+"Import from SwitchHosts?" = "从 SwitchHosts 导入？";
+"hostflip found existing SwitchHosts data on this Mac. Imported profiles arrive inactive, so nothing changes until you activate them. This suggestion appears only once; the File menu keeps an import entry." = "hostflip 在这台 Mac 上发现了 SwitchHosts 数据。导入的方案全部为未生效状态，在你启用之前不会有任何变化。此提示仅显示一次；之后仍可从「文件」菜单导入。";
+"Import" = "导入";
+"Don’t Import" = "不导入";
+"Select your SwitchHosts data folder" = "选择 SwitchHosts 数据文件夹";
+"Choose Folder…" = "选择文件夹…";
+
 /* Helper maintenance */
 "Helper Ready" = "辅助程序就绪";
 "The helper is approved and ready to update the system hosts file." = "辅助程序已获批准，可以更新系统 hosts 文件。";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -178,6 +178,34 @@
 "Imported %lld profiles." = "已匯入 %lld 個方案。";
 "Remote profiles will fetch content from these URLs:" = "遠端方案將從以下 URL 取得內容：";
 
+/* SwitchHosts import */
+"Import from SwitchHosts…" = "從 SwitchHosts 匯入…";
+"SwitchHosts Import Complete" = "SwitchHosts 匯入完成";
+"Imported 1 profile from SwitchHosts." = "已從 SwitchHosts 匯入 1 個方案。";
+"Imported %lld profiles from SwitchHosts." = "已從 SwitchHosts 匯入 %lld 個方案。";
+"Created 1 group." = "建立了 1 個群組。";
+"Created %lld groups." = "建立了 %lld 個群組。";
+"1 remote rule became a Remote Profile and will fetch content from this URL:" = "1 條遠端規則已轉為遠端方案，將從以下 URL 取得內容：";
+"%lld remote rules became Remote Profiles and will fetch content from these URLs:" = "%lld 條遠端規則已轉為遠端方案，將從以下 URL 取得內容：";
+"Skipped:" = "已略過：";
+"System hosts entries: %lld" = "系統 hosts 項目：%lld";
+"History snapshots: %lld" = "歷史快照：%lld";
+"Trashed items: %lld" = "垃圾桶項目：%lld";
+"Notes:" = "請注意：";
+"Profiles in “%@” are now mutually exclusive; move a profile out of the group to stack it." = "「%@」群組內的方案現為互斥；如需疊加生效，請將方案移出群組。";
+"“%@” was expanded to a snapshot of its members and will no longer update with them." = "「%@」已展開為其成員內容的快照，不再隨成員更新。";
+"“%@” will refresh every %@ instead of every %@." = "「%@」將改為每 %@ 重新整理一次（原為每 %@）。";
+"“%@” was imported as a local profile: %@ is not an HTTPS URL." = "「%@」已作為本機方案匯入：%@ 不是 HTTPS URL。";
+"Nothing was imported: no SwitchHosts data was found in that folder." = "未匯入任何內容：該檔案夾中找不到 SwitchHosts 資料。";
+"Nothing was imported: the SwitchHosts data could not be read (%@)." = "未匯入任何內容：無法讀取 SwitchHosts 資料（%@）。";
+"Detected SwitchHosts v%lld data." = "偵測到 SwitchHosts v%lld 資料。";
+"Import from SwitchHosts?" = "從 SwitchHosts 匯入？";
+"hostflip found existing SwitchHosts data on this Mac. Imported profiles arrive inactive, so nothing changes until you activate them. This suggestion appears only once; the File menu keeps an import entry." = "hostflip 在這台 Mac 上發現了 SwitchHosts 資料。匯入的方案全部為未生效狀態，在你啟用之前不會有任何變化。此提示只會顯示一次；之後仍可從「檔案」選單匯入。";
+"Import" = "匯入";
+"Don’t Import" = "不匯入";
+"Select your SwitchHosts data folder" = "選擇 SwitchHosts 資料所在的檔案夾";
+"Choose Folder…" = "選擇檔案夾…";
+
 /* Helper maintenance */
 "Helper Ready" = "輔助程式已就緒";
 "The helper is approved and ready to update the system hosts file." = "輔助程式已獲核准，可以更新系統 hosts 檔案。";

--- a/Packaging/ReleaseNotes/0.3.0.html
+++ b/Packaging/ReleaseNotes/0.3.0.html
@@ -1,0 +1,5 @@
+<h2>What's New</h2>
+<ul>
+  <li><b>Import from SwitchHosts.</b> One click brings your whole SwitchHosts setup over — every generation of its data format (v3, v4, and the current v5) is detected automatically. Folders become groups (nested paths flatten into the group name), remote rules become Remote Profiles that keep refreshing on their own, and combined rules arrive as frozen content snapshots. Everything lands inactive, so nothing changes until you activate it, and the import summary reports exactly what came in, what was skipped, and what was adjusted.</li>
+  <li><b>Found where you keep it.</b> hostflip looks in the default SwitchHosts location and follows a custom data-directory setting; a folder picker covers anything else. When SwitchHosts data is present, a one-time suggestion offers the import on first launch — the File menu keeps a permanent entry either way.</li>
+</ul>

--- a/README.md
+++ b/README.md
@@ -85,6 +85,14 @@ To confirm the switch itself took effect, ask the system resolver directly: `dsc
 
 One adjacent trap: with DNS-over-HTTPS enabled (Chrome's "Secure DNS", Firefox's TRR), some configurations bypass `/etc/hosts` entirely. That shows up as hosts entries *never* working — different from needing a browser restart.
 
+**I clicked “Deactivate and Remove Helper”, but System Settings still lists Hostflip under App Background Activity.**
+
+The button did complete its job: the helper is unregistered from the system's background-task records, it stops running, and nothing of hostflip launches in the background afterwards — the status light drops to “Helper Not Installed”, and your next profile switch simply requests the helper again.
+
+The row under System Settings → General → Login Items & Extensions → App Background Activity belongs to macOS, not to the app. Its toggle records your permission for Hostflip to run background items, and macOS keeps showing the row while the app remains installed, whether or not anything is currently registered. Once you delete `Hostflip.app`, the row clears on its own (System Settings may need a relaunch, or occasionally a log-out, before it notices).
+
+There is no supported command to remove a single app's row. The only lever macOS offers is `sudo sfltool resetbtm`, which wipes the background-item records of **every** app on the machine and makes each one re-prompt — a troubleshooting measure of last resort, not part of a normal uninstall.
+
 ## Updating
 
 - Homebrew: `brew upgrade --cask hostflip`
@@ -100,7 +108,7 @@ An ad-hoc build verifies the packaging structure, but the XPC channel intentiona
 
 ## Uninstall
 
-Use “Deactivate and Remove Helper…” in the app first (unregisters the daemon), then delete `Hostflip.app`. `brew uninstall --zap --cask hostflip` also clears application data.
+Use “Deactivate and Remove Helper…” in the app first (unregisters the daemon), then delete `Hostflip.app`. `brew uninstall --zap --cask hostflip` also clears application data. The Hostflip row under App Background Activity in System Settings clears once the app is deleted — see the FAQ if it seems to linger.
 
 Note that `/etc/hosts` keeps whatever hostflip last wrote — uninstalling does not rewrite it. Everything hostflip added sits in a clearly fenced block at the bottom of the file (`# ══ hostflip:begin … ══` through `# ══ hostflip:end ══`), so leftover entries are easy to spot and delete by hand. Better still, turn off the master switch **before** removing the helper: that restores the file to exactly your baseline hosts, with no hostflip traces at all — once the helper is gone, hostflip can no longer write the file. Your pre-hostflip hosts file is also preserved as `hosts.orig` in `~/Library/Application Support/hostflip` until that folder is zapped.
 

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -71,6 +71,11 @@ struct HostflipApp: App {
             MainWindowView(store: store, maintenanceStore: maintenanceStore)
                 .onAppear {
                     dockIconStore.mainWindowDidOpen()
+                    // Deferred so the window paints before the one-time SwitchHosts
+                    // suggestion's modal alert can block the run loop (#75).
+                    Task { @MainActor in
+                        SwitchHostsImportFlow.offerSuggestionIfNeeded(store: store)
+                    }
                 }
                 .onDisappear {
                     dockIconStore.mainWindowDidClose()

--- a/Sources/Hostflip/ImportExportCommands.swift
+++ b/Sources/Hostflip/ImportExportCommands.swift
@@ -14,6 +14,11 @@ struct ImportExportCommands: Commands {
             }
             .disabled(store.model == nil)
 
+            Button("Import from SwitchHosts…") {
+                SwitchHostsImportFlow.run(store: store)
+            }
+            .disabled(store.model == nil)
+
             Button("Export…") {
                 runExportPanel()
             }

--- a/Sources/Hostflip/SwitchHostsImportFlow.swift
+++ b/Sources/Hostflip/SwitchHostsImportFlow.swift
@@ -1,0 +1,89 @@
+import AppKit
+import HostflipCore
+
+/// The one SwitchHosts import flow (#74/#75, ADR-0013), shared by the File menu entry and
+/// the first-launch suggestion: discovery chain first, a manual folder picker as the
+/// fallback, then the import summary or failure alert.
+@MainActor
+enum SwitchHostsImportFlow {
+    static func run(store: WorkspaceStore) {
+        NSApp.activate()
+        if let directory = SwitchHostsDiscovery.discoverDataDirectory() {
+            importAndPresent(store: store, directory: directory)
+        } else if let directory = runFolderPanel() {
+            importAndPresent(store: store, directory: directory)
+        }
+    }
+
+    /// The first-launch one-time suggestion (#75): offered when SwitchHosts data is
+    /// discoverable, then never again — accepting, declining, and the shown alert itself
+    /// all burn the single offer; the File menu stays as the durable entry point.
+    static func offerSuggestionIfNeeded(
+        store: WorkspaceStore,
+        suggestion: SwitchHostsImportSuggestion = SwitchHostsImportSuggestion()
+    ) {
+        guard store.model != nil,
+              !suggestion.wasOffered,
+              let directory = SwitchHostsDiscovery.discoverDataDirectory()
+        else { return }
+        suggestion.markOffered()
+
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Import from SwitchHosts?")
+        alert.informativeText = String(localized: "hostflip found existing SwitchHosts data on this Mac. Imported profiles arrive inactive, so nothing changes until you activate them. This suggestion appears only once; the File menu keeps an import entry.")
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "Import"))
+        alert.addButton(withTitle: String(localized: "Don’t Import"))
+        NSApp.activate()
+        guard alert.runModal() == .alertFirstButtonReturn else { return }
+        importAndPresent(store: store, directory: directory)
+    }
+
+    private static func importAndPresent(store: WorkspaceStore, directory: URL) {
+        switch store.importSwitchHosts(at: directory) {
+        case .imported(let summary):
+            presentSummary(summary)
+        case .failed(let message):
+            presentFailure(store: store, message: message)
+        }
+    }
+
+    /// The manual pick lands on either the data directory itself or a wrapper holding a
+    /// `SwitchHosts.data/` store — the reader resolves both.
+    private static func runFolderPanel() -> URL? {
+        let panel = NSOpenPanel()
+        panel.canChooseDirectories = true
+        panel.canChooseFiles = false
+        panel.allowsMultipleSelection = false
+        panel.showsHiddenFiles = true
+        panel.message = String(localized: "Select your SwitchHosts data folder")
+        panel.prompt = String(localized: "Import")
+        guard panel.runModal() == .OK else { return nil }
+        return panel.url
+    }
+
+    private static func presentSummary(_ summary: SwitchHostsImportSummary) {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "SwitchHosts Import Complete")
+        alert.informativeText = SwitchHostsImportPresentation.paragraphs(for: summary)
+            .joined(separator: "\n\n")
+        alert.alertStyle = .informational
+        alert.addButton(withTitle: String(localized: "OK"))
+        alert.runModal()
+    }
+
+    /// Failure keeps the flow alive: a corrupt or stale marker in a discovered directory
+    /// must not strand the user without the manual pick, so every failure alert offers
+    /// choosing another folder and retrying through the same path.
+    private static func presentFailure(store: WorkspaceStore, message: String) {
+        let alert = NSAlert()
+        alert.messageText = String(localized: "Import Failed")
+        alert.informativeText = message
+        alert.alertStyle = .warning
+        alert.addButton(withTitle: String(localized: "Choose Folder…"))
+        alert.addButton(withTitle: String(localized: "Cancel"))
+        guard alert.runModal() == .alertFirstButtonReturn,
+              let directory = runFolderPanel() else { return }
+        importAndPresent(store: store, directory: directory)
+    }
+}

--- a/Sources/Hostflip/SwitchHostsImportPresentation.swift
+++ b/Sources/Hostflip/SwitchHostsImportPresentation.swift
@@ -1,0 +1,90 @@
+import Foundation
+import HostflipCore
+
+/// The localized paragraphs of the SwitchHosts import summary alert (#74): counts, the
+/// transposed Remote Profiles with their Source URLs, the skipped list, and every deliberate
+/// semantic shift. ADR-0013 forbids silent drops and silent shifts, so whatever the summary
+/// carries is rendered — nothing is elided.
+enum SwitchHostsImportPresentation {
+    static func paragraphs(for summary: SwitchHostsImportSummary) -> [String] {
+        var paragraphs = [countsLine(for: summary)]
+        if !summary.remoteProfiles.isEmpty {
+            let header = summary.remoteProfiles.count == 1
+                ? String(localized: "1 remote rule became a Remote Profile and will fetch content from this URL:")
+                : String(localized: "\(summary.remoteProfiles.count) remote rules became Remote Profiles and will fetch content from these URLs:")
+            paragraphs.append(
+                header + "\n" + summary.remoteProfiles
+                    .map { "\($0.profileName) — \($0.sourceURL)" }
+                    .joined(separator: "\n")
+            )
+        }
+        let skipped = skippedLines(for: summary)
+        if !skipped.isEmpty {
+            paragraphs.append(String(localized: "Skipped:") + "\n" + skipped.joined(separator: "\n"))
+        }
+        let notes = noteLines(for: summary)
+        if !notes.isEmpty {
+            paragraphs.append(String(localized: "Notes:") + "\n" + notes.joined(separator: "\n"))
+        }
+        return paragraphs
+    }
+
+    private static func countsLine(for summary: SwitchHostsImportSummary) -> String {
+        var line = summary.profileCount == 1
+            ? String(localized: "Imported 1 profile from SwitchHosts.")
+            : String(localized: "Imported \(summary.profileCount) profiles from SwitchHosts.")
+        if summary.groupCount > 0 {
+            line += " " + (summary.groupCount == 1
+                ? String(localized: "Created 1 group.")
+                : String(localized: "Created \(summary.groupCount) groups."))
+        }
+        if let format = summary.detectedFormat {
+            line += " " + String(localized: "Detected SwitchHosts v\(format.rawValue) data.")
+        }
+        return line
+    }
+
+    private static func skippedLines(for summary: SwitchHostsImportSummary) -> [String] {
+        var lines: [String] = []
+        if summary.skippedSystemEntryCount > 0 {
+            lines.append(String(localized: "System hosts entries: \(summary.skippedSystemEntryCount)"))
+        }
+        if summary.skippedHistoryEntryCount > 0 {
+            lines.append(String(localized: "History snapshots: \(summary.skippedHistoryEntryCount)"))
+        }
+        if summary.skippedTrashedItemCount > 0 {
+            lines.append(String(localized: "Trashed items: \(summary.skippedTrashedItemCount)"))
+        }
+        return lines
+    }
+
+    private static func noteLines(for summary: SwitchHostsImportSummary) -> [String] {
+        var lines: [String] = []
+        for name in summary.exclusivityTightenedGroups {
+            lines.append(String(localized: "Profiles in “\(name)” are now mutually exclusive; move a profile out of the group to stack it."))
+        }
+        for name in summary.frozenCombinedProfiles {
+            lines.append(String(localized: "“\(name)” was expanded to a snapshot of its members and will no longer update with them."))
+        }
+        for remoteProfile in summary.remoteProfiles {
+            // Manual is never marked adjusted, so an adjusted entry always has a period.
+            guard let seconds = remoteProfile.adjustedFromSeconds,
+                  let period = remoteProfile.interval.period
+            else { continue }
+            lines.append(String(localized: "“\(remoteProfile.profileName)” will refresh every \(duration(seconds: Int(period))) instead of every \(duration(seconds: seconds))."))
+        }
+        for downgraded in summary.downgradedRemotes {
+            lines.append(String(localized: "“\(downgraded.profileName)” was imported as a local profile: \(downgraded.urlString) is not an HTTPS URL."))
+        }
+        return lines
+    }
+
+    /// Durations localize through the formatter (per the app language at runtime), so the
+    /// catalogs only carry the sentence around them.
+    private static func duration(seconds: Int) -> String {
+        let formatter = DateComponentsFormatter()
+        formatter.allowedUnits = [.day, .hour, .minute]
+        formatter.unitsStyle = .full
+        return formatter.string(from: TimeInterval(seconds)) ?? "\(seconds)s"
+    }
+}

--- a/Sources/Hostflip/SwitchHostsImportSuggestion.swift
+++ b/Sources/Hostflip/SwitchHostsImportSuggestion.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// The one-shot flag behind the first-launch SwitchHosts import suggestion (#75,
+/// ADR-0013): the offer is made at most once, ever — marking happens when the suggestion
+/// is shown, so accepting, declining, and quitting mid-alert all count as the one offer.
+struct SwitchHostsImportSuggestion {
+    private static let offeredKey = "switchHostsImportSuggestionOffered"
+
+    private let loadOffered: () -> Bool
+    private let saveOffered: () -> Void
+
+    init() {
+        let defaults = UserDefaults.standard
+        self.init(
+            loadOffered: { defaults.bool(forKey: Self.offeredKey) },
+            saveOffered: { defaults.set(true, forKey: Self.offeredKey) }
+        )
+    }
+
+    init(loadOffered: @escaping () -> Bool, saveOffered: @escaping () -> Void) {
+        self.loadOffered = loadOffered
+        self.saveOffered = saveOffered
+    }
+
+    var wasOffered: Bool {
+        loadOffered()
+    }
+
+    func markOffered() {
+        saveOffered()
+    }
+}

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -60,6 +60,13 @@ enum ImportOutcome: Equatable {
     case failed(String)
 }
 
+/// Result of one SwitchHosts import (#74): the full mapping report on success — counts,
+/// transposed Remote Profiles, skips, and semantic shifts — or a failure with zero change.
+enum SwitchHostsImportOutcome: Equatable {
+    case imported(SwitchHostsImportSummary)
+    case failed(String)
+}
+
 /// Result of the create-remote-profile flow (ADR-0012): success dismisses the dialog and selects
 /// the new profile; failure keeps it open with display copy so the user can retry or cancel.
 enum RemoteProfileCreationOutcome: Equatable {
@@ -1517,29 +1524,58 @@ final class WorkspaceStore {
                     }
                 }
             }
-            // Imports commit only when the save succeeds, so this path stays off persistByReplaying,
-            // whose disk-failure fallback would keep the imported content in memory.
-            if saveError == nil {
-                switch try workspace.save(applying: applyImports) {
-                case .saved(let saved):
-                    model = saved
-                case .conflict(let latest, let reason):
-                    model = latest
-                    throw reason
-                }
-            } else {
-                guard var updated = model else {
-                    return .failed(String(localized: "Nothing was imported: the workspace is not loaded."))
-                }
-                try applyImports(&updated)
-                try workspace.save(updated)
-                model = updated
-                saveError = nil
-            }
+            try commitImportBatch(applying: applyImports)
             return .imported(ImportSummary(of: contents))
         } catch {
             return .failed(Self.importFailureMessage(for: error))
         }
+    }
+
+    /// One-click SwitchHosts migration (#74/#75, ADR-0013): reads whatever generation the
+    /// directory holds offline, maps it to native profiles, and applies the plan through
+    /// the same commit path as importFiles — inactive content, no applyEdit, and any parse
+    /// failure means zero change. The detected format rides on the summary; the mapping
+    /// engine never sees it.
+    func importSwitchHosts(at directory: URL) -> SwitchHostsImportOutcome {
+        guard model != nil else {
+            return .failed(String(localized: "Nothing was imported: the workspace is not loaded."))
+        }
+        do {
+            let (data, format) = try SwitchHostsReader.read(at: directory)
+            var plan = SwitchHostsMapper.plan(for: data)
+            plan.summary.detectedFormat = format
+            try commitImportBatch { [plan] in try $0.importSnapshot(plan.snapshot) }
+            return .imported(plan.summary)
+        } catch {
+            return .failed(Self.switchHostsImportFailureMessage(for: error))
+        }
+    }
+
+    /// Shared commit path of the import entries: the batch commits only when the save
+    /// succeeds, so imports stay off persistByReplaying, whose disk-failure fallback would
+    /// keep the imported content in memory.
+    private func commitImportBatch(applying applyImports: (inout ActivationModel) throws -> Void) throws {
+        if saveError == nil {
+            switch try workspace.save(applying: applyImports) {
+            case .saved(let saved):
+                model = saved
+            case .conflict(let latest, let reason):
+                model = latest
+                throw reason
+            }
+        } else {
+            guard var updated = model else {
+                throw ImportCommitError.workspaceNotLoaded
+            }
+            try applyImports(&updated)
+            try workspace.save(updated)
+            model = updated
+            saveError = nil
+        }
+    }
+
+    private enum ImportCommitError: Error {
+        case workspaceNotLoaded
     }
 
     /// A portable snapshot of every profile and the group structure; Base Hosts and active state
@@ -1555,6 +1591,9 @@ final class WorkspaceStore {
     }
 
     private static func importFailureMessage(for error: any Error) -> String {
+        if case ImportCommitError.workspaceNotLoaded = error {
+            return String(localized: "Nothing was imported: the workspace is not loaded.")
+        }
         guard let failure = error as? ImportFileFailure else {
             return String(localized: "Nothing was imported: \(String(describing: error))")
         }
@@ -1571,6 +1610,19 @@ final class WorkspaceStore {
             "\(failure.underlying)"
         }
         return String(localized: "Nothing was imported. \(failure.fileName): \(reason).")
+    }
+
+    private static func switchHostsImportFailureMessage(for error: any Error) -> String {
+        switch error {
+        case SwitchHostsImportError.dataNotFound:
+            String(localized: "Nothing was imported: no SwitchHosts data was found in that folder.")
+        case SwitchHostsImportError.malformedData(let file):
+            String(localized: "Nothing was imported: the SwitchHosts data could not be read (\(file)).")
+        case ImportCommitError.workspaceNotLoaded:
+            String(localized: "Nothing was imported: the workspace is not loaded.")
+        default:
+            String(localized: "Nothing was imported: \(String(describing: error))")
+        }
     }
 
     // MARK: - Persisting and follow-up merging

--- a/Sources/HostflipCore/SwitchHostsDiscovery.swift
+++ b/Sources/HostflipCore/SwitchHostsDiscovery.swift
@@ -1,0 +1,133 @@
+import Foundation
+
+/// The SwitchHosts persistence generation a data directory holds (#75, ADR-0013). The raw
+/// value is the marketing major version, shown in the import summary's format note.
+public enum SwitchHostsFormat: Int, Equatable, Sendable {
+    case v3 = 3
+    case v4 = 4
+    case v5 = 5
+}
+
+/// Format detection and the unified read entry over the per-generation readers (#75).
+public enum SwitchHostsReader {
+    /// The generation stored at this directory, or nil for no SwitchHosts data. Probed
+    /// newest first — when several generations' leftovers coexist (an upgraded install
+    /// keeps archives around), the newest is the live one (ADR-0013).
+    public static func detectFormat(at root: URL) -> SwitchHostsFormat? {
+        let fileManager = FileManager.default
+        if fileManager.fileExists(atPath: root.appendingPathComponent("manifest.json").path) {
+            return .v5
+        }
+        if fileManager.fileExists(atPath: root.appendingPathComponent("data/list/tree.json").path) {
+            return .v4
+        }
+        if fileManager.fileExists(atPath: root.appendingPathComponent("data.json").path) {
+            return .v3
+        }
+        return nil
+    }
+
+    /// Where the data actually lives for a user-supplied directory: the directory itself,
+    /// or its `SwitchHosts.data/` subdirectory — v5 nests the store under that name inside
+    /// a custom location, and a manual pick may land on either level. The newest generation
+    /// wins across both levels, so older leftovers beside a nested v5 store never shadow it
+    /// (the ADR-0013 detection order, applied to the whole candidate set).
+    public static func resolveDataRoot(at directory: URL) -> (root: URL, format: SwitchHostsFormat)? {
+        [directory, directory.appendingPathComponent("SwitchHosts.data", isDirectory: true)]
+            .compactMap { candidate in detectFormat(at: candidate).map { (candidate, $0) } }
+            .max { $0.1.rawValue < $1.1.rawValue }
+    }
+
+    /// Reads whatever generation the directory holds into the shared intermediate model.
+    /// The format tag rides along for the import summary; the mapping engine never sees it.
+    public static func read(at directory: URL) throws -> (data: SwitchHostsData, format: SwitchHostsFormat) {
+        guard let (root, format) = resolveDataRoot(at: directory) else {
+            throw SwitchHostsImportError.dataNotFound
+        }
+        let data = switch format {
+        case .v5: try SwitchHostsV5Reader.read(at: root)
+        case .v4: try SwitchHostsV4Reader.read(at: root)
+        case .v3: try SwitchHostsV3Reader.read(at: root)
+        }
+        return (data, format)
+    }
+}
+
+/// The data directory discovery chain (#75, ADR-0013): default `~/.SwitchHosts` → the v5
+/// custom-directory pointer → nil, which the UI answers with a manual folder picker.
+public enum SwitchHostsDiscovery {
+    /// The resolved data root of the first chain link that holds data, or nil when the
+    /// chain is exhausted. v4's Electron userData pointer is deliberately not consulted
+    /// (ADR-0013): rare, and the manual pick covers it.
+    public static func discoverDataDirectory(
+        homeDirectory: URL = FileManager.default.homeDirectoryForCurrentUser,
+        applicationSupportDirectory: URL? = FileManager.default
+            .urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+    ) -> URL? {
+        var candidates = [homeDirectory.appendingPathComponent(".SwitchHosts", isDirectory: true)]
+        if let applicationSupportDirectory,
+           let pointed = customDataDirectory(applicationSupportDirectory: applicationSupportDirectory) {
+            candidates.append(pointed)
+        }
+        for candidate in candidates {
+            if let (root, _) = SwitchHostsReader.resolveDataRoot(at: candidate) {
+                return root
+            }
+        }
+        return nil
+    }
+
+    /// The directory the v5 pointer file names, or nil without a readable pointer. The
+    /// pointer lives in v5's config directory (`net.oldj.switchhosts/data_dir.json`); the
+    /// key is read in both spellings since only the serialized form is observable.
+    private static func customDataDirectory(applicationSupportDirectory: URL) -> URL? {
+        let pointerURL = applicationSupportDirectory
+            .appendingPathComponent("net.oldj.switchhosts/data_dir.json")
+        guard let data = try? Data(contentsOf: pointerURL),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let path = (object["dataDir"] ?? object["data_dir"]) as? String,
+              !path.isEmpty
+        else { return nil }
+        return URL(fileURLWithPath: path)
+    }
+}
+
+/// Parsing helpers shared by the per-generation readers.
+enum SwitchHostsReaderSupport {
+    static func decode<Value: Decodable>(
+        _ type: Value.Type,
+        at url: URL,
+        file: String
+    ) throws -> Value {
+        guard let data = try? Data(contentsOf: url),
+              let value = try? JSONDecoder().decode(Value.self, from: data)
+        else {
+            throw SwitchHostsImportError.malformedData(file: file)
+        }
+        return value
+    }
+
+    /// Every tree entry must carry a unique, non-empty id — content lookup and combined
+    /// rules resolve members by id, so a hole or collision would silently misattribute
+    /// content. Refusing the batch keeps ADR-0008's one-bad-file-zero-change promise.
+    static func validateIDs(of items: [SwitchHostsItem], file: String) throws {
+        var seen: Set<String> = []
+        var pending = items
+        while let item = pending.popLast() {
+            guard !item.id.isEmpty, seen.insert(item.id).inserted else {
+                throw SwitchHostsImportError.malformedData(file: file)
+            }
+            if case .folder(_, let children) = item.kind {
+                pending.append(contentsOf: children)
+            }
+        }
+    }
+
+    /// Int(exactly:) rejects non-finite and out-of-range doubles instead of trapping;
+    /// absurd magnitudes clamp to the nearest representable meaning — a huge positive
+    /// cadence stays "very slow" (24h after mapping, disclosed as adjusted), anything
+    /// else reads as "never".
+    static func clampedSeconds(_ value: Double) -> Int {
+        Int(exactly: value.rounded()) ?? (value > 0 ? .max : .min)
+    }
+}

--- a/Sources/HostflipCore/SwitchHostsImport.swift
+++ b/Sources/HostflipCore/SwitchHostsImport.swift
@@ -1,0 +1,314 @@
+import Foundation
+
+/// SwitchHosts data read from one of its persistence formats (#74, ADR-0013). This is the
+/// format-independent intermediate model between the per-version readers and the mapping
+/// engine: the v4 reader produces it today, and the v5/v3 readers (M2) will produce the same
+/// shape so the engine never learns about on-disk formats.
+public struct SwitchHostsData: Equatable, Sendable {
+    /// The tree as SwitchHosts shows it: top-level entries and folders, in list order.
+    public var items: [SwitchHostsItem]
+    /// Records in the history collection; never imported, counted for the summary.
+    public var historyEntryCount: Int
+    /// Items in the trashcan; never imported, counted for the summary.
+    public var trashedItemCount: Int
+
+    public init(items: [SwitchHostsItem], historyEntryCount: Int = 0, trashedItemCount: Int = 0) {
+        self.items = items
+        self.historyEntryCount = historyEntryCount
+        self.trashedItemCount = trashedItemCount
+    }
+}
+
+/// One entry of the SwitchHosts tree, with its rule content already resolved by the reader.
+public struct SwitchHostsItem: Equatable, Sendable {
+    public enum Kind: Equatable, Sendable {
+        case local
+        /// A remote rule: the URL it refreshes from and its refresh cadence in seconds
+        /// (nil or non-positive = never). `content` holds the locally cached fetch result.
+        case remote(urlString: String, refreshIntervalSeconds: Int?)
+        /// A combined rule (SwitchHosts type "group"): its content is its members' contents
+        /// joined in `memberIDs` order.
+        case combined(memberIDs: [String])
+        /// A folder: a container, not a rule. `isSingleSelection` is SwitchHosts folder mode 1,
+        /// the only mode matching a native group's in-group mutual exclusion.
+        case folder(isSingleSelection: Bool, children: [SwitchHostsItem])
+    }
+
+    public var id: String
+    public var title: String
+    /// The rule text (for remote items: the cached fetch result); empty for containers.
+    public var content: String
+    /// SwitchHosts' built-in system hosts entry; skipped on import (Base Hosts owns that role).
+    public var isSystem: Bool
+    public var kind: Kind
+
+    public init(id: String, title: String, content: String = "", isSystem: Bool = false, kind: Kind) {
+        self.id = id
+        self.title = title
+        self.content = content
+        self.isSystem = isSystem
+        self.kind = kind
+    }
+}
+
+/// What one SwitchHosts import will do: the snapshot to apply (through the ADR-0008 import
+/// path: all inactive, same-named objects coexist, one atomic batch) and the report of how
+/// the data was mapped.
+public struct SwitchHostsImportPlan: Equatable, Sendable {
+    public var snapshot: ExportSnapshot
+    public var summary: SwitchHostsImportSummary
+
+    public init(snapshot: ExportSnapshot, summary: SwitchHostsImportSummary) {
+        self.snapshot = snapshot
+        self.summary = summary
+    }
+}
+
+/// The full mapping report of one SwitchHosts import (#74): counts, every transposed Remote
+/// Profile with its Source URL, everything skipped, and every deliberate semantic shift.
+/// ADR-0013 forbids silent drops and silent shifts, so whatever the mapper decides must
+/// surface here.
+public struct SwitchHostsImportSummary: Equatable, Sendable {
+    /// A remote rule transposed to a native Remote Profile.
+    public struct RemoteProfile: Equatable, Sendable {
+        public var profileName: String
+        public var sourceURL: String
+        public var interval: RemoteHeader.RefreshInterval
+        /// The SwitchHosts cadence in seconds when it had no exact native preset and was
+        /// rounded to `interval`; nil when the mapped preset matches the original cadence.
+        public var adjustedFromSeconds: Int?
+
+        public init(
+            profileName: String,
+            sourceURL: String,
+            interval: RemoteHeader.RefreshInterval,
+            adjustedFromSeconds: Int? = nil
+        ) {
+            self.profileName = profileName
+            self.sourceURL = sourceURL
+            self.interval = interval
+            self.adjustedFromSeconds = adjustedFromSeconds
+        }
+    }
+
+    /// A remote rule whose URL cannot be a Source URL (non-HTTPS or unparseable): imported
+    /// as a local profile carrying the cached content, reported instead of dropped.
+    public struct DowngradedRemote: Equatable, Sendable {
+        public var profileName: String
+        public var urlString: String
+
+        public init(profileName: String, urlString: String) {
+            self.profileName = profileName
+            self.urlString = urlString
+        }
+    }
+
+    public var profileCount: Int
+    public var groupCount: Int
+    public var remoteProfiles: [RemoteProfile]
+    public var skippedSystemEntryCount: Int
+    public var skippedHistoryEntryCount: Int
+    public var skippedTrashedItemCount: Int
+    /// Groups whose SwitchHosts folder allowed stacking several active entries (mode default
+    /// or multiple): the group structure survives, the stacking semantics tighten to native
+    /// in-group mutual exclusion.
+    public var exclusivityTightenedGroups: [String]
+    /// Combined rules expanded to a frozen snapshot of their members' contents.
+    public var frozenCombinedProfiles: [String]
+    public var downgradedRemotes: [DowngradedRemote]
+    /// Which SwitchHosts generation the data was read from (#75) — stitched in after
+    /// mapping by whoever ran the unified reader, so the mapping engine itself stays
+    /// format-blind; nil when the caller read a known format directly.
+    public var detectedFormat: SwitchHostsFormat?
+
+    public init(
+        profileCount: Int = 0,
+        groupCount: Int = 0,
+        remoteProfiles: [RemoteProfile] = [],
+        skippedSystemEntryCount: Int = 0,
+        skippedHistoryEntryCount: Int = 0,
+        skippedTrashedItemCount: Int = 0,
+        exclusivityTightenedGroups: [String] = [],
+        frozenCombinedProfiles: [String] = [],
+        downgradedRemotes: [DowngradedRemote] = [],
+        detectedFormat: SwitchHostsFormat? = nil
+    ) {
+        self.profileCount = profileCount
+        self.groupCount = groupCount
+        self.remoteProfiles = remoteProfiles
+        self.skippedSystemEntryCount = skippedSystemEntryCount
+        self.skippedHistoryEntryCount = skippedHistoryEntryCount
+        self.skippedTrashedItemCount = skippedTrashedItemCount
+        self.exclusivityTightenedGroups = exclusivityTightenedGroups
+        self.frozenCombinedProfiles = frozenCombinedProfiles
+        self.downgradedRemotes = downgradedRemotes
+        self.detectedFormat = detectedFormat
+    }
+}
+
+/// The mapping engine (#74, ADR-0013): SwitchHosts' intermediate model → an import plan.
+/// Pure and offline — remote rules are transposed by writing a Remote Header over their
+/// cached content, never by fetching.
+public enum SwitchHostsMapper {
+    /// The rules, in ADR-0013's terms: folders flatten to groups named by their joined path,
+    /// top-level loose entries land standalone, remote rules transpose to native Remote
+    /// Profiles, combined rules freeze to snapshots, and system entries are skipped and counted.
+    public static func plan(for data: SwitchHostsData) -> SwitchHostsImportPlan {
+        var builder = Builder(itemsByID: itemsByID(in: data.items))
+        builder.walk(data.items, path: [])
+        var summary = builder.summary
+        summary.profileCount = builder.standaloneProfiles.count
+            + builder.groups.reduce(0) { $0 + $1.profiles.count }
+        summary.groupCount = builder.groups.count
+        summary.skippedHistoryEntryCount = data.historyEntryCount
+        summary.skippedTrashedItemCount = data.trashedItemCount
+        return SwitchHostsImportPlan(
+            snapshot: ExportSnapshot(
+                standaloneProfiles: builder.standaloneProfiles,
+                groups: builder.groups
+            ),
+            summary: summary
+        )
+    }
+
+    /// Maps a SwitchHosts refresh cadence to the largest native preset that fetches at least
+    /// as often — a migrated Remote Profile may refresh more often than before, never
+    /// silently slower (ADR-0013); sub-hour cadences take 1h, the fastest preset there is,
+    /// exactly as #74's table pins (≤3600s→1h). Nil or non-positive is SwitchHosts' "never":
+    /// manual. `isAdjusted` reports an inexact match, which the import summary must disclose.
+    public static func refreshInterval(
+        forSeconds seconds: Int?
+    ) -> (interval: RemoteHeader.RefreshInterval, isAdjusted: Bool) {
+        guard let seconds, seconds > 0 else { return (.manual, false) }
+        if seconds < 21600 { return (.oneHour, seconds != 3600) }
+        if seconds < 86400 { return (.sixHours, seconds != 21600) }
+        return (.twentyFourHours, seconds != 86400)
+    }
+
+    private static func itemsByID(in items: [SwitchHostsItem]) -> [String: SwitchHostsItem] {
+        var index: [String: SwitchHostsItem] = [:]
+        var pending = items
+        while let item = pending.popLast() {
+            index[item.id] = item
+            if case .folder(_, let children) = item.kind {
+                pending.append(contentsOf: children)
+            }
+        }
+        return index
+    }
+
+    private struct Builder {
+        let itemsByID: [String: SwitchHostsItem]
+        var standaloneProfiles: [ExportSnapshot.Profile] = []
+        var groups: [ExportSnapshot.Group] = []
+        var summary = SwitchHostsImportSummary()
+
+        /// Maps one container's entries: direct entries become this container's profiles
+        /// (standalone at the top level, one group per non-empty folder path otherwise),
+        /// then each subfolder recurses with its name appended to the path.
+        mutating func walk(_ items: [SwitchHostsItem], path: [String], isSingleSelection: Bool = true) {
+            var directProfiles: [ExportSnapshot.Profile] = []
+            var subfolders: [SwitchHostsItem] = []
+            for item in items {
+                if item.isSystem {
+                    summary.skippedSystemEntryCount += 1
+                } else if case .folder = item.kind {
+                    subfolders.append(item)
+                } else {
+                    directProfiles.append(profile(for: item))
+                }
+            }
+
+            if path.isEmpty {
+                standaloneProfiles.append(contentsOf: directProfiles)
+            } else if !directProfiles.isEmpty {
+                let name = path.joined(separator: " / ")
+                groups.append(ExportSnapshot.Group(name: name, profiles: directProfiles))
+                // A default- or multiple-mode folder let several entries stack; the group
+                // keeps the structure but tightens to in-group mutual exclusion. ADR-0013
+                // wants every such folder disclosed, member count regardless.
+                if !isSingleSelection {
+                    summary.exclusivityTightenedGroups.append(name)
+                }
+            }
+
+            for folder in subfolders {
+                guard case .folder(let single, let children) = folder.kind else { continue }
+                walk(children, path: path + [displayName(folder.title)], isSingleSelection: single)
+            }
+        }
+
+        private mutating func profile(for item: SwitchHostsItem) -> ExportSnapshot.Profile {
+            let name = displayName(item.title)
+            switch item.kind {
+            case .local:
+                return ExportSnapshot.Profile(
+                    name: name,
+                    content: RemoteHeader.escapingEmbeddedHeader(in: item.content)
+                )
+            case .remote(let urlString, let seconds):
+                let (interval, isAdjusted) = SwitchHostsMapper.refreshInterval(forSeconds: seconds)
+                guard let url = URL(string: urlString),
+                      let header = RemoteHeader(sourceURL: url, interval: interval)
+                else {
+                    summary.downgradedRemotes.append(.init(profileName: name, urlString: urlString))
+                    return ExportSnapshot.Profile(
+                        name: name,
+                        content: RemoteHeader.escapingEmbeddedHeader(in: item.content)
+                    )
+                }
+                summary.remoteProfiles.append(.init(
+                    profileName: name,
+                    sourceURL: header.sourceURL.absoluteString,
+                    interval: interval,
+                    adjustedFromSeconds: isAdjusted ? seconds : nil
+                ))
+                // The cached fetch result becomes the initial content under the header — the
+                // import itself stays offline; the refresh engine takes over from here.
+                return ExportSnapshot.Profile(
+                    name: name,
+                    content: header.storedContent(forFetched: item.content)
+                )
+            case .combined(let memberIDs):
+                summary.frozenCombinedProfiles.append(name)
+                let expanded = expandedContent(ofMembers: memberIDs, visited: [item.id])
+                return ExportSnapshot.Profile(
+                    name: name,
+                    content: RemoteHeader.escapingEmbeddedHeader(in: expanded)
+                )
+            case .folder:
+                // Folders never reach here: walk() routes them into recursion.
+                return ExportSnapshot.Profile(name: name, content: "")
+            }
+        }
+
+        /// A combined rule's content: its members' contents joined in include order —
+        /// SwitchHosts' own combination semantics, frozen at import time. Remote members
+        /// contribute their cached content; folder, system, unknown, and already-visited
+        /// members (a cycle) contribute nothing.
+        private func expandedContent(ofMembers memberIDs: [String], visited: Set<String>) -> String {
+            var chunks: [String] = []
+            for memberID in memberIDs {
+                guard let member = itemsByID[memberID],
+                      !visited.contains(memberID),
+                      !member.isSystem
+                else { continue }
+                switch member.kind {
+                case .local, .remote:
+                    chunks.append(member.content)
+                case .combined(let nested):
+                    chunks.append(expandedContent(ofMembers: nested, visited: visited.union([memberID])))
+                case .folder:
+                    continue
+                }
+            }
+            return chunks.joined(separator: "\n")
+        }
+
+        /// SwitchHosts allows blank titles (shown as "(No title)"); imports fall back to the
+        /// same default name plain-text file import uses.
+        private func displayName(_ title: String) -> String {
+            title.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "Untitled" : title
+        }
+    }
+}

--- a/Sources/HostflipCore/SwitchHostsV3Reader.swift
+++ b/Sources/HostflipCore/SwitchHostsV3Reader.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+/// Reads a SwitchHosts v3 (Electron, single-file) data directory: `data.json` holds
+/// `{list, version}` where the list is the same tree shape as v4 with three field
+/// remappings — `where` instead of `type`, refresh intervals in hours instead of
+/// seconds, and content inline on each node instead of a collection (#75, ADR-0013).
+public enum SwitchHostsV3Reader {
+    public static func read(at root: URL) throws -> SwitchHostsData {
+        let dataURL = root.appendingPathComponent("data.json")
+        guard FileManager.default.fileExists(atPath: dataURL.path) else {
+            throw SwitchHostsImportError.dataNotFound
+        }
+        let file = try SwitchHostsReaderSupport.decode(DataFile.self, at: dataURL, file: "data.json")
+        // A version array from another major would mean this is not actually v3 data;
+        // an absent array stays tolerated — the earliest 3.x files predate the field.
+        if let major = file.version?.first, major != 3 {
+            throw SwitchHostsImportError.malformedData(file: "data.json")
+        }
+        let items = try file.list.map(item(for:))
+        try SwitchHostsReaderSupport.validateIDs(of: items, file: "data.json")
+        // v3 predates both the trashcan and the standalone history store, so there is
+        // nothing to skip-count beyond the tree itself.
+        return SwitchHostsData(items: items, historyEntryCount: 0, trashedItemCount: 0)
+    }
+
+    private struct DataFile: Decodable {
+        var list: [Node]
+        var version: [Int]?
+    }
+
+    /// One tree node as v3 stores it; `where` is the discriminator (absent reads as a
+    /// local rule, matching the other readers' default).
+    private struct Node: Decodable {
+        var id: String?
+        var title: String?
+        var kindName: String?
+        var content: String?
+        var url: String?
+        /// Hours, possibly fractional — v3's one unit quirk.
+        var refresh_interval: Double?
+        var include: [String]?
+        var folder_mode: Int?
+        var is_sys: Bool?
+        var children: [Node]?
+
+        enum CodingKeys: String, CodingKey {
+            case id, title, content, url, refresh_interval, include, folder_mode, is_sys, children
+            case kindName = "where"
+        }
+    }
+
+    private static func item(for node: Node) throws -> SwitchHostsItem {
+        let kind: SwitchHostsItem.Kind
+        switch node.kindName ?? "local" {
+        case "local":
+            kind = .local
+        case "remote":
+            kind = .remote(
+                urlString: node.url ?? "",
+                refreshIntervalSeconds: node.refresh_interval
+                    .map { SwitchHostsReaderSupport.clampedSeconds($0 * 3600) }
+            )
+        case "group":
+            kind = .combined(memberIDs: node.include ?? [])
+        case "folder":
+            kind = .folder(
+                isSingleSelection: node.folder_mode == 1,
+                children: try (node.children ?? []).map(item(for:))
+            )
+        default:
+            throw SwitchHostsImportError.malformedData(file: "data.json")
+        }
+        return SwitchHostsItem(
+            id: node.id ?? "",
+            title: node.title ?? "",
+            content: node.content ?? "",
+            isSystem: node.is_sys == true,
+            kind: kind
+        )
+    }
+}

--- a/Sources/HostflipCore/SwitchHostsV4Reader.swift
+++ b/Sources/HostflipCore/SwitchHostsV4Reader.swift
@@ -1,0 +1,147 @@
+import Foundation
+
+public enum SwitchHostsImportError: Error, Equatable, Sendable {
+    /// The directory holds no SwitchHosts data in a supported format (M1: v4 only).
+    case dataNotFound
+    /// A data file exists but does not parse as expected; the whole import is refused —
+    /// one bad file means zero change (ADR-0008). The path is relative to the data directory.
+    case malformedData(file: String)
+}
+
+/// Reads a SwitchHosts v4 (Electron) data directory — PotDb on disk: `data/list/tree.json`
+/// holds the tree, the `data/collection/hosts` collection holds one JSON record per rule's
+/// content, keyed back to tree entries by their id (#74, ADR-0013). Output is the
+/// format-independent intermediate model; everything v4-specific ends here.
+public enum SwitchHostsV4Reader {
+    public static func read(at root: URL) throws -> SwitchHostsData {
+        let dataDirectory = root.appendingPathComponent("data", isDirectory: true)
+        let treeURL = dataDirectory.appendingPathComponent("list/tree.json")
+        guard FileManager.default.fileExists(atPath: treeURL.path) else {
+            throw SwitchHostsImportError.dataNotFound
+        }
+
+        let nodes: [TreeNode] = try SwitchHostsReaderSupport.decode(
+            [TreeNode].self, at: treeURL, file: "data/list/tree.json"
+        )
+        let contentsByID = try contents(
+            inCollectionAt: dataDirectory.appendingPathComponent("collection/hosts", isDirectory: true),
+            file: "data/collection/hosts"
+        )
+        let items = try nodes.map { try item(for: $0, contentsByID: contentsByID) }
+        try SwitchHostsReaderSupport.validateIDs(of: items, file: "data/list/tree.json")
+        return SwitchHostsData(
+            items: items,
+            historyEntryCount: try recordCount(
+                inCollectionAt: dataDirectory.appendingPathComponent("collection/history", isDirectory: true),
+                file: "data/collection/history"
+            ),
+            trashedItemCount: try trashedItemCount(
+                at: dataDirectory.appendingPathComponent("list/trashcan.json")
+            )
+        )
+    }
+
+    /// One tree entry as v4 stores it. Everything but `id` is optional on disk; an absent
+    /// `type` is a local rule (the common case in real data — v4 only writes the field it
+    /// changed away from the default).
+    private struct TreeNode: Decodable {
+        var id: String?
+        var title: String?
+        var type: String?
+        var url: String?
+        var refresh_interval: Double?
+        var include: [String]?
+        var folder_mode: Int?
+        var is_sys: Bool?
+        var children: [TreeNode]?
+    }
+
+    /// A record of the hosts collection: the content of the tree entry named by `id`.
+    private struct ContentRecord: Decodable {
+        var id: String?
+        var content: String?
+    }
+
+    private static func item(
+        for node: TreeNode,
+        contentsByID: [String: String]
+    ) throws -> SwitchHostsItem {
+        let id = node.id ?? ""
+        let kind: SwitchHostsItem.Kind
+        switch node.type ?? "local" {
+        case "local":
+            kind = .local
+        case "remote":
+            kind = .remote(
+                urlString: node.url ?? "",
+                refreshIntervalSeconds: node.refresh_interval
+                    .map(SwitchHostsReaderSupport.clampedSeconds)
+            )
+        case "group":
+            kind = .combined(memberIDs: node.include ?? [])
+        case "folder":
+            // Mode 1 is single selection; 0 (default) and 2 (multiple) allow stacking.
+            kind = .folder(
+                isSingleSelection: node.folder_mode == 1,
+                children: try (node.children ?? []).map { try item(for: $0, contentsByID: contentsByID) }
+            )
+        default:
+            throw SwitchHostsImportError.malformedData(file: "data/list/tree.json")
+        }
+        return SwitchHostsItem(
+            id: id,
+            title: node.title ?? "",
+            // A rule that was never edited has no collection record: empty content.
+            content: contentsByID[id] ?? "",
+            isSystem: node.is_sys == true,
+            kind: kind
+        )
+    }
+
+    /// Loads the hosts collection: `ids.json` lists the record file names — with null holes
+    /// where records were deleted (PotDb never compacts) — and `data/<n>.json` holds one
+    /// record each. A listed record that is missing or unreadable fails the whole import.
+    private static func contents(
+        inCollectionAt collection: URL,
+        file: String
+    ) throws -> [String: String] {
+        guard let recordIDs = try recordIDs(inCollectionAt: collection, file: file) else { return [:] }
+        var contentsByID: [String: String] = [:]
+        for recordID in recordIDs {
+            let record = try SwitchHostsReaderSupport.decode(
+                ContentRecord.self,
+                at: collection.appendingPathComponent("data/\(recordID).json"),
+                file: "\(file)/data/\(recordID).json"
+            )
+            guard let treeID = record.id else { continue }
+            contentsByID[treeID] = record.content ?? ""
+        }
+        return contentsByID
+    }
+
+    private static func recordCount(inCollectionAt collection: URL, file: String) throws -> Int {
+        try recordIDs(inCollectionAt: collection, file: file)?.count ?? 0
+    }
+
+    /// The non-null entries of a collection's `ids.json`; nil when the collection does not
+    /// exist at all (a valid state — nothing was ever stored in it).
+    private static func recordIDs(inCollectionAt collection: URL, file: String) throws -> [String]? {
+        let idsURL = collection.appendingPathComponent("ids.json")
+        guard FileManager.default.fileExists(atPath: idsURL.path) else { return nil }
+        return try SwitchHostsReaderSupport
+            .decode([String?].self, at: idsURL, file: "\(file)/ids.json")
+            .compactMap(\.self)
+    }
+
+    /// The trashcan is informational only (skipped + counted in the summary), so its items
+    /// are counted without interpreting their shape.
+    private static func trashedItemCount(at url: URL) throws -> Int {
+        guard FileManager.default.fileExists(atPath: url.path) else { return 0 }
+        guard let data = try? Data(contentsOf: url),
+              let items = try? JSONSerialization.jsonObject(with: data) as? [Any]
+        else {
+            throw SwitchHostsImportError.malformedData(file: "data/list/trashcan.json")
+        }
+        return items.count
+    }
+}

--- a/Sources/HostflipCore/SwitchHostsV5Reader.swift
+++ b/Sources/HostflipCore/SwitchHostsV5Reader.swift
@@ -1,0 +1,123 @@
+import Foundation
+
+/// Reads a SwitchHosts v5 (Tauri) data directory: `manifest.json` holds the tree with
+/// camelCase node fields, and each rule's content lives in the file its `contentFile`
+/// names (`entries/<id>.hosts`) — cached fetch results included (#75, ADR-0013). Output
+/// is the format-independent intermediate model; everything v5-specific ends here.
+public enum SwitchHostsV5Reader {
+    public static func read(at root: URL) throws -> SwitchHostsData {
+        let manifestURL = root.appendingPathComponent("manifest.json")
+        guard FileManager.default.fileExists(atPath: manifestURL.path) else {
+            throw SwitchHostsImportError.dataNotFound
+        }
+        let manifest = try SwitchHostsReaderSupport.decode(
+            Manifest.self, at: manifestURL, file: "manifest.json"
+        )
+        let items = try manifest.root.map { try item(for: $0, root: root) }
+        try SwitchHostsReaderSupport.validateIDs(of: items, file: "manifest.json")
+        return SwitchHostsData(
+            items: items,
+            historyEntryCount: try historyEntryCount(at: root),
+            trashedItemCount: try trashedItemCount(at: root)
+        )
+    }
+
+    /// One tree node as v5 serializes it. Everything but `id` is optional on disk; an
+    /// absent `type` reads as a local rule, matching the v4 reader's default.
+    private struct Manifest: Decodable {
+        var root: [Node]
+    }
+
+    private struct Node: Decodable {
+        var id: String?
+        var title: String?
+        var type: String?
+        /// Path of the rule's content, relative to the data root.
+        var contentFile: String?
+        /// A remote rule's Source URL — v5 renamed v4's `url`.
+        var source: String?
+        var refreshIntervalSec: Double?
+        var include: [String]?
+        var folder: FolderInfo?
+        var isSys: Bool?
+        var children: [Node]?
+    }
+
+    private struct FolderInfo: Decodable {
+        /// Same encoding as v4's folder_mode: 1 is single selection, 0/2 allow stacking.
+        var mode: Int?
+    }
+
+    private static func item(for node: Node, root: URL) throws -> SwitchHostsItem {
+        let kind: SwitchHostsItem.Kind
+        switch node.type ?? "local" {
+        case "local":
+            kind = .local
+        case "remote":
+            kind = .remote(
+                urlString: node.source ?? "",
+                refreshIntervalSeconds: node.refreshIntervalSec
+                    .map(SwitchHostsReaderSupport.clampedSeconds)
+            )
+        case "group":
+            kind = .combined(memberIDs: node.include ?? [])
+        case "folder":
+            kind = .folder(
+                isSingleSelection: node.folder?.mode == 1,
+                children: try (node.children ?? []).map { try item(for: $0, root: root) }
+            )
+        default:
+            throw SwitchHostsImportError.malformedData(file: "manifest.json")
+        }
+        return SwitchHostsItem(
+            id: node.id ?? "",
+            title: node.title ?? "",
+            content: try content(named: node.contentFile, root: root),
+            isSystem: node.isSys == true,
+            kind: kind
+        )
+    }
+
+    /// A node without a content file has no content; a named file that is missing or not
+    /// UTF-8 fails the whole import (ADR-0008 atomicity). The path must stay inside the
+    /// data root: a manifest naming an absolute or `..`-escaping path would otherwise pull
+    /// arbitrary readable files into imported content, so it reads as malformed instead.
+    private static func content(named contentFile: String?, root: URL) throws -> String {
+        guard let contentFile else { return "" }
+        guard !contentFile.hasPrefix("/"),
+              !contentFile.split(separator: "/").contains(".."),
+              let data = try? Data(contentsOf: root.appendingPathComponent(contentFile)),
+              let content = String(data: data, encoding: .utf8)
+        else {
+            throw SwitchHostsImportError.malformedData(file: contentFile)
+        }
+        return content
+    }
+
+    /// v5 keeps the system-hosts apply history (v4's history collection successor) under
+    /// `internal/histories/system-hosts.json` as one JSON array of snapshots.
+    private static func historyEntryCount(at root: URL) throws -> Int {
+        let url = root.appendingPathComponent("internal/histories/system-hosts.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return 0 }
+        guard let data = try? Data(contentsOf: url),
+              let items = try? JSONSerialization.jsonObject(with: data) as? [Any]
+        else {
+            throw SwitchHostsImportError.malformedData(file: "internal/histories/system-hosts.json")
+        }
+        return items.count
+    }
+
+    /// The trashcan is informational only (skipped + counted in the summary), so its
+    /// items are counted without interpreting their shape.
+    private static func trashedItemCount(at root: URL) throws -> Int {
+        let url = root.appendingPathComponent("trashcan.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return 0 }
+        guard let data = try? Data(contentsOf: url),
+              let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let items = object["items"] as? [Any]
+        else {
+            throw SwitchHostsImportError.malformedData(file: "trashcan.json")
+        }
+        return items.count
+    }
+}

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -16,5 +16,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.2.0"
+    public static let version = "0.3.0"
 }

--- a/Tests/HostflipCoreTests/SwitchHostsFormatsTests.swift
+++ b/Tests/HostflipCoreTests/SwitchHostsFormatsTests.swift
@@ -1,0 +1,372 @@
+import Foundation
+import HostflipCore
+import XCTest
+
+/// The M2 surface of the SwitchHosts import (#75, ADR-0013): the v5 and v3 readers over
+/// the shared intermediate model, the newest-generation-first format detection, and the
+/// data directory discovery chain. Directory fixtures are desensitized samples of real
+/// data shapes, nested folders and remote rules included.
+final class SwitchHostsFormatsTests: XCTestCase {
+
+    // MARK: - v5 reading
+
+    func testReadsAV5DirectoryIntoTheSharedModel() throws {
+        let root = try makeTemporaryDirectory()
+        try writeV5Fixture(at: root)
+
+        let data = try SwitchHostsV5Reader.read(at: root)
+
+        XCTAssertEqual(data.items, [
+            SwitchHostsItem(id: "sys0", title: "系统 Hosts", isSystem: true, kind: .local),
+            SwitchHostsItem(id: "aaaa", title: "dev", content: "127.0.0.1 dev.example.test\n", kind: .local),
+            SwitchHostsItem(id: "ffff", title: "预发环境", kind: .folder(isSingleSelection: true, children: [
+                SwitchHostsItem(id: "bbbb", title: "pre1", content: "10.0.2.1 app.example.test\n", kind: .local),
+                SwitchHostsItem(id: "gggg", title: "前端", kind: .folder(isSingleSelection: false, children: [
+                    SwitchHostsItem(id: "cccc", title: "web1", content: "10.0.2.2 web.example.test\n", kind: .local)
+                ])),
+            ])),
+            SwitchHostsItem(
+                id: "rrrr",
+                title: "Team Blocklist",
+                content: "0.0.0.0 tracker.example.test\n",
+                kind: .remote(urlString: "https://rules.example.test/list.hosts", refreshIntervalSeconds: 86400)
+            ),
+            SwitchHostsItem(id: "mmmm", title: "combo", kind: .combined(memberIDs: ["rrrr", "aaaa"])),
+        ])
+        XCTAssertEqual(data.historyEntryCount, 2)
+        XCTAssertEqual(data.trashedItemCount, 1)
+    }
+
+    func testV5MapsThroughTheUnchangedEngine() throws {
+        let root = try makeTemporaryDirectory()
+        try writeV5Fixture(at: root)
+
+        let plan = SwitchHostsMapper.plan(for: try SwitchHostsV5Reader.read(at: root))
+
+        XCTAssertEqual(plan.summary.profileCount, 5)
+        XCTAssertEqual(plan.snapshot.groups.map(\.name), ["预发环境", "预发环境 / 前端"])
+        XCTAssertEqual(plan.summary.exclusivityTightenedGroups, ["预发环境 / 前端"])
+        XCTAssertEqual(plan.summary.remoteProfiles.map(\.sourceURL), ["https://rules.example.test/list.hosts"])
+        XCTAssertEqual(plan.summary.frozenCombinedProfiles, ["combo"])
+        XCTAssertEqual(plan.summary.skippedSystemEntryCount, 1)
+    }
+
+    func testAV5NodeNamingAMissingContentFileFailsTheRead() throws {
+        let root = try makeTemporaryDirectory()
+        try write(
+            #"{"format": "switchhosts-data", "schemaVersion": 1, "root": [{"id": "aaaa", "title": "dev", "type": "local", "on": false, "contentFile": "entries/aaaa.hosts"}]}"#,
+            to: root.appendingPathComponent("manifest.json")
+        )
+
+        XCTAssertThrowsError(try SwitchHostsV5Reader.read(at: root)) { error in
+            XCTAssertEqual(error as? SwitchHostsImportError, .malformedData(file: "entries/aaaa.hosts"))
+        }
+    }
+
+    // MARK: - v3 reading
+
+    func testReadsAV3DataFileIntoTheSharedModel() throws {
+        let root = try makeTemporaryDirectory()
+        try write(Self.v3Data, to: root.appendingPathComponent("data.json"))
+
+        let data = try SwitchHostsV3Reader.read(at: root)
+
+        XCTAssertEqual(data.items, [
+            SwitchHostsItem(id: "aaaa", title: "dev", content: "127.0.0.1 dev.example.test\n", kind: .local),
+            SwitchHostsItem(id: "ffff", title: "预发环境", kind: .folder(isSingleSelection: true, children: [
+                SwitchHostsItem(id: "gggg", title: "前端", kind: .folder(isSingleSelection: false, children: [
+                    SwitchHostsItem(id: "cccc", title: "web1", content: "10.0.2.2 web.example.test\n", kind: .local)
+                ]))
+            ])),
+            SwitchHostsItem(
+                id: "rrrr",
+                title: "Team Blocklist",
+                content: "0.0.0.0 tracker.example.test\n",
+                // 24 hours → 86400 seconds; v3's one unit quirk.
+                kind: .remote(urlString: "https://rules.example.test/list.hosts", refreshIntervalSeconds: 86400)
+            ),
+            SwitchHostsItem(id: "mmmm", title: "combo", kind: .combined(memberIDs: ["aaaa", "rrrr"])),
+        ])
+        XCTAssertEqual(data.historyEntryCount, 0)
+        XCTAssertEqual(data.trashedItemCount, 0)
+    }
+
+    func testV3FractionalHoursConvertToSeconds() throws {
+        let root = try makeTemporaryDirectory()
+        try write(
+            #"{"list": [{"id": "r", "title": "r", "where": "remote", "url": "https://x.example.test/r", "refresh_interval": 0.5, "on": false}], "version": [3, 5, 8, 0]}"#,
+            to: root.appendingPathComponent("data.json")
+        )
+
+        let data = try SwitchHostsV3Reader.read(at: root)
+
+        XCTAssertEqual(data.items.first?.kind, .remote(
+            urlString: "https://x.example.test/r",
+            refreshIntervalSeconds: 1800
+        ))
+    }
+
+    func testAV3EntryWithoutAWhereFieldReadsAsLocal() throws {
+        let root = try makeTemporaryDirectory()
+        try write(
+            #"{"list": [{"id": "aaaa", "title": "dev", "content": "x\n", "on": false}], "version": [3, 5, 8, 0]}"#,
+            to: root.appendingPathComponent("data.json")
+        )
+
+        let data = try SwitchHostsV3Reader.read(at: root)
+
+        XCTAssertEqual(data.items, [
+            SwitchHostsItem(id: "aaaa", title: "dev", content: "x\n", kind: .local)
+        ])
+    }
+
+    // MARK: - Format detection
+
+    func testDetectionPrefersTheNewestGenerationAmongLeftovers() throws {
+        let root = try makeTemporaryDirectory()
+        try write(#"{"list": [], "version": [3, 5, 8, 0]}"#, to: root.appendingPathComponent("data.json"))
+        XCTAssertEqual(SwitchHostsReader.detectFormat(at: root), .v3)
+
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent("data/list"), withIntermediateDirectories: true
+        )
+        try write("[]", to: root.appendingPathComponent("data/list/tree.json"))
+        XCTAssertEqual(SwitchHostsReader.detectFormat(at: root), .v4)
+
+        try write(
+            #"{"format": "switchhosts-data", "schemaVersion": 1, "root": []}"#,
+            to: root.appendingPathComponent("manifest.json")
+        )
+        XCTAssertEqual(SwitchHostsReader.detectFormat(at: root), .v5)
+    }
+
+    func testDetectionReturnsNilForAnEmptyDirectory() throws {
+        XCTAssertNil(SwitchHostsReader.detectFormat(at: try makeTemporaryDirectory()))
+    }
+
+    func testUnifiedReadResolvesASwitchHostsDataSubdirectory() throws {
+        let wrapper = try makeTemporaryDirectory()
+        let store = wrapper.appendingPathComponent("SwitchHosts.data", isDirectory: true)
+        try FileManager.default.createDirectory(at: store, withIntermediateDirectories: true)
+        try writeV5Fixture(at: store)
+
+        let (data, format) = try SwitchHostsReader.read(at: wrapper)
+
+        XCTAssertEqual(format, .v5)
+        XCTAssertEqual(data.items.count, 5)
+    }
+
+    func testResolutionPrefersANestedV5StoreOverOlderLeftoversBeside() throws {
+        let wrapper = try makeTemporaryDirectory()
+        // v4 leftovers at the wrapper level…
+        try FileManager.default.createDirectory(
+            at: wrapper.appendingPathComponent("data/list"), withIntermediateDirectories: true
+        )
+        try write("[]", to: wrapper.appendingPathComponent("data/list/tree.json"))
+        // …must not shadow the live v5 store nested underneath.
+        let store = wrapper.appendingPathComponent("SwitchHosts.data", isDirectory: true)
+        try FileManager.default.createDirectory(at: store, withIntermediateDirectories: true)
+        try writeV5Fixture(at: store)
+
+        let (data, format) = try SwitchHostsReader.read(at: wrapper)
+
+        XCTAssertEqual(format, .v5)
+        XCTAssertEqual(data.items.count, 5)
+    }
+
+    func testAV5ContentFileMustStayInsideTheDataRoot() throws {
+        let root = try makeTemporaryDirectory()
+        try write("outside\n", to: root.deletingLastPathComponent().appendingPathComponent("escape.hosts"))
+        try write(
+            #"{"format": "switchhosts-data", "schemaVersion": 1, "root": [{"id": "aaaa", "title": "dev", "type": "local", "contentFile": "../escape.hosts"}]}"#,
+            to: root.appendingPathComponent("manifest.json")
+        )
+
+        XCTAssertThrowsError(try SwitchHostsV5Reader.read(at: root)) { error in
+            XCTAssertEqual(error as? SwitchHostsImportError, .malformedData(file: "../escape.hosts"))
+        }
+    }
+
+    func testAV3VersionFromAnotherMajorFailsTheRead() throws {
+        let root = try makeTemporaryDirectory()
+        try write(
+            #"{"list": [{"id": "aaaa", "title": "dev", "content": "x\n"}], "version": [4, 0, 0, 0]}"#,
+            to: root.appendingPathComponent("data.json")
+        )
+
+        XCTAssertThrowsError(try SwitchHostsV3Reader.read(at: root)) { error in
+            XCTAssertEqual(error as? SwitchHostsImportError, .malformedData(file: "data.json"))
+        }
+
+        // The earliest 3.x files predate the version array: absent stays tolerated.
+        let versionless = try makeTemporaryDirectory()
+        try write(
+            #"{"list": [{"id": "aaaa", "title": "dev", "content": "x\n"}]}"#,
+            to: versionless.appendingPathComponent("data.json")
+        )
+        XCTAssertEqual(try SwitchHostsV3Reader.read(at: versionless).items.count, 1)
+    }
+
+    func testUnifiedReadTagsTheDetectedFormat() throws {
+        let root = try makeTemporaryDirectory()
+        try write(Self.v3Data, to: root.appendingPathComponent("data.json"))
+
+        let (_, format) = try SwitchHostsReader.read(at: root)
+
+        XCTAssertEqual(format, .v3)
+    }
+
+    func testUnifiedReadReportsAnEmptyDirectoryAsDataNotFound() throws {
+        XCTAssertThrowsError(try SwitchHostsReader.read(at: try makeTemporaryDirectory())) { error in
+            XCTAssertEqual(error as? SwitchHostsImportError, .dataNotFound)
+        }
+    }
+
+    // MARK: - Discovery chain
+
+    func testDiscoveryFindsTheDefaultDirectoryFirst() throws {
+        let home = try makeTemporaryDirectory()
+        let defaultDirectory = home.appendingPathComponent(".SwitchHosts", isDirectory: true)
+        try FileManager.default.createDirectory(at: defaultDirectory, withIntermediateDirectories: true)
+        try writeV5Fixture(at: defaultDirectory)
+
+        let discovered = SwitchHostsDiscovery.discoverDataDirectory(
+            homeDirectory: home,
+            applicationSupportDirectory: try makeTemporaryDirectory()
+        )
+
+        XCTAssertEqual(discovered, defaultDirectory)
+    }
+
+    func testDiscoveryFollowsTheV5PointerWhenTheDefaultIsEmpty() throws {
+        let home = try makeTemporaryDirectory()
+        let applicationSupport = try makeTemporaryDirectory()
+        let custom = try makeTemporaryDirectory()
+        let store = custom.appendingPathComponent("SwitchHosts.data", isDirectory: true)
+        try FileManager.default.createDirectory(at: store, withIntermediateDirectories: true)
+        try writeV5Fixture(at: store)
+        let pointerDirectory = applicationSupport.appendingPathComponent("net.oldj.switchhosts")
+        try FileManager.default.createDirectory(at: pointerDirectory, withIntermediateDirectories: true)
+        try write(
+            #"{"format": "switchhosts-data-dir-pointer", "schemaVersion": 1, "dataDir": "\#(custom.path)"}"#,
+            to: pointerDirectory.appendingPathComponent("data_dir.json")
+        )
+
+        let discovered = SwitchHostsDiscovery.discoverDataDirectory(
+            homeDirectory: home,
+            applicationSupportDirectory: applicationSupport
+        )
+
+        // The chain hands back the resolved store, SwitchHosts.data nesting included.
+        XCTAssertEqual(discovered, store)
+    }
+
+    func testDiscoveryReadsTheSnakeCasePointerSpellingToo() throws {
+        let home = try makeTemporaryDirectory()
+        let applicationSupport = try makeTemporaryDirectory()
+        let custom = try makeTemporaryDirectory()
+        try write(Self.v3Data, to: custom.appendingPathComponent("data.json"))
+        let pointerDirectory = applicationSupport.appendingPathComponent("net.oldj.switchhosts")
+        try FileManager.default.createDirectory(at: pointerDirectory, withIntermediateDirectories: true)
+        try write(
+            #"{"data_dir": "\#(custom.path)"}"#,
+            to: pointerDirectory.appendingPathComponent("data_dir.json")
+        )
+
+        let discovered = SwitchHostsDiscovery.discoverDataDirectory(
+            homeDirectory: home,
+            applicationSupportDirectory: applicationSupport
+        )
+
+        XCTAssertEqual(discovered, custom)
+    }
+
+    func testDiscoveryReturnsNilWhenTheChainIsExhausted() throws {
+        XCTAssertNil(SwitchHostsDiscovery.discoverDataDirectory(
+            homeDirectory: try makeTemporaryDirectory(),
+            applicationSupportDirectory: try makeTemporaryDirectory()
+        ))
+    }
+
+    // MARK: - Fixtures
+
+    /// Desensitized sample of a real v5 store: the manifest tree (camelCase fields, the
+    /// system entry, a nested folder pair, a remote rule, a combined rule) plus content
+    /// files under entries/, an apply history, and one trashed item.
+    private func writeV5Fixture(at root: URL) throws {
+        let manifest = #"""
+        {
+         "format": "switchhosts-data",
+         "schemaVersion": 1,
+         "root": [
+          {"id": "sys0", "title": "系统 Hosts", "isSys": true, "on": true, "type": "local"},
+          {"contentFile": "entries/aaaa.hosts", "id": "aaaa", "on": false, "title": "dev", "type": "local"},
+          {"children": [
+            {"contentFile": "entries/bbbb.hosts", "id": "bbbb", "on": false, "title": "pre1", "type": "local"},
+            {"children": [
+              {"contentFile": "entries/cccc.hosts", "id": "cccc", "on": false, "title": "web1", "type": "local"}
+             ],
+             "folder": {"mode": 2}, "id": "gggg", "on": false, "title": "前端", "type": "folder"}
+           ],
+           "folder": {"mode": 1}, "id": "ffff", "on": false, "title": "预发环境", "type": "folder"},
+          {"contentFile": "entries/rrrr.hosts", "id": "rrrr", "on": false, "title": "Team Blocklist",
+           "type": "remote", "source": "https://rules.example.test/list.hosts",
+           "refreshIntervalSec": 86400, "lastRefresh": "2026-08-19 10:00:00", "lastRefreshMs": 1787101200000},
+          {"id": "mmmm", "on": false, "title": "combo", "type": "group", "include": ["rrrr", "aaaa"]}
+         ]
+        }
+        """#
+        try write(manifest, to: root.appendingPathComponent("manifest.json"))
+        let entries = root.appendingPathComponent("entries", isDirectory: true)
+        try FileManager.default.createDirectory(at: entries, withIntermediateDirectories: true)
+        try write("127.0.0.1 dev.example.test\n", to: entries.appendingPathComponent("aaaa.hosts"))
+        try write("10.0.2.1 app.example.test\n", to: entries.appendingPathComponent("bbbb.hosts"))
+        try write("10.0.2.2 web.example.test\n", to: entries.appendingPathComponent("cccc.hosts"))
+        try write("0.0.0.0 tracker.example.test\n", to: entries.appendingPathComponent("rrrr.hosts"))
+        let histories = root.appendingPathComponent("internal/histories", isDirectory: true)
+        try FileManager.default.createDirectory(at: histories, withIntermediateDirectories: true)
+        try write(
+            #"[{"_id": "1", "add_time_ms": 1787101200000, "content": "x"}, {"_id": "2", "add_time_ms": 1787101300000, "content": "y"}]"#,
+            to: histories.appendingPathComponent("system-hosts.json")
+        )
+        try write(
+            #"{"format": "switchhosts-trashcan", "schemaVersion": 1, "items": [{"id": "gone", "title": "old"}]}"#,
+            to: root.appendingPathComponent("trashcan.json")
+        )
+    }
+
+    /// Desensitized sample of a v3 `data.json`: the same tree shape with `where`
+    /// discriminators, inline content, and hour-based refresh intervals.
+    private static let v3Data = #"""
+    {
+     "list": [
+      {"id": "aaaa", "title": "dev", "where": "local", "content": "127.0.0.1 dev.example.test\n", "on": false},
+      {"id": "ffff", "title": "预发环境", "where": "folder", "folder_mode": 1, "on": false,
+       "children": [
+        {"id": "gggg", "title": "前端", "where": "folder", "folder_mode": 0, "folder_open": true,
+         "children": [
+          {"id": "cccc", "title": "web1", "where": "local", "content": "10.0.2.2 web.example.test\n", "on": false}
+         ]}
+       ]},
+      {"id": "rrrr", "title": "Team Blocklist", "where": "remote",
+       "url": "https://rules.example.test/list.hosts", "refresh_interval": 24,
+       "last_refresh": "2026-8-19 10:00:00", "content": "0.0.0.0 tracker.example.test\n", "on": false},
+      {"id": "mmmm", "title": "combo", "where": "group", "include": ["aaaa", "rrrr"], "on": false}
+     ],
+     "version": [3, 5, 8, 0]
+    }
+    """#
+
+    private func write(_ text: String, to url: URL) throws {
+        try Data(text.utf8).write(to: url)
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("switchhosts-formats-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        // Standardized so equality against URLs the readers derive holds on /var → /private/var symlinks.
+        return url.standardizedFileURL
+    }
+}

--- a/Tests/HostflipCoreTests/SwitchHostsImportTests.swift
+++ b/Tests/HostflipCoreTests/SwitchHostsImportTests.swift
@@ -1,0 +1,543 @@
+import Foundation
+import HostflipCore
+import XCTest
+
+/// The SwitchHosts import (#74, ADR-0013): the mapping engine over the intermediate model,
+/// the v4 PotDb directory reader, and the two end to end. Directory fixtures are desensitized
+/// samples of real v4 data shapes (nested folders, remote rules, combined rules).
+final class SwitchHostsImportTests: XCTestCase {
+
+    // MARK: - Mapping: structure
+
+    func testFoldersFlattenToPathNamedGroupsAndLooseItemsLandStandalone() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(id: "a", title: "dev", content: "127.0.0.1 dev.example.test\n", kind: .local),
+            SwitchHostsItem(id: "f1", title: "Staging", kind: .folder(isSingleSelection: true, children: [
+                SwitchHostsItem(id: "b", title: "pre1", content: "10.0.2.1 app.example.test\n", kind: .local),
+                SwitchHostsItem(id: "f2", title: "Frontend", kind: .folder(isSingleSelection: true, children: [
+                    SwitchHostsItem(id: "c", title: "web1", content: "10.0.2.2 web.example.test\n", kind: .local)
+                ])),
+                SwitchHostsItem(id: "d", title: "pre2", content: "10.0.2.3 app.example.test\n", kind: .local),
+            ])),
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        XCTAssertEqual(plan.snapshot, ExportSnapshot(
+            standaloneProfiles: [.init(name: "dev", content: "127.0.0.1 dev.example.test\n")],
+            groups: [
+                .init(name: "Staging", profiles: [
+                    .init(name: "pre1", content: "10.0.2.1 app.example.test\n"),
+                    .init(name: "pre2", content: "10.0.2.3 app.example.test\n"),
+                ]),
+                .init(name: "Staging / Frontend", profiles: [
+                    .init(name: "web1", content: "10.0.2.2 web.example.test\n")
+                ]),
+            ]
+        ))
+        XCTAssertEqual(plan.summary.profileCount, 4)
+        XCTAssertEqual(plan.summary.groupCount, 2)
+        XCTAssertEqual(plan.summary.exclusivityTightenedGroups, [])
+    }
+
+    func testFolderOfOnlySubfoldersAddsNoGroupOfItsOwn() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(id: "f1", title: "Outer", kind: .folder(isSingleSelection: true, children: [
+                SwitchHostsItem(id: "f2", title: "Inner", kind: .folder(isSingleSelection: true, children: [
+                    SwitchHostsItem(id: "a", title: "only", content: "x\n", kind: .local)
+                ]))
+            ]))
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        XCTAssertEqual(plan.snapshot.groups.map(\.name), ["Outer / Inner"])
+        XCTAssertEqual(plan.summary.groupCount, 1)
+    }
+
+    func testNonSingleSelectionFolderBecomesAGroupAndReportsTheTightening() {
+        let stacking = SwitchHostsData(items: [
+            SwitchHostsItem(id: "f1", title: "Overrides", kind: .folder(isSingleSelection: false, children: [
+                SwitchHostsItem(id: "a", title: "one", content: "a\n", kind: .local),
+                SwitchHostsItem(id: "b", title: "two", content: "b\n", kind: .local),
+            ]))
+        ])
+        XCTAssertEqual(
+            SwitchHostsMapper.plan(for: stacking).summary.exclusivityTightenedGroups,
+            ["Overrides"]
+        )
+
+        // ADR-0013 wants every non-single folder disclosed, member count regardless.
+        let singleMember = SwitchHostsData(items: [
+            SwitchHostsItem(id: "f1", title: "Overrides", kind: .folder(isSingleSelection: false, children: [
+                SwitchHostsItem(id: "a", title: "one", content: "a\n", kind: .local)
+            ]))
+        ])
+        XCTAssertEqual(
+            SwitchHostsMapper.plan(for: singleMember).summary.exclusivityTightenedGroups,
+            ["Overrides"]
+        )
+    }
+
+    func testSystemEntriesAreSkippedAndCounted() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(id: "0", title: "system", content: "127.0.0.1 localhost\n", isSystem: true, kind: .local),
+            SwitchHostsItem(id: "a", title: "dev", content: "x\n", kind: .local),
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        XCTAssertEqual(plan.snapshot.standaloneProfiles.map(\.name), ["dev"])
+        XCTAssertEqual(plan.summary.skippedSystemEntryCount, 1)
+        XCTAssertEqual(plan.summary.profileCount, 1)
+    }
+
+    func testHistoryAndTrashCountsPassThroughToTheSummary() {
+        let data = SwitchHostsData(
+            items: [SwitchHostsItem(id: "a", title: "dev", content: "x\n", kind: .local)],
+            historyEntryCount: 23,
+            trashedItemCount: 2
+        )
+
+        let summary = SwitchHostsMapper.plan(for: data).summary
+
+        XCTAssertEqual(summary.skippedHistoryEntryCount, 23)
+        XCTAssertEqual(summary.skippedTrashedItemCount, 2)
+    }
+
+    func testBlankTitlesFallBackToUntitled() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(id: "a", title: "  ", content: "x\n", kind: .local),
+            SwitchHostsItem(id: "f", title: "", kind: .folder(isSingleSelection: true, children: [
+                SwitchHostsItem(id: "b", title: "member", content: "y\n", kind: .local)
+            ])),
+        ])
+
+        let snapshot = SwitchHostsMapper.plan(for: data).snapshot
+
+        XCTAssertEqual(snapshot.standaloneProfiles.map(\.name), ["Untitled"])
+        XCTAssertEqual(snapshot.groups.map(\.name), ["Untitled"])
+    }
+
+    func testLocalContentWhoseFirstLineIsARemoteHeaderIsEscaped() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(
+                id: "a",
+                title: "sneaky",
+                content: "#!hostflip-remote https://x.example.test/a interval=1h\n0.0.0.0 ads.example.test\n",
+                kind: .local
+            )
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        let imported = plan.snapshot.standaloneProfiles[0].content
+        XCTAssertNil(RemoteHeader.parse(fromContent: imported), "a local rule must stay local")
+        XCTAssertEqual(plan.summary.remoteProfiles, [])
+    }
+
+    // MARK: - Mapping: remote rules
+
+    func testRemoteRuleBecomesARemoteProfileOverItsCachedContent() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(
+                id: "r",
+                title: "Team Blocklist",
+                content: "0.0.0.0 tracker.example.test\n",
+                kind: .remote(urlString: "https://rules.example.test/list.hosts", refreshIntervalSeconds: 86400)
+            )
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        XCTAssertEqual(plan.snapshot.standaloneProfiles, [.init(
+            name: "Team Blocklist",
+            content: "#!hostflip-remote https://rules.example.test/list.hosts interval=24h\n"
+                + "0.0.0.0 tracker.example.test\n"
+        )])
+        XCTAssertEqual(plan.summary.remoteProfiles, [.init(
+            profileName: "Team Blocklist",
+            sourceURL: "https://rules.example.test/list.hosts",
+            interval: .twentyFourHours
+        )])
+    }
+
+    func testRefreshIntervalsMapToTheNearestPresetThatFetchesAtLeastAsOften() {
+        func mapped(_ seconds: Int?) -> (interval: RemoteHeader.RefreshInterval, isAdjusted: Bool) {
+            SwitchHostsMapper.refreshInterval(forSeconds: seconds)
+        }
+        XCTAssertEqual(mapped(nil).interval, .manual)
+        XCTAssertEqual(mapped(0).interval, .manual)
+        XCTAssertFalse(mapped(0).isAdjusted)
+        XCTAssertEqual(mapped(3600).interval, .oneHour)
+        XCTAssertFalse(mapped(3600).isAdjusted)
+        XCTAssertEqual(mapped(1800).interval, .oneHour)
+        XCTAssertTrue(mapped(1800).isAdjusted)
+        XCTAssertEqual(mapped(21600).interval, .sixHours)
+        XCTAssertFalse(mapped(21600).isAdjusted)
+        // 2h has no exact preset; 6h would silently slow it down, so it rounds down to 1h.
+        XCTAssertEqual(mapped(7200).interval, .oneHour)
+        XCTAssertTrue(mapped(7200).isAdjusted)
+        XCTAssertEqual(mapped(43200).interval, .sixHours)
+        XCTAssertTrue(mapped(43200).isAdjusted)
+        XCTAssertEqual(mapped(86400).interval, .twentyFourHours)
+        XCTAssertFalse(mapped(86400).isAdjusted)
+        XCTAssertEqual(mapped(604800).interval, .twentyFourHours)
+        XCTAssertTrue(mapped(604800).isAdjusted)
+    }
+
+    func testAdjustedIntervalsAreReportedOnTheRemoteProfile() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(
+                id: "r",
+                title: "Weekly",
+                content: "",
+                kind: .remote(urlString: "https://rules.example.test/w.hosts", refreshIntervalSeconds: 604800)
+            )
+        ])
+
+        let remoteProfiles = SwitchHostsMapper.plan(for: data).summary.remoteProfiles
+
+        XCTAssertEqual(remoteProfiles, [.init(
+            profileName: "Weekly",
+            sourceURL: "https://rules.example.test/w.hosts",
+            interval: .twentyFourHours,
+            adjustedFromSeconds: 604800
+        )])
+    }
+
+    func testNonHTTPSRemoteRuleImportsAsLocalAndIsReported() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(
+                id: "r",
+                title: "Intranet Feed",
+                content: "10.0.0.1 feed.example.test\n",
+                kind: .remote(urlString: "http://feed.example.test/rules", refreshIntervalSeconds: 3600)
+            )
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        XCTAssertEqual(plan.snapshot.standaloneProfiles, [.init(
+            name: "Intranet Feed",
+            content: "10.0.0.1 feed.example.test\n"
+        )])
+        XCTAssertEqual(plan.summary.remoteProfiles, [])
+        XCTAssertEqual(plan.summary.downgradedRemotes, [.init(
+            profileName: "Intranet Feed",
+            urlString: "http://feed.example.test/rules"
+        )])
+    }
+
+    // MARK: - Mapping: combined rules
+
+    func testCombinedRuleExpandsMembersInIncludeOrderAndIsReportedFrozen() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(id: "a", title: "one", content: "1.1.1.1 a.example.test\n", kind: .local),
+            SwitchHostsItem(id: "f", title: "F", kind: .folder(isSingleSelection: true, children: [
+                SwitchHostsItem(
+                    id: "r",
+                    title: "cached remote",
+                    content: "2.2.2.2 b.example.test\n",
+                    kind: .remote(urlString: "https://x.example.test/r", refreshIntervalSeconds: 0)
+                )
+            ])),
+            SwitchHostsItem(id: "c", title: "combo", kind: .combined(memberIDs: ["r", "missing", "a"])),
+        ])
+
+        let plan = SwitchHostsMapper.plan(for: data)
+
+        let combo = plan.snapshot.standaloneProfiles.first { $0.name == "combo" }
+        XCTAssertEqual(combo?.content, "2.2.2.2 b.example.test\n\n1.1.1.1 a.example.test\n")
+        XCTAssertEqual(plan.summary.frozenCombinedProfiles, ["combo"])
+    }
+
+    func testCombinedRuleCyclesExpandEachMemberOnce() {
+        let data = SwitchHostsData(items: [
+            SwitchHostsItem(id: "c1", title: "combo1", kind: .combined(memberIDs: ["c2", "a"])),
+            SwitchHostsItem(id: "c2", title: "combo2", kind: .combined(memberIDs: ["c1", "a"])),
+            SwitchHostsItem(id: "a", title: "leaf", content: "x\n", kind: .local),
+        ])
+
+        let snapshot = SwitchHostsMapper.plan(for: data).snapshot
+
+        let combo1 = snapshot.standaloneProfiles.first { $0.name == "combo1" }
+        // c1 → c2 → (c1 already visited, skipped) → leaf, then c1's own leaf.
+        XCTAssertEqual(combo1?.content, "x\n\nx\n")
+    }
+
+    // MARK: - v4 directory reading
+
+    func testReadsANestedFolderDirectoryEndToEnd() throws {
+        let root = try writeV4Fixture(
+            tree: Self.nestedFoldersTree,
+            hostsRecords: [
+                "1": #"{"id": "aaaa", "content": "127.0.0.1 dev.example.test\n", "_id": "1"}"#,
+                "2": #"{"id": "bbbb", "content": "10.0.2.1 app.example.test\n", "_id": "2"}"#,
+                "3": #"{"id": "cccc", "content": "10.0.2.2 web.example.test\n", "_id": "3"}"#,
+            ],
+            hostsIDs: #"["1", null, "2", "3"]"#,
+            historyIDs: #"["7", "8", null]"#,
+            trashcan: #"[{"data": {"id": "gone", "title": "old"}, "parent_id": null}]"#
+        )
+
+        let plan = SwitchHostsMapper.plan(for: try SwitchHostsV4Reader.read(at: root))
+
+        XCTAssertEqual(plan.snapshot.standaloneProfiles, [
+            .init(name: "dev", content: "127.0.0.1 dev.example.test\n")
+        ])
+        XCTAssertEqual(plan.snapshot.groups, [
+            .init(name: "预发环境", profiles: [.init(name: "pre1", content: "10.0.2.1 app.example.test\n")]),
+            .init(name: "预发环境 / 前端", profiles: [.init(name: "web1", content: "10.0.2.2 web.example.test\n")]),
+        ])
+        XCTAssertEqual(plan.summary.skippedSystemEntryCount, 1)
+        XCTAssertEqual(plan.summary.skippedHistoryEntryCount, 2)
+        XCTAssertEqual(plan.summary.skippedTrashedItemCount, 1)
+
+        // The plan applies through the ADR-0008 import path: appended, fresh IDs, all inactive.
+        var model = try ActivationModel(
+            baseHosts: BaseHosts(content: "127.0.0.1 localhost\n"),
+            standaloneProfiles: [],
+            groups: []
+        )
+        try model.importSnapshot(plan.snapshot)
+        XCTAssertEqual(model.standaloneProfiles.map(\.name), ["dev"])
+        XCTAssertEqual(model.groups.map(\.name), ["预发环境", "预发环境 / 前端"])
+        XCTAssertEqual(model.activeProfileIDs, [])
+    }
+
+    func testReadsARemoteRuleWithURLAndInterval() throws {
+        let root = try writeV4Fixture(
+            tree: Self.remoteRuleTree,
+            hostsRecords: [
+                "1": #"{"id": "rrrr", "content": "0.0.0.0 tracker.example.test\n", "_id": "1"}"#
+            ],
+            hostsIDs: #"["1"]"#
+        )
+
+        let data = try SwitchHostsV4Reader.read(at: root)
+
+        XCTAssertEqual(data.items, [SwitchHostsItem(
+            id: "rrrr",
+            title: "Team Blocklist",
+            content: "0.0.0.0 tracker.example.test\n",
+            kind: .remote(urlString: "https://rules.example.test/list.hosts", refreshIntervalSeconds: 604800)
+        )])
+    }
+
+    func testReadsACombinedRuleWithItsIncludeOrder() throws {
+        let root = try writeV4Fixture(
+            tree: Self.combinedRuleTree,
+            hostsRecords: [
+                "1": #"{"id": "aaaa", "content": "1.1.1.1 a.example.test\n", "_id": "1"}"#,
+                "2": #"{"id": "bbbb", "content": "2.2.2.2 b.example.test\n", "_id": "2"}"#,
+            ],
+            hostsIDs: #"["1", "2"]"#
+        )
+
+        let data = try SwitchHostsV4Reader.read(at: root)
+
+        XCTAssertEqual(data.items.last, SwitchHostsItem(
+            id: "cccc",
+            title: "combo",
+            content: "",
+            kind: .combined(memberIDs: ["bbbb", "aaaa"])
+        ))
+    }
+
+    func testEntriesWithoutATypeReadAsLocal() throws {
+        let root = try writeV4Fixture(
+            tree: #"[{"title": "dev", "id": "aaaa", "on": false}]"#,
+            hostsRecords: [:],
+            hostsIDs: "[]"
+        )
+
+        let data = try SwitchHostsV4Reader.read(at: root)
+
+        XCTAssertEqual(data.items, [SwitchHostsItem(id: "aaaa", title: "dev", content: "", kind: .local)])
+    }
+
+    func testMissingTreeReadsAsDataNotFound() throws {
+        let root = try makeTemporaryDirectory()
+
+        XCTAssertThrowsError(try SwitchHostsV4Reader.read(at: root)) { error in
+            XCTAssertEqual(error as? SwitchHostsImportError, .dataNotFound)
+        }
+    }
+
+    func testACorruptCollectionRecordFailsTheWholeRead() throws {
+        let root = try writeV4Fixture(
+            tree: #"[{"title": "dev", "id": "aaaa", "on": false}]"#,
+            hostsRecords: ["1": "not json"],
+            hostsIDs: #"["1"]"#
+        )
+
+        XCTAssertThrowsError(try SwitchHostsV4Reader.read(at: root)) { error in
+            XCTAssertEqual(
+                error as? SwitchHostsImportError,
+                .malformedData(file: "data/collection/hosts/data/1.json")
+            )
+        }
+    }
+
+    func testAListedButMissingCollectionRecordFailsTheWholeRead() throws {
+        let root = try writeV4Fixture(
+            tree: #"[{"title": "dev", "id": "aaaa", "on": false}]"#,
+            hostsRecords: [:],
+            hostsIDs: #"["1"]"#
+        )
+
+        XCTAssertThrowsError(try SwitchHostsV4Reader.read(at: root)) { error in
+            XCTAssertEqual(
+                error as? SwitchHostsImportError,
+                .malformedData(file: "data/collection/hosts/data/1.json")
+            )
+        }
+    }
+
+    func testAnOutOfRangeRefreshIntervalClampsInsteadOfTrapping() throws {
+        let root = try writeV4Fixture(
+            tree: #"""
+            [{"type": "remote", "title": "r", "id": "rrrr",
+              "url": "https://rules.example.test/r", "refresh_interval": 1e100}]
+            """#,
+            hostsRecords: [:],
+            hostsIDs: "[]"
+        )
+
+        let data = try SwitchHostsV4Reader.read(at: root)
+
+        // The absurd cadence stays "very slow": 24h after mapping, disclosed as adjusted.
+        XCTAssertEqual(data.items.first?.kind, .remote(
+            urlString: "https://rules.example.test/r",
+            refreshIntervalSeconds: .max
+        ))
+        let mapped = SwitchHostsMapper.refreshInterval(forSeconds: .max)
+        XCTAssertEqual(mapped.interval, .twentyFourHours)
+        XCTAssertTrue(mapped.isAdjusted)
+    }
+
+    func testAMissingOrDuplicateEntryIDFailsTheRead() throws {
+        let missingID = try writeV4Fixture(
+            tree: #"[{"title": "dev", "on": false}]"#,
+            hostsRecords: [:],
+            hostsIDs: "[]"
+        )
+        XCTAssertThrowsError(try SwitchHostsV4Reader.read(at: missingID)) { error in
+            XCTAssertEqual(
+                error as? SwitchHostsImportError,
+                .malformedData(file: "data/list/tree.json")
+            )
+        }
+
+        let duplicateID = try writeV4Fixture(
+            tree: #"[{"title": "a", "id": "aaaa"}, {"title": "b", "id": "aaaa"}]"#,
+            hostsRecords: [:],
+            hostsIDs: "[]"
+        )
+        XCTAssertThrowsError(try SwitchHostsV4Reader.read(at: duplicateID)) { error in
+            XCTAssertEqual(
+                error as? SwitchHostsImportError,
+                .malformedData(file: "data/list/tree.json")
+            )
+        }
+    }
+
+    func testAnUnknownEntryTypeFailsTheRead() throws {
+        let root = try writeV4Fixture(
+            tree: #"[{"title": "dev", "id": "aaaa", "type": "hologram"}]"#,
+            hostsRecords: [:],
+            hostsIDs: "[]"
+        )
+
+        XCTAssertThrowsError(try SwitchHostsV4Reader.read(at: root)) { error in
+            XCTAssertEqual(
+                error as? SwitchHostsImportError,
+                .malformedData(file: "data/list/tree.json")
+            )
+        }
+    }
+
+    // MARK: - Fixtures
+
+    /// Desensitized sample of a real v4 tree (#74): the system entry, a loose rule, and a
+    /// single-selection folder with a rule and a nested subfolder — v4 writes `type` only
+    /// for non-default entries, keeps `folder_mode`, and carries UI noise fields.
+    private static let nestedFoldersTree = #"""
+    [
+     {"id": "0", "title": "系统 Hosts", "is_sys": true, "on": true},
+     {"title": "dev", "id": "aaaa", "on": false},
+     {"type": "folder", "title": "预发环境", "folder_mode": 1, "id": "ffff",
+      "children": [
+       {"title": "pre1", "id": "bbbb", "on": false},
+       {"type": "folder", "title": "前端", "folder_mode": 1, "id": "gggg",
+        "children": [{"title": "web1", "type": "local", "id": "cccc", "on": false}],
+        "is_collapsed": false}
+      ],
+      "on": false, "is_collapsed": false}
+    ]
+    """#
+
+    /// Desensitized sample of a v4 remote rule: URL, weekly refresh, cached content in the
+    /// hosts collection, and the refresh bookkeeping fields v4 writes alongside.
+    private static let remoteRuleTree = #"""
+    [
+     {"type": "remote", "title": "Team Blocklist", "id": "rrrr",
+      "url": "https://rules.example.test/list.hosts", "refresh_interval": 604800,
+      "last_refresh": "8/19/2026, 10:00:00 AM", "last_refresh_ms": 1787101200000, "on": false}
+    ]
+    """#
+
+    /// Desensitized sample of a v4 combined rule: `include` lists member ids in combination order.
+    private static let combinedRuleTree = #"""
+    [
+     {"title": "one", "id": "aaaa", "on": false},
+     {"title": "two", "id": "bbbb", "on": false},
+     {"type": "group", "title": "combo", "id": "cccc", "include": ["bbbb", "aaaa"], "on": false}
+    ]
+    """#
+
+    /// Materializes a v4 PotDb directory: `data/list/tree.json`, the hosts collection
+    /// (`ids.json` + one file per record), and optionally history ids and a trashcan list.
+    private func writeV4Fixture(
+        tree: String,
+        hostsRecords: [String: String],
+        hostsIDs: String,
+        historyIDs: String? = nil,
+        trashcan: String? = nil
+    ) throws -> URL {
+        let root = try makeTemporaryDirectory()
+        let fileManager = FileManager.default
+        let listDirectory = root.appendingPathComponent("data/list", isDirectory: true)
+        let hostsDirectory = root.appendingPathComponent("data/collection/hosts/data", isDirectory: true)
+        try fileManager.createDirectory(at: listDirectory, withIntermediateDirectories: true)
+        try fileManager.createDirectory(at: hostsDirectory, withIntermediateDirectories: true)
+        try Data(tree.utf8).write(to: listDirectory.appendingPathComponent("tree.json"))
+        try Data(hostsIDs.utf8).write(
+            to: hostsDirectory.deletingLastPathComponent().appendingPathComponent("ids.json")
+        )
+        try Data(#"{"index": \#(hostsRecords.count)}"#.utf8).write(
+            to: hostsDirectory.deletingLastPathComponent().appendingPathComponent("meta.json")
+        )
+        for (recordID, json) in hostsRecords {
+            try Data(json.utf8).write(to: hostsDirectory.appendingPathComponent("\(recordID).json"))
+        }
+        if let historyIDs {
+            let historyDirectory = root.appendingPathComponent("data/collection/history", isDirectory: true)
+            try fileManager.createDirectory(at: historyDirectory, withIntermediateDirectories: true)
+            try Data(historyIDs.utf8).write(to: historyDirectory.appendingPathComponent("ids.json"))
+        }
+        if let trashcan {
+            try Data(trashcan.utf8).write(to: listDirectory.appendingPathComponent("trashcan.json"))
+        }
+        return root
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("switchhosts-import-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}

--- a/Tests/HostflipTests/SwitchHostsImportPresentationTests.swift
+++ b/Tests/HostflipTests/SwitchHostsImportPresentationTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import HostflipCore
+import XCTest
+@testable import Hostflip
+
+/// The SwitchHosts import summary alert copy (#74): every part of the mapping report —
+/// counts, Remote Profiles, skips, semantic shifts — must render; nothing may be elided.
+final class SwitchHostsImportPresentationTests: XCTestCase {
+    func testAPlainImportRendersOnlyTheCountsParagraph() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(
+            for: SwitchHostsImportSummary(profileCount: 3, groupCount: 2)
+        )
+
+        XCTAssertEqual(paragraphs, ["Imported 3 profiles from SwitchHosts. Created 2 groups."])
+    }
+
+    func testASingleProfileWithoutGroupsUsesTheSingularLine() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(
+            for: SwitchHostsImportSummary(profileCount: 1)
+        )
+
+        XCTAssertEqual(paragraphs, ["Imported 1 profile from SwitchHosts."])
+    }
+
+    func testRemoteProfilesListNamesWithTheirSourceURLs() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(for: SwitchHostsImportSummary(
+            profileCount: 1,
+            remoteProfiles: [.init(
+                profileName: "Blocklist",
+                sourceURL: "https://rules.example/list.hosts",
+                interval: .twentyFourHours
+            )]
+        ))
+
+        XCTAssertEqual(paragraphs.count, 2)
+        XCTAssertEqual(
+            paragraphs[1],
+            "1 remote rule became a Remote Profile and will fetch content from this URL:\n"
+                + "Blocklist — https://rules.example/list.hosts"
+        )
+    }
+
+    func testSkippedCountsRenderOnlyTheNonZeroLines() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(for: SwitchHostsImportSummary(
+            profileCount: 1,
+            skippedSystemEntryCount: 1,
+            skippedHistoryEntryCount: 23
+        ))
+
+        XCTAssertEqual(paragraphs.count, 2)
+        XCTAssertEqual(paragraphs[1], "Skipped:\nSystem hosts entries: 1\nHistory snapshots: 23")
+    }
+
+    func testEverySemanticShiftRendersANoteLine() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(for: SwitchHostsImportSummary(
+            profileCount: 4,
+            remoteProfiles: [.init(
+                profileName: "Weekly",
+                sourceURL: "https://rules.example/w.hosts",
+                interval: .twentyFourHours,
+                adjustedFromSeconds: 604800
+            )],
+            exclusivityTightenedGroups: ["Overrides"],
+            frozenCombinedProfiles: ["combo"],
+            downgradedRemotes: [.init(profileName: "Feed", urlString: "http://feed.example/rules")]
+        ))
+
+        let notes = try? XCTUnwrap(paragraphs.last)
+        XCTAssertTrue(paragraphs.count >= 3)
+        let noteLines = (notes ?? "").components(separatedBy: "\n")
+        XCTAssertEqual(noteLines.first, "Notes:")
+        XCTAssertEqual(noteLines.count, 5)
+        XCTAssertTrue(noteLines[1].contains("“Overrides”"), noteLines[1])
+        XCTAssertTrue(noteLines[1].contains("mutually exclusive"), noteLines[1])
+        XCTAssertTrue(noteLines[2].contains("“combo”"), noteLines[2])
+        XCTAssertTrue(noteLines[2].contains("snapshot"), noteLines[2])
+        // Durations render through DateComponentsFormatter, so the exact wording is
+        // locale-dependent; the note must name the profile and both cadences.
+        XCTAssertTrue(noteLines[3].contains("“Weekly”"), noteLines[3])
+        XCTAssertTrue(noteLines[3].contains("instead of"), noteLines[3])
+        XCTAssertTrue(noteLines[4].contains("“Feed”"), noteLines[4])
+        XCTAssertTrue(noteLines[4].contains("http://feed.example/rules"), noteLines[4])
+    }
+
+    func testTheDetectedFormatJoinsTheCountsParagraph() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(
+            for: SwitchHostsImportSummary(profileCount: 2, detectedFormat: .v5)
+        )
+
+        XCTAssertEqual(paragraphs, [
+            "Imported 2 profiles from SwitchHosts. Detected SwitchHosts v5 data."
+        ])
+    }
+
+    func testAnUnadjustedRemoteProfileAddsNoNoteLine() {
+        let paragraphs = SwitchHostsImportPresentation.paragraphs(for: SwitchHostsImportSummary(
+            profileCount: 1,
+            remoteProfiles: [.init(
+                profileName: "Blocklist",
+                sourceURL: "https://rules.example/list.hosts",
+                interval: .oneHour
+            )]
+        ))
+
+        XCTAssertFalse(paragraphs.contains { $0.hasPrefix("Notes:") })
+    }
+}

--- a/Tests/HostflipTests/SwitchHostsImportSuggestionTests.swift
+++ b/Tests/HostflipTests/SwitchHostsImportSuggestionTests.swift
@@ -1,0 +1,29 @@
+import Foundation
+import XCTest
+@testable import Hostflip
+
+/// The one-shot first-launch suggestion flag (#75): offered at most once, ever.
+final class SwitchHostsImportSuggestionTests: XCTestCase {
+    func testStartsUnoffered() {
+        var stored = false
+        let suggestion = SwitchHostsImportSuggestion(
+            loadOffered: { stored },
+            saveOffered: { stored = true }
+        )
+
+        XCTAssertFalse(suggestion.wasOffered)
+    }
+
+    func testMarkingPersistsAndSticks() {
+        var stored = false
+        let suggestion = SwitchHostsImportSuggestion(
+            loadOffered: { stored },
+            saveOffered: { stored = true }
+        )
+
+        suggestion.markOffered()
+
+        XCTAssertTrue(stored)
+        XCTAssertTrue(suggestion.wasOffered)
+    }
+}

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -1456,6 +1456,101 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertNil(store.followUpMergeTask)
     }
 
+    // MARK: - SwitchHosts import (#74)
+
+    @MainActor
+    func testSwitchHostsImportAppendsMappedContentInactiveWithoutMerging() throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        let directory = try writeSwitchHostsV4Directory(
+            tree: #"""
+            [
+             {"title": "dev", "id": "aaaa", "on": false},
+             {"type": "remote", "title": "Blocklist", "id": "rrrr",
+              "url": "https://rules.example/list.hosts", "refresh_interval": 86400, "on": false}
+            ]
+            """#,
+            records: [
+                "1": #"{"id": "aaaa", "content": "127.0.0.1 dev.example\n", "_id": "1"}"#,
+                "2": #"{"id": "rrrr", "content": "0.0.0.0 tracker.example\n", "_id": "2"}"#,
+            ]
+        )
+
+        let outcome = store.importSwitchHosts(at: directory)
+
+        XCTAssertEqual(outcome, .imported(SwitchHostsImportSummary(
+            profileCount: 2,
+            remoteProfiles: [.init(
+                profileName: "Blocklist",
+                sourceURL: "https://rules.example/list.hosts",
+                interval: .twentyFourHours
+            )],
+            detectedFormat: .v4
+        )))
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["dev", "Blocklist"])
+        XCTAssertTrue(try XCTUnwrap(store.standaloneProfiles.last).isRemote)
+        XCTAssertEqual(store.model?.activeProfileIDs, [])
+        // Offline and purely local: nothing reaches the coordinator, no follow-up merge.
+        XCTAssertNil(store.followUpMergeTask)
+        XCTAssertTrue(stub.authorizedMerges.isEmpty)
+        XCTAssertTrue(stub.performedSwitches.isEmpty)
+        XCTAssertEqual(try reloadModel().standaloneProfiles.map(\.name), ["dev", "Blocklist"])
+    }
+
+    @MainActor
+    func testSwitchHostsImportAppliesNothingWhenTheDataIsMalformed() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let directory = try writeSwitchHostsV4Directory(
+            tree: #"[{"title": "dev", "id": "aaaa"}]"#,
+            records: ["1": "not json"]
+        )
+
+        let outcome = store.importSwitchHosts(at: directory)
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("the import must fail as a whole, got: \(outcome)")
+        }
+        XCTAssertTrue(message.contains("data/collection/hosts/data/1.json"), message)
+        XCTAssertTrue(store.standaloneProfiles.isEmpty)
+        XCTAssertTrue(try reloadModel().standaloneProfiles.isEmpty)
+    }
+
+    @MainActor
+    func testSwitchHostsImportReportsAMissingDataDirectory() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+
+        let outcome = store.importSwitchHosts(
+            at: rootDirectory.appendingPathComponent("no-switchhosts", isDirectory: true)
+        )
+
+        guard case .failed(let message) = outcome else {
+            return XCTFail("the import must fail, got: \(outcome)")
+        }
+        XCTAssertTrue(message.contains("that folder"), message)
+        XCTAssertTrue(store.standaloneProfiles.isEmpty)
+    }
+
+    /// A minimal v4 PotDb directory; record keys are the collection `_id`s listed in ids.json.
+    private func writeSwitchHostsV4Directory(
+        tree: String,
+        records: [String: String]
+    ) throws -> URL {
+        let root = rootDirectory.appendingPathComponent("switchhosts-v4", isDirectory: true)
+        let listDirectory = root.appendingPathComponent("data/list", isDirectory: true)
+        let dataDirectory = root.appendingPathComponent("data/collection/hosts/data", isDirectory: true)
+        try FileManager.default.createDirectory(at: listDirectory, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: dataDirectory, withIntermediateDirectories: true)
+        try Data(tree.utf8).write(to: listDirectory.appendingPathComponent("tree.json"))
+        let ids = records.keys.sorted().map { "\"\($0)\"" }.joined(separator: ", ")
+        try Data("[\(ids)]".utf8).write(
+            to: dataDirectory.deletingLastPathComponent().appendingPathComponent("ids.json")
+        )
+        for (recordID, json) in records {
+            try Data(json.utf8).write(to: dataDirectory.appendingPathComponent("\(recordID).json"))
+        }
+        return root
+    }
+
     @MainActor
     func testExportedDataRoundTripsAsASnapshotOfCurrentProfiles() throws {
         let store = makeStore(coordinator: SwitchCoordinatingStub())


### PR DESCRIPTION
## What's in here

One-click migration from SwitchHosts, covering every generation of its data format:

- **Readers for all three generations** — v5 Tauri (`manifest.json` + `entries/*.hosts`), v4 Electron PotDb (`tree.json` + collection files), and v3 (single `data.json`, `where` discriminator, hour-based intervals, inline content). All three produce one shared intermediate model; the mapping engine is format-blind.
- **Mapping** — folders flatten to groups named by their joined path, top-level entries land standalone, remote rules transpose to native Remote Profiles over their cached content (offline; refresh intervals round to the nearest preset that fetches at least as often), combined rules freeze to content snapshots. Everything arrives inactive, one atomic batch: any parse failure means zero change.
- **Discovery** — default `~/.SwitchHosts` → the v5 custom data-dir pointer → a folder picker fallback (which also resolves a nested `SwitchHosts.data/` store). Newest generation wins when leftovers coexist.
- **Entry points** — a File-menu item, plus a one-time first-launch suggestion when SwitchHosts data is present; both share the same flow. The import summary reports counts, Remote Profile URLs, the detected format, everything skipped, and every deliberate semantic shift.
- **Hardening** — unique-id validation, refresh-interval overflow clamping, content-file path containment, and a v3 major-version check all refuse the batch instead of importing something wrong.
- **Docs** — a FAQ entry on the App Background Activity row that macOS keeps showing after "Deactivate and Remove Helper".

Plus the 0.3.0 release notes and version bump.

## Testing

725 tests pass, including desensitized real-shape fixtures for all three formats (nested folders, remote rules, combined rules) and an end-to-end run against real v4 and v5 data sets that cross-validated identical output.
