### PR TITLE
fix: dismiss the approval banner once the helper is approved

### DIFF
--- a/Sources/Hostflip/MainWindowPresentation.swift
+++ b/Sources/Hostflip/MainWindowPresentation.swift
@@ -31,9 +31,15 @@ struct MainWindowPresentation: Equatable {
         profileCount: Int,
         isSwitching: Bool
     ) {
+        // A needsApproval verdict is only as current as the helper status: once the
+        // helper leaves requiresApproval (approved in System Settings, or re-registered)
+        // the feedback is stale and must not outrank the steady-state banner. An unknown
+        // status keeps it — the switch just reported the helper needs approval.
+        let approvalFeedbackIsStale = switchFeedback == .needsApproval
+            && helperStatus != nil && helperStatus != .requiresApproval
         if hasHostsDrift || switchFeedback == .hostsDrift {
             self.banner = .hostsDrift
-        } else if let switchFeedback, switchFeedback != .merged {
+        } else if let switchFeedback, switchFeedback != .merged, !approvalFeedbackIsStale {
             self.banner = .switchFeedback(switchFeedback)
         } else if let backgroundSyncError {
             self.banner = .backgroundSyncError(backgroundSyncError)

--- a/Tests/HostflipTests/MainWindowPresentationTests.swift
+++ b/Tests/HostflipTests/MainWindowPresentationTests.swift
@@ -69,6 +69,50 @@ final class MainWindowPresentationTests: XCTestCase {
         XCTAssertFalse(presentation.activationControlsDisabled)
     }
 
+    func testApprovalFeedbackIsRetiredOnceTheHelperIsApproved() {
+        let presentation = MainWindowPresentation(
+            isPaused: false,
+            hasHostsDrift: false,
+            helperStatus: .enabled,
+            switchFeedback: .needsApproval,
+            backgroundSyncError: nil,
+            profileCount: 2,
+            isSwitching: false
+        )
+
+        XCTAssertNil(presentation.banner)
+    }
+
+    func testApprovalFeedbackStaysWhileApprovalIsPendingOrStatusIsUnknown() {
+        for helperStatus in [DaemonRegistrationStatus.requiresApproval, nil] {
+            let presentation = MainWindowPresentation(
+                isPaused: false,
+                hasHostsDrift: false,
+                helperStatus: helperStatus,
+                switchFeedback: .needsApproval,
+                backgroundSyncError: nil,
+                profileCount: 2,
+                isSwitching: false
+            )
+
+            XCTAssertEqual(presentation.banner, .switchFeedback(.needsApproval), "helperStatus: \(String(describing: helperStatus))")
+        }
+    }
+
+    func testStaleApprovalFeedbackDoesNotHideOtherSwitchFeedback() {
+        let presentation = MainWindowPresentation(
+            isPaused: false,
+            hasHostsDrift: false,
+            helperStatus: .enabled,
+            switchFeedback: .unavailable,
+            backgroundSyncError: nil,
+            profileCount: 2,
+            isSwitching: false
+        )
+
+        XCTAssertEqual(presentation.banner, .switchFeedback(.unavailable))
+    }
+
     func testEmptyWorkspaceShowsCreationStateWithoutAWarningBanner() {
         let presentation = MainWindowPresentation(
             isPaused: false,


### PR DESCRIPTION
## Summary
- After clicking "Open System Settings…" and approving the helper, the "Switch blocked: … needs system approval" banner stayed until dismissed by hand, even though the toolbar pill already showed "Helper ready".
- `MainWindowPresentation` now treats `.needsApproval` switch feedback as stale once the helper status is known and no longer `requiresApproval`, so the banner falls through to the steady-state result whether the status settled via activation refresh or the approval poll.

## Test plan
- [x] New `MainWindowPresentationTests` cover approved / pending / unknown helper status and other feedback kinds
- [x] Manually verified on a fresh install: approve in System Settings → return to the app → banner disappears