### PR TITLE
build: bump version to 0.4.0

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.3.0</string>
+	<string>0.4.0</string>
 	<key>CFBundleVersion</key>
-	<string>12</string>
+	<string>13</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Packaging/ReleaseNotes/0.4.0.html
+++ b/Packaging/ReleaseNotes/0.4.0.html
@@ -1,0 +1,6 @@
+<h2>What's New</h2>
+<ul>
+  <li><b>A cleaner first snapshot.</b> On first launch, hostflip now recognises content that belongs to another hosts manager — the block SwitchHosts appends below its marker, or a leftover block from a previous hostflip install — and keeps it out of your read-only Base Hosts. No need to turn SwitchHosts rules off before trying hostflip; the original file is still preserved in full as <code>hosts.orig</code>.</li>
+  <li><b>SwitchHosts v5 data-loss rescue.</b> Some v4 → v5 SwitchHosts upgrades lose the rule list. The import now looks into the archives v5 leaves behind and reads the newest one whose data survived — no folder picking needed. A step-by-step migration guide now ships in the repository: what carries over, what works differently, and the order that keeps your hosts file clean.</li>
+  <li><b>A truer drift review.</b> Before hostflip's first write, the drift review now compares against the exact snapshot taken at first launch, so an external edit shows only what actually changed.</li>
+</ul>

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -16,5 +16,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.3.0"
+    public static let version = "0.4.0"
 }


### PR DESCRIPTION
## Summary

- Add the 0.4.0 release notes: capture-time recognition of other managers' blocks (SwitchHosts marker, previous install's fence), the SwitchHosts v5 data-loss archive rescue with the shipped migration guide, and the pre-first-write drift review baseline fix.
- Bump CFBundleShortVersionString to 0.4.0 (build 13) and the XPC channel version string.

Merge right before running the release pipeline.