### PR TITLE
fix: align the drift review baseline and strip a previous install's fence at capture

### DIFF
--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -1484,10 +1484,22 @@ final class WorkspaceStore {
 
     private func refreshHostsDriftComparison() {
         guard let model else { return }
-        let refreshed = try? HostsDriftComparison(
-            expectedContent: model.mergedHosts.content,
-            actualData: readSystemHosts()
-        )
+        // Before the first confirmed write, the drift verdict compares against hosts.orig, so the
+        // review must diff against that same baseline: diffing against the merged output — whose
+        // Base Hosts left the SwitchHosts block out at capture (#81) — would show the block as
+        // additions and hand it back to "Add to Base Hosts" (#82). An unreadable baseline fails
+        // closed as no comparison, like the monitor's verdict — falling back to the merged output
+        // would resurrect exactly the weld-back this guards against.
+        let expectedContent: String?
+        do {
+            expectedContent = try workspace.expectedSystemHostsContentBeforeFirstWrite()
+                ?? model.mergedHosts.content
+        } catch {
+            expectedContent = nil
+        }
+        let refreshed = try? expectedContent.map {
+            try HostsDriftComparison(expectedContent: $0, actualData: readSystemHosts())
+        }
         guard refreshed != hostsDriftComparison else { return }
         hostsDriftComparison = refreshed
         hostsDriftGeneration &+= 1

--- a/Sources/HostflipCore/MergedHosts.swift
+++ b/Sources/HostflipCore/MergedHosts.swift
@@ -30,6 +30,67 @@ extension MergedHosts {
     public static let appendedBlockBegin =
         "# ══ hostflip:begin — delete through hostflip:end to remove ══"
     public static let appendedBlockEnd = "# ══ hostflip:end ══"
+
+    /// Captured content with this manager's own appended block removed (#83): a workspace
+    /// deleted while profiles were active leaves the previous install's block in the file,
+    /// and — like the SwitchHosts marker (#81) — it is manager-owned output, not the user's
+    /// baseline. The block spans the first line that is exactly `appendedBlockBegin` through
+    /// the next line that is exactly `appendedBlockEnd`; content after the block is kept.
+    /// A begin without an end, or a block with nothing but whitespace before it, returns the
+    /// content unchanged — malformed shapes are not guessed at, and an empty Base Hosts would
+    /// make a no-profile write empty the system hosts. Removal repeats while blocks remain,
+    /// so a file polluted by two successive deleted installs comes fully clean. (A profile
+    /// whose own content contains the exact end fence line would cut its block short — no
+    /// hosts content has a reason to carry that line, so the shape is not guarded against.)
+    public static func removingAppendedBlock(from content: String) -> String {
+        var content = content
+        while true {
+            let removed = removingFirstAppendedBlock(from: content)
+            if removed == content { return content }
+            content = removed
+        }
+    }
+
+    private static func removingFirstAppendedBlock(from content: String) -> String {
+        guard let begin = lineRange(ofExact: appendedBlockBegin, in: content, from: content.startIndex),
+              let end = lineRange(ofExact: appendedBlockEnd, in: content, from: begin.upperBound)
+        else { return content }
+        // An orphan begin must not pair with a LATER block's end — everything in between,
+        // the user's own lines included, would silently go with it. A second begin before
+        // the end marks the shape malformed, and malformed shapes are not guessed at.
+        if let nextBegin = lineRange(ofExact: appendedBlockBegin, in: content, from: begin.upperBound),
+           nextBegin.lowerBound < end.lowerBound {
+            return content
+        }
+        let head = content[..<begin.lowerBound]
+        guard let lastContent = head.lastIndex(where: { !$0.isWhitespace }) else { return content }
+        var tail = content[end.upperBound...]
+        while let first = tail.first, first.isNewline {
+            tail = tail.dropFirst()
+        }
+        let newline = head.contains("\r\n") ? "\r\n" : "\n"
+        return head[...lastContent] + newline + tail
+    }
+
+    /// The first line in `content` at or after `start` whose whole content is `line`, as the
+    /// range from the line's start through its newline (`Character.isNewline` treats CRLF as
+    /// one grapheme). Nil when no such line exists. Shared with the SwitchHosts capture strip.
+    static func lineRange(
+        ofExact line: String,
+        in content: String,
+        from start: String.Index
+    ) -> Range<String.Index>? {
+        var lineStart = start
+        while lineStart < content.endIndex {
+            let lineEnd = content[lineStart...].firstIndex(where: \.isNewline) ?? content.endIndex
+            let after = lineEnd < content.endIndex ? content.index(after: lineEnd) : content.endIndex
+            if content[lineStart..<lineEnd] == line {
+                return lineStart..<after
+            }
+            lineStart = after
+        }
+        return nil
+    }
     /// The banner releases up to 0.1.1 wrote at the top of the file; still
     /// recognized wherever generated output must be detected.
     public static let legacyGeneratedBanner =

--- a/Sources/HostflipCore/SwitchHostsResidue.swift
+++ b/Sources/HostflipCore/SwitchHostsResidue.swift
@@ -28,17 +28,8 @@ public enum SwitchHostsResidue {
         return head[...lastContent] + newline
     }
 
-    /// The start of the first line whose whole content is the marker. `Character.isNewline`
-    /// treats CRLF as one grapheme, so lines come out clean in CRLF files too.
+    /// The start of the first line whose whole content is the marker.
     private static func markerLineStart(in content: String) -> String.Index? {
-        var lineStart = content.startIndex
-        while lineStart < content.endIndex {
-            let lineEnd = content[lineStart...].firstIndex(where: \.isNewline) ?? content.endIndex
-            if content[lineStart..<lineEnd] == marker {
-                return lineStart
-            }
-            lineStart = lineEnd < content.endIndex ? content.index(after: lineEnd) : content.endIndex
-        }
-        return nil
+        MergedHosts.lineRange(ofExact: marker, in: content, from: content.startIndex)?.lowerBound
     }
 }

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -73,9 +73,12 @@ public struct Workspace: Sendable {
         try FileManager.default.createDirectory(at: profilesDirectory, withIntermediateDirectories: true)
         try writeOriginalBackupIfAbsent(content)
 
-        // hosts.orig keeps the file as found; Base Hosts leaves out a SwitchHosts block (#81).
+        // hosts.orig keeps the file as found; Base Hosts leaves out manager-owned blocks —
+        // a previous install's own appended block (#83) and a SwitchHosts block (#81).
         let model = try ActivationModel(
-            baseHosts: BaseHosts(content: SwitchHostsResidue.stripped(from: content)),
+            baseHosts: BaseHosts(
+                content: SwitchHostsResidue.stripped(from: MergedHosts.removingAppendedBlock(from: content))
+            ),
             standaloneProfiles: [],
             groups: []
         )

--- a/Sources/HostflipCore/Workspace.swift
+++ b/Sources/HostflipCore/Workspace.swift
@@ -252,6 +252,17 @@ public struct Workspace: Sendable {
         return MergedHosts.hash(of: try Data(contentsOf: originalBackupURL))
     }
 
+    /// The content counterpart of `expectedSystemHostsHash()` for the window before the first
+    /// confirmed merge write: the pristine first-capture backup, which is what the drift verdict
+    /// compares against while `lastWrittenHash` is nil. After a confirmed write it returns nil —
+    /// the expected content is then the caller's merged output. Kept branch-identical to
+    /// `expectedSystemHostsHash()` so a drift review never diffs against a different baseline
+    /// than the verdict that raised it (#82).
+    public func expectedSystemHostsContentBeforeFirstWrite() throws -> String? {
+        guard try requireManifest().lastWrittenHash == nil else { return nil }
+        return try String(contentsOf: originalBackupURL, encoding: .utf8)
+    }
+
     /// Records the hash after a successful merge write; only this field is updated, domain state is left untouched.
     public func recordLastWrittenHash(_ hash: String) throws {
         try withManifestLock {

--- a/Sources/HostflipXPC/MergeCoordinator.swift
+++ b/Sources/HostflipXPC/MergeCoordinator.swift
@@ -91,6 +91,11 @@ public actor MergeCoordinator {
                 if case .mergeWriteFailed(let failure) = error,
                    let writtenHash = failure.writtenHash {
                     await confirmedWriteTracker?.hostsWriteDidConfirm(writtenHash)
+                    // The replacement landed — persist it like a success, or a restart (and
+                    // the drift review, which reads the manifest, #82) would treat the write
+                    // as never having happened. Best effort: the error already describes the
+                    // real failure.
+                    try? workspace.recordLastWrittenHash(writtenHash)
                 }
                 throw error
             }

--- a/Tests/HostflipCoreTests/MergedHostsTests.swift
+++ b/Tests/HostflipCoreTests/MergedHostsTests.swift
@@ -223,4 +223,64 @@ final class MergedHostsTests: XCTestCase {
 
         XCTAssertNotEqual(model.mergedHosts.hash, inactiveHash)
     }
+    // MARK: - Appended-block removal at capture (#83)
+
+    private static let fencedFile = "127.0.0.1 localhost\n\n"
+        + MergedHosts.appendedBlockBegin + "\n"
+        + "# ── Dev ──\n10.0.0.5 dev.local\n"
+        + MergedHosts.appendedBlockEnd + "\n"
+
+    func testRemovingTheAppendedBlockKeepsTheBaseline() {
+        XCTAssertEqual(
+            MergedHosts.removingAppendedBlock(from: Self.fencedFile),
+            "127.0.0.1 localhost\n"
+        )
+    }
+
+    func testContentAfterTheBlockSurvivesRemoval() {
+        let content = Self.fencedFile + "\n9.9.9.9 appended-later.local\n"
+        XCTAssertEqual(
+            MergedHosts.removingAppendedBlock(from: content),
+            "127.0.0.1 localhost\n9.9.9.9 appended-later.local\n"
+        )
+    }
+
+    func testABeginWithoutAnEndLeavesTheContentUnchanged() {
+        let content = "127.0.0.1 localhost\n" + MergedHosts.appendedBlockBegin + "\n10.0.0.5 dev.local\n"
+        XCTAssertEqual(MergedHosts.removingAppendedBlock(from: content), content)
+    }
+
+    func testABlockWithNothingBeforeItLeavesTheContentUnchanged() {
+        let content = MergedHosts.appendedBlockBegin + "\n10.0.0.5 dev.local\n"
+            + MergedHosts.appendedBlockEnd + "\n"
+        XCTAssertEqual(MergedHosts.removingAppendedBlock(from: content), content)
+        let whitespaceOnly = "\n\n" + content
+        XCTAssertEqual(MergedHosts.removingAppendedBlock(from: whitespaceOnly), whitespaceOnly)
+    }
+
+    func testTwoSuccessiveBlocksAreBothRemoved() {
+        let twicePolluted = "127.0.0.1 localhost\n\n"
+            + MergedHosts.appendedBlockBegin + "\n10.0.0.5 old.local\n" + MergedHosts.appendedBlockEnd + "\n"
+            + "\n" + MergedHosts.appendedBlockBegin + "\n10.0.0.6 older.local\n" + MergedHosts.appendedBlockEnd + "\n"
+        XCTAssertEqual(
+            MergedHosts.removingAppendedBlock(from: twicePolluted),
+            "127.0.0.1 localhost\n"
+        )
+    }
+
+    func testAnOrphanBeginNeverPairsWithALaterBlocksEnd() {
+        // The user deleted only the end line of an old fence and added entries after it;
+        // pairing the orphan begin with the later block's end would swallow those entries.
+        let content = "127.0.0.1 localhost\n"
+            + MergedHosts.appendedBlockBegin + "\n"
+            + "203.0.113.9 work.internal\n"
+            + MergedHosts.appendedBlockBegin + "\n10.0.0.5 dev.local\n" + MergedHosts.appendedBlockEnd + "\n"
+        XCTAssertEqual(MergedHosts.removingAppendedBlock(from: content), content)
+    }
+
+    func testTheBlockMarkersInsideLongerLinesDoNotMatch() {
+        let content = "127.0.0.1 localhost\n# about " + MergedHosts.appendedBlockBegin + "\n10.0.0.5 dev.local\n"
+        XCTAssertEqual(MergedHosts.removingAppendedBlock(from: content), content)
+    }
+
 }

--- a/Tests/HostflipCoreTests/WorkspaceTests.swift
+++ b/Tests/HostflipCoreTests/WorkspaceTests.swift
@@ -39,6 +39,43 @@ final class WorkspaceTests: XCTestCase {
         XCTAssertEqual(try reopenWithoutImporting(workspace).baseHosts.content, "127.0.0.1 localhost\n")
     }
 
+    func testFirstCaptureLeavesAPreviousInstallsAppendedBlockOutOfBaseHosts() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        let systemHosts = "127.0.0.1 localhost\n\n"
+            + MergedHosts.appendedBlockBegin + "\n"
+            + "# ── Dev ──\n10.0.0.5 dev.local\n"
+            + MergedHosts.appendedBlockEnd + "\n"
+
+        var model = try workspace.open(systemHosts: { systemHosts })
+
+        XCTAssertEqual(model.baseHosts.content, "127.0.0.1 localhost\n")
+        XCTAssertEqual(try contentsOfWorkspaceFile("hosts.orig"), systemHosts)
+
+        // Re-activating a profile produces a single fence, not a nested one.
+        model = try ActivationModel(
+            baseHosts: model.baseHosts,
+            standaloneProfiles: [Profile(id: .init("dev"), name: "Dev", content: "10.0.0.5 dev.local\n")],
+            groups: []
+        )
+        try model.toggleProfile(.init("dev"))
+        XCTAssertEqual(
+            model.mergedHosts.content.components(separatedBy: MergedHosts.appendedBlockBegin).count,
+            2
+        )
+    }
+
+    func testFirstCaptureStripsBothManagersBlocksFromOneFile() throws {
+        let workspace = Workspace(rootDirectory: rootDirectory)
+        let systemHosts = "127.0.0.1 localhost\n\n"
+            + MergedHosts.appendedBlockBegin + "\n10.0.0.5 dev.local\n" + MergedHosts.appendedBlockEnd + "\n"
+            + "\n# --- SWITCHHOSTS_CONTENT_START ---\n\n10.0.0.1 api.example.com\n"
+
+        let model = try workspace.open(systemHosts: { systemHosts })
+
+        XCTAssertEqual(model.baseHosts.content, "127.0.0.1 localhost\n")
+        XCTAssertEqual(try contentsOfWorkspaceFile("hosts.orig"), systemHosts)
+    }
+
     func testFirstCaptureWithASwitchHostsBlockReportsNoDriftBeforeTheFirstWrite() throws {
         let workspace = Workspace(rootDirectory: rootDirectory)
         let systemHosts = "127.0.0.1 localhost\n\n# --- SWITCHHOSTS_CONTENT_START ---\n\n10.0.0.1 api.example.com\n"

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -794,6 +794,87 @@ final class WorkspaceStoreTests: XCTestCase {
         XCTAssertEqual(coordinator.performedSwitches.count, 1)
     }
 
+    /// #82: before the first confirmed write, the drift review diffs against hosts.orig —
+    /// the same baseline as the verdict — not against the capture-stripped merged output.
+    @MainActor
+    func testPreFirstWriteDriftDiffsAgainstTheFullCaptureBackup() async throws {
+        let captured = "127.0.0.1 localhost\n\n# --- SWITCHHOSTS_CONTENT_START ---\n\n10.0.0.1 api.example.com\n"
+        try FileManager.default.removeItem(at: rootDirectory)
+        _ = try Workspace(rootDirectory: rootDirectory).open(systemHosts: { captured })
+        let systemHosts = SystemHostsDataSource(Data(captured.utf8))
+        let monitor = HostsDriftMonitoringStub()
+        let store = WorkspaceStore(
+            workspace: Workspace(rootDirectory: rootDirectory),
+            coordinator: SwitchCoordinatingStub(),
+            driftMonitor: monitor,
+            readSystemHosts: systemHosts.read,
+            fetchRemote: { _, _ in throw StubError() },
+            now: { Self.refreshClock }
+        )
+        store.loadIfNeeded()
+        XCTAssertEqual(store.baseHostsContent, "127.0.0.1 localhost\n")
+
+        systemHosts.replace(with: Data((captured + "1.2.3.4 external.local\n").utf8))
+        monitor.report(true)
+
+        let comparison = try XCTUnwrap(store.hostsDriftComparison)
+        XCTAssertEqual(comparison.driftAdditions, ["1.2.3.4 external.local"])
+
+        store.reconcileHosts(.addDriftLinesToBaseHosts)
+        await store.reconciliationTask?.value
+        XCTAssertEqual(
+            store.baseHostsContent,
+            "127.0.0.1 localhost\n1.2.3.4 external.local\n"
+        )
+    }
+
+    /// #82: an unreadable pre-write baseline yields no comparison at all — falling back to
+    /// the merged output would show the capture-stripped block as additions again.
+    @MainActor
+    func testAnUnreadableCaptureBackupFailsClosedWithNoComparison() throws {
+        let monitor = HostsDriftMonitoringStub()
+        let store = makeStore(coordinator: SwitchCoordinatingStub(), driftMonitor: monitor)
+        try FileManager.default.removeItem(at: rootDirectory.appendingPathComponent("hosts.orig"))
+
+        monitor.report(true)
+
+        XCTAssertTrue(store.hasHostsDrift)
+        XCTAssertNil(store.hostsDriftComparison)
+    }
+
+    /// #82: once a write is confirmed the expected side is the merged output, exactly as before.
+    @MainActor
+    func testPostWriteDriftStillDiffsAgainstTheMergedOutput() async throws {
+        let systemHosts = SystemHostsDataSource(Data(Self.importedHosts.utf8))
+        let monitor = HostsDriftMonitoringStub()
+        let coordinator = SwitchCoordinatingStub()
+        let store = WorkspaceStore(
+            workspace: Workspace(rootDirectory: rootDirectory),
+            coordinator: coordinator,
+            driftMonitor: monitor,
+            readSystemHosts: systemHosts.read,
+            fetchRemote: { _, _ in throw StubError() },
+            now: { Self.refreshClock }
+        )
+        store.loadIfNeeded()
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.updateProfileContent(profileID, content: "10.0.0.5 dev.local\n")
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+        // The coordinator stub bypasses the real MergeCoordinator, which records the
+        // written hash after the daemon confirms; record it here as production would.
+        try Workspace(rootDirectory: rootDirectory).recordLastWrittenHash("stub")
+
+        systemHosts.replace(with: Data("127.0.0.1 localhost\n9.9.9.9 rogue.local\n".utf8))
+        monitor.report(true)
+
+        let comparison = try XCTUnwrap(store.hostsDriftComparison)
+        // Expected side is the merged output: the active profile's line reads as removed
+        // from the actual file, the rogue line as added.
+        XCTAssertEqual(comparison.driftAdditions, ["9.9.9.9 rogue.local"])
+        XCTAssertTrue(comparison.readableDiff.contains("- 10.0.0.5 dev.local"))
+    }
+
     @MainActor
     func testUsingSystemHostsAsBaseAcceptsCurrentFileWithoutRewritingIt() throws {
         let actualHosts = Data("9.9.9.9 adopted.local\n".utf8)
@@ -2575,6 +2656,9 @@ final class WorkspaceStoreTests: XCTestCase {
         store.setProfileActive(localID, true)
         await store.switchTask?.value
         await store.followUpMergeTask?.value
+        // The coordinator stub bypasses the real MergeCoordinator's hash recording; record it
+        // so the drift review diffs against the merged output, as it does after a real write (#82).
+        try Workspace(rootDirectory: rootDirectory).recordLastWrittenHash("stub")
         let remoteID = try await createRemoteProfile(in: store, url: url)
         driftMonitor.report(true)
         let comparisonBefore = try XCTUnwrap(store.hostsDriftComparison)

--- a/Tests/HostflipXPCTests/MergeCoordinatorTests.swift
+++ b/Tests/HostflipXPCTests/MergeCoordinatorTests.swift
@@ -137,7 +137,9 @@ final class MergeCoordinatorTests: XCTestCase {
 
         let confirmedTargetHashes = await tracker.confirmedTargetHashes
         XCTAssertEqual(confirmedTargetHashes, [merged.hash])
-        XCTAssertNil(try workspace.lastWrittenHash())
+        // The write is a fact: it must survive into the manifest, not just the in-memory
+        // tracker, or a restart (and the drift review, #82) would treat it as never made.
+        XCTAssertEqual(try workspace.lastWrittenHash(), merged.hash)
     }
 
     func testMergeUsesConfirmedBaselineAndReportsConfirmationBeforeManifestRecordFailure() async throws {


### PR DESCRIPTION
## Summary

Two hardening fixes around the capture-time block stripping introduced in #27:

- **Drift review baseline**: before the first confirmed merge write, the drift verdict compares against the first-capture backup (`hosts.orig`), but the review sheet diffed against the merged output — whose Base Hosts had the SwitchHosts block stripped at capture. In that window an external edit showed the whole block as "+ additions", drowning the real change, and "Add to Base Hosts" welded the block back in. The review now diffs against the same baseline as the verdict (the backup until a write is confirmed, the merged output after); an unreadable baseline fails closed as no comparison, and a write that landed but failed its DNS flush now persists its hash like a success, so the never-written state cannot misreport an actual write.
- **Own fence at capture**: a workspace deleted while profiles were active leaves the previous install's `# ══ hostflip:begin ══ … end ══` block in the file; first capture welded it into Base Hosts, nesting a second fence into every later merge and permanently disabling the use-as-base drift action. Capture now removes each fenced span with the same rails as the SwitchHosts marker (whole-line matches, content after a block kept, `hosts.orig` always the full file) and leaves malformed shapes untouched — begin-without-end, an orphan begin that would swallow user lines before a later block, and empty heads.

## Test plan

- `swift test`: 753 tests, 0 failures. New coverage: pre-first-write drift diffs against the backup and adds only the real external line; post-write behaviour byte-identical; unreadable backup → no comparison; flush-failed write records its hash; fence removal (baseline kept, tail kept, begin-without-end, orphan begin, whitespace-only head, two successive blocks, markers inside longer lines, both managers' blocks in one file); capture keeps `hosts.orig` complete and merges produce a single fence.