### PR TITLE
docs: invite Intel build requests instead of silently excluding them

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Most hosts managers treat `/etc/hosts` as their own: every save rewrites the who
 
 ## Install
 
-Requires macOS 14 or later on Apple silicon.
+Requires macOS 14 or later on Apple silicon. Intel builds are not planned unless there is demand — if you need one, [open an issue](https://github.com/heronapp/hostflip/issues/new?title=Intel%20support).
 
 **Homebrew**
 


### PR DESCRIPTION
Turns the bare "Apple silicon only" note into a demand signal: readers who need an Intel build get a one-click issue link instead of leaving silently. No product change.