### PR TITLE
refactor: retire helper-blocked switch feedback in the workspace store

### DIFF
--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -45,6 +45,9 @@ struct HostflipApp: App {
             remoteRefreshScheduler?.resync()
         }
         remoteRefreshScheduler.resync()
+        maintenanceStore.helperStatusChanged = { [weak store] status in
+            store?.helperStatusDidChange(status)
+        }
         self.store = store
         self.remoteRefreshScheduler = remoteRefreshScheduler
         self.maintenanceStore = maintenanceStore

--- a/Sources/Hostflip/MainWindowPresentation.swift
+++ b/Sources/Hostflip/MainWindowPresentation.swift
@@ -31,15 +31,9 @@ struct MainWindowPresentation: Equatable {
         profileCount: Int,
         isSwitching: Bool
     ) {
-        // A needsApproval verdict is only as current as the helper status: once the
-        // helper leaves requiresApproval (approved in System Settings, or re-registered)
-        // the feedback is stale and must not outrank the steady-state banner. An unknown
-        // status keeps it — the switch just reported the helper needs approval.
-        let approvalFeedbackIsStale = switchFeedback == .needsApproval
-            && helperStatus != nil && helperStatus != .requiresApproval
         if hasHostsDrift || switchFeedback == .hostsDrift {
             self.banner = .hostsDrift
-        } else if let switchFeedback, switchFeedback != .merged, !approvalFeedbackIsStale {
+        } else if let switchFeedback, switchFeedback != .merged {
             self.banner = .switchFeedback(switchFeedback)
         } else if let backgroundSyncError {
             self.banner = .backgroundSyncError(backgroundSyncError)

--- a/Sources/Hostflip/MaintenanceStore.swift
+++ b/Sources/Hostflip/MaintenanceStore.swift
@@ -34,7 +34,12 @@ enum MaintenanceFeedback: Equatable {
 @MainActor
 @Observable
 final class MaintenanceStore {
-    private(set) var helperStatus: DaemonRegistrationStatus?
+    private(set) var helperStatus: DaemonRegistrationStatus? {
+        didSet { if let helperStatus { helperStatusChanged?(helperStatus) } }
+    }
+    /// Forwards every status read to the workspace store, which retires switch feedback the
+    /// status has overtaken; wired at launch, nil in tests that exercise this store alone.
+    @ObservationIgnored var helperStatusChanged: ((DaemonRegistrationStatus) -> Void)?
     private(set) var feedback: MaintenanceFeedback?
     private(set) var isRemovingHelper = false
 

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -1269,6 +1269,30 @@ final class WorkspaceStore {
         switchFeedback = nil
     }
 
+    /// Retires feedback that only described the helper not being ready, and that neither the
+    /// switch nor the reconciliation path has any other way to notice is over. Every read is
+    /// forwarded, repeats included: a switch made from the menu bar with the window closed can
+    /// observe a revocation that no status read ever did, so a later `.enabled` is fresh news
+    /// even when it matches the previous read. Every other feedback kind stays.
+    func helperStatusDidChange(_ status: DaemonRegistrationStatus) {
+        let retire: Bool = switch switchFeedback {
+        // "Needs approval" holds only while the system still says so; enabled, not registered,
+        // and not found (helper removed) all make the approval guidance meaningless.
+        case .needsApproval: status != .requiresApproval
+        // "Unavailable" (app outside Applications) is over only once the helper registered.
+        case .unavailable: status == .enabled
+        default: false
+        }
+        guard retire, let feedback = switchFeedback else { return }
+        // The reconciliation path records the verdict a second time, as its error copy, using the
+        // feedback's own message; matching on it retires exactly that record and leaves an
+        // unrelated reconciliation error (a DNS flush failure kept after the drift resolved) alone.
+        if reconciliationError == feedback.message {
+            reconciliationError = nil
+        }
+        switchFeedback = nil
+    }
+
     func clearBackgroundSyncError() {
         backgroundSyncError = nil
     }

--- a/Tests/HostflipTests/MainWindowPresentationTests.swift
+++ b/Tests/HostflipTests/MainWindowPresentationTests.swift
@@ -69,50 +69,6 @@ final class MainWindowPresentationTests: XCTestCase {
         XCTAssertFalse(presentation.activationControlsDisabled)
     }
 
-    func testApprovalFeedbackIsRetiredOnceTheHelperIsApproved() {
-        let presentation = MainWindowPresentation(
-            isPaused: false,
-            hasHostsDrift: false,
-            helperStatus: .enabled,
-            switchFeedback: .needsApproval,
-            backgroundSyncError: nil,
-            profileCount: 2,
-            isSwitching: false
-        )
-
-        XCTAssertNil(presentation.banner)
-    }
-
-    func testApprovalFeedbackStaysWhileApprovalIsPendingOrStatusIsUnknown() {
-        for helperStatus in [DaemonRegistrationStatus.requiresApproval, nil] {
-            let presentation = MainWindowPresentation(
-                isPaused: false,
-                hasHostsDrift: false,
-                helperStatus: helperStatus,
-                switchFeedback: .needsApproval,
-                backgroundSyncError: nil,
-                profileCount: 2,
-                isSwitching: false
-            )
-
-            XCTAssertEqual(presentation.banner, .switchFeedback(.needsApproval), "helperStatus: \(String(describing: helperStatus))")
-        }
-    }
-
-    func testStaleApprovalFeedbackDoesNotHideOtherSwitchFeedback() {
-        let presentation = MainWindowPresentation(
-            isPaused: false,
-            hasHostsDrift: false,
-            helperStatus: .enabled,
-            switchFeedback: .unavailable,
-            backgroundSyncError: nil,
-            profileCount: 2,
-            isSwitching: false
-        )
-
-        XCTAssertEqual(presentation.banner, .switchFeedback(.unavailable))
-    }
-
     func testEmptyWorkspaceShowsCreationStateWithoutAWarningBanner() {
         let presentation = MainWindowPresentation(
             isPaused: false,

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -1335,6 +1335,166 @@ final class WorkspaceStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testHelperBecomingEnabledRetiresApprovalFeedback() async throws {
+        let stub = SwitchCoordinatingStub()
+        stub.switchOutcome = .success(.blocked(.needsApproval))
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+        XCTAssertEqual(store.switchFeedback, .needsApproval)
+
+        store.helperStatusDidChange(.requiresApproval)
+        XCTAssertEqual(store.switchFeedback, .needsApproval)
+
+        store.helperStatusDidChange(.enabled)
+        XCTAssertNil(store.switchFeedback)
+    }
+
+    @MainActor
+    func testHelperBecomingEnabledRetiresUnavailableFeedback() async throws {
+        let stub = SwitchCoordinatingStub()
+        stub.switchOutcome = .success(.blocked(.unavailable))
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+        XCTAssertEqual(store.switchFeedback, .unavailable)
+
+        store.helperStatusDidChange(.enabled)
+        XCTAssertNil(store.switchFeedback)
+    }
+
+    @MainActor
+    func testHelperStatusNeverRetiresOtherFeedback() async throws {
+        let stub = SwitchCoordinatingStub()
+        stub.switchOutcome = .failure(StubError())
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+        guard case .failed = store.switchFeedback else {
+            return XCTFail("expected failure feedback, got: \(String(describing: store.switchFeedback))")
+        }
+
+        for status in [DaemonRegistrationStatus.enabled, .notRegistered, .notFound, .requiresApproval] {
+            store.helperStatusDidChange(status)
+        }
+        guard case .failed = store.switchFeedback else {
+            return XCTFail("failure feedback must survive helper status changes")
+        }
+    }
+
+    @MainActor
+    func testApprovalFeedbackHoldsOnlyWhileApprovalIsStillRequired() async throws {
+        for status in [DaemonRegistrationStatus.enabled, .notRegistered, .notFound] {
+            let stub = SwitchCoordinatingStub()
+            stub.switchOutcome = .success(.blocked(.needsApproval))
+            let store = makeStore(coordinator: stub)
+            let profileID = try XCTUnwrap(store.createStandaloneProfile())
+            store.setProfileActive(profileID, true)
+            await store.switchTask?.value
+
+            store.helperStatusDidChange(.requiresApproval)
+            XCTAssertEqual(store.switchFeedback, .needsApproval)
+            // Helper removed after the verdict: guiding the user to approve it would be nonsense.
+            store.helperStatusDidChange(status)
+            XCTAssertNil(store.switchFeedback, "status: \(status)")
+        }
+    }
+
+    @MainActor
+    func testUnavailableFeedbackHoldsUntilTheHelperIsEnabled() async throws {
+        let stub = SwitchCoordinatingStub()
+        stub.switchOutcome = .success(.blocked(.unavailable))
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+
+        for status in [DaemonRegistrationStatus.notFound, .notRegistered, .requiresApproval] {
+            store.helperStatusDidChange(status)
+            XCTAssertEqual(store.switchFeedback, .unavailable, "status: \(status)")
+        }
+    }
+
+    @MainActor
+    func testRepeatedEnabledStatusRetiresApprovalFeedbackFromAnUnobservedRevocation() async throws {
+        let stub = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: stub)
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.helperStatusDidChange(.enabled)
+
+        // Approval revoked and the switch made from the menu bar with the window closed: no
+        // status read ever sees requiresApproval.
+        stub.switchOutcome = .success(.blocked(.needsApproval))
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+        XCTAssertEqual(store.switchFeedback, .needsApproval)
+
+        // Re-approved, window opened: the first read is .enabled again and must still retire.
+        store.helperStatusDidChange(.enabled)
+        XCTAssertNil(store.switchFeedback)
+    }
+
+    @MainActor
+    func testHelperBecomingEnabledRetiresMatchingReconciliationError() async throws {
+        let coordinator = SwitchCoordinatingStub()
+        coordinator.switchOutcome = .success(.blocked(.needsApproval))
+        let monitor = HostsDriftMonitoringStub()
+        let store = makeStore(coordinator: coordinator, driftMonitor: monitor)
+        monitor.report(true)
+
+        store.reconcileHosts(.addDriftLinesToBaseHosts)
+        await store.reconciliationTask?.value
+        XCTAssertEqual(store.switchFeedback, .needsApproval)
+        XCTAssertEqual(store.reconciliationError, SwitchFeedback.needsApproval.message)
+
+        store.helperStatusDidChange(.enabled)
+        XCTAssertNil(store.switchFeedback)
+        XCTAssertNil(store.reconciliationError)
+        XCTAssertTrue(store.hasHostsDrift, "retiring the helper verdict must not pretend the drift was reconciled")
+    }
+
+    @MainActor
+    func testHelperBecomingEnabledKeepsAnUnrelatedReconciliationError() async throws {
+        let actualHosts = "127.0.0.1 localhost\n"
+            + "1.2.3.4 external.local\n"
+        let failure = HostsWriteError(
+            stage: .flushDNS,
+            message: "refresh failed",
+            writtenHash: MergedHosts(content: actualHosts).hash
+        )
+        let coordinator = SwitchCoordinatingStub()
+        coordinator.switchOutcome = .success(.channelFailed(
+            .mergeWriteFailed(failure),
+            statusAfterError: .enabled
+        ))
+        let monitor = HostsDriftMonitoringStub()
+        let store = makeStore(
+            coordinator: coordinator,
+            driftMonitor: monitor,
+            systemHosts: Data(actualHosts.utf8)
+        )
+        monitor.report(true)
+        store.reconcileHosts(.addDriftLinesToBaseHosts)
+        await store.reconciliationTask?.value
+        let flushError = try XCTUnwrap(store.reconciliationError)
+        XCTAssertFalse(store.hasHostsDrift)
+
+        // A later switch is blocked on approval; retiring that verdict must not erase the flush error.
+        coordinator.switchOutcome = .success(.blocked(.needsApproval))
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        store.setProfileActive(profileID, true)
+        await store.switchTask?.value
+        XCTAssertEqual(store.switchFeedback, .needsApproval)
+
+        store.helperStatusDidChange(.enabled)
+        XCTAssertNil(store.switchFeedback)
+        XCTAssertEqual(store.reconciliationError, flushError)
+    }
+
+    @MainActor
     func testDeleteActiveProfileGoesThroughSwitchAndPersists() async throws {
         let stub = SwitchCoordinatingStub()
         let store = makeStore(coordinator: stub)


### PR DESCRIPTION
## Summary
- "Needs approval" and "helper unavailable" switch feedback had no proper retirement path: the approval banner was filtered in the presentation layer only, the unavailable banner stayed until dismissed or the next switch.
- The composition root now forwards every helper status read to `WorkspaceStore`, which retires the approval verdict on any status other than `requiresApproval` (approved, or helper removed) and the unavailable verdict once the helper is enabled. The presentation-layer filter is removed.
- No user-visible copy changes.

## Test plan
- [x] 8 new `WorkspaceStoreTests` cover retirement rules, non-retirement of other feedback, an unobserved revocation round trip, and an unrelated reconciliation error surviving
- [x] Presentation tests reduced to priority-only checks; full suite green (761)
- [ ] Manual: approve the helper with the main window closed, reopen — banner gone
- [ ] Manual: launch outside Applications → unavailable banner → move to Applications, reopen — banner gone once registered