### PR TITLE
feat: duplicate a profile from the sidebar

### DIFF
--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -54,11 +54,8 @@
 "New" = "新規";
 "New Profile" = "新規プロファイル";
 "New Group" = "新規グループ";
-"PROFILE_DEFAULT_NAME" = "新規プロファイル";
-"PROFILE_DEFAULT_NAME_NUMBERED" = "新規プロファイル %lld";
 "GROUP_DEFAULT_NAME" = "新規グループ";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新規グループ %lld";
-"PROFILE_COPY_NAME" = "%@ のコピー";
 "Group Name" = "グループ名";
 "Rename Group…" = "グループの名前を変更…";
 "Move Up" = "上に移動";

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -58,12 +58,14 @@
 "PROFILE_DEFAULT_NAME_NUMBERED" = "新規プロファイル %lld";
 "GROUP_DEFAULT_NAME" = "新規グループ";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新規グループ %lld";
+"PROFILE_COPY_NAME" = "%@ のコピー";
 "Group Name" = "グループ名";
 "Rename Group…" = "グループの名前を変更…";
 "Move Up" = "上に移動";
 "Move Down" = "下に移動";
 "Delete Group…" = "グループを削除…";
 "Rename Profile…" = "プロファイルの名前を変更…";
+"Duplicate Profile" = "プロファイルを複製";
 "Move To" = "移動先";
 "Delete Profile…" = "プロファイルを削除…";
 "Profile Actions" = "プロファイルの操作";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -54,11 +54,8 @@
 "New" = "新建";
 "New Profile" = "新建方案";
 "New Group" = "新建分组";
-"PROFILE_DEFAULT_NAME" = "新方案";
-"PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
 "GROUP_DEFAULT_NAME" = "新分组";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新分组 %lld";
-"PROFILE_COPY_NAME" = "%@ 副本";
 "Group Name" = "分组名称";
 "Rename Group…" = "重命名分组…";
 "Move Up" = "上移";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -58,12 +58,14 @@
 "PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
 "GROUP_DEFAULT_NAME" = "新分组";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新分组 %lld";
+"PROFILE_COPY_NAME" = "%@ 副本";
 "Group Name" = "分组名称";
 "Rename Group…" = "重命名分组…";
 "Move Up" = "上移";
 "Move Down" = "下移";
 "Delete Group…" = "删除分组…";
 "Rename Profile…" = "重命名方案…";
+"Duplicate Profile" = "复制方案";
 "Move To" = "移动到";
 "Delete Profile…" = "删除方案…";
 "Profile Actions" = "方案操作";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -58,7 +58,7 @@
 "PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
 "GROUP_DEFAULT_NAME" = "新群組";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新群組 %lld";
-"PROFILE_COPY_NAME" = "%@ 拷貝";
+"PROFILE_COPY_NAME" = "%@ 副本";
 "Group Name" = "群組名稱";
 "Rename Group…" = "重新命名群組…";
 "Move Up" = "上移";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -58,12 +58,14 @@
 "PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
 "GROUP_DEFAULT_NAME" = "新群組";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新群組 %lld";
+"PROFILE_COPY_NAME" = "%@ 拷貝";
 "Group Name" = "群組名稱";
 "Rename Group…" = "重新命名群組…";
 "Move Up" = "上移";
 "Move Down" = "下移";
 "Delete Group…" = "刪除群組…";
 "Rename Profile…" = "重新命名方案…";
+"Duplicate Profile" = "複製方案";
 "Move To" = "移至";
 "Delete Profile…" = "刪除方案…";
 "Profile Actions" = "方案操作";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -54,11 +54,8 @@
 "New" = "新增";
 "New Profile" = "新增方案";
 "New Group" = "新增群組";
-"PROFILE_DEFAULT_NAME" = "新方案";
-"PROFILE_DEFAULT_NAME_NUMBERED" = "新方案 %lld";
 "GROUP_DEFAULT_NAME" = "新群組";
 "GROUP_DEFAULT_NAME_NUMBERED" = "新群組 %lld";
-"PROFILE_COPY_NAME" = "%@ 副本";
 "Group Name" = "群組名稱";
 "Rename Group…" = "重新命名群組…";
 "Move Up" = "上移";

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -831,6 +831,11 @@ struct MainWindowView: View {
             selection = .profile(profile.id)
             profilePendingNameFocus = profile.id
         }
+        Button("Duplicate Profile") {
+            guard let copyID = store.duplicateProfile(profile.id) else { return }
+            selection = .profile(copyID)
+            profilePendingNameFocus = copyID
+        }
         Button("Move Up") {
             store.moveProfile(profile.id, toGroup: groupID, at: index - 1)
         }

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -372,13 +372,20 @@ final class WorkspaceStore {
     /// unique, matching the rename semantics.
     @discardableResult
     func duplicateProfile(_ profileID: Profile.ID) -> Profile.ID? {
-        guard let profile = profile(profileID) else { return nil }
+        guard profile(profileID) != nil else { return nil }
         let copyID = Profile.ID(UUID().uuidString)
-        // Semantic key: the suffix is a name fragment, not a command, and each language
-        // places it differently (see PROFILE_DEFAULT_NAME).
-        let name = String(localized: "PROFILE_COPY_NAME", defaultValue: "\(profile.name) Copy")
-        applyEdit { try $0.duplicateProfile(profileID, as: copyID, name: name) }
-        return copyID
+        applyEdit { model in
+            // The name derives from the replayed model, so a concurrent foreign rename is
+            // reflected; a foreign deletion drops the edit like any other.
+            guard let latest = model.profile(profileID) else {
+                throw ActivationModelError.unknownProfile(profileID)
+            }
+            // Semantic key: the suffix is a name fragment, not a command, and each language
+            // places it differently (see PROFILE_DEFAULT_NAME).
+            let name = String(localized: "PROFILE_COPY_NAME", defaultValue: "\(latest.name) Copy")
+            try model.duplicateProfile(profileID, as: copyID, name: name)
+        }
+        return profile(copyID) == nil ? nil : copyID
     }
 
     func renameProfile(_ profileID: Profile.ID, to name: String) {

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -366,6 +366,21 @@ final class WorkspaceStore {
         return profileID
     }
 
+    /// Duplicates a profile in place (#89): the copy lands right after the original in the
+    /// same container, inactive, so it is a purely local edit — no helper interaction. Returns
+    /// the copy's ID so the caller can select it for renaming. The suffixed name is not made
+    /// unique, matching the rename semantics.
+    @discardableResult
+    func duplicateProfile(_ profileID: Profile.ID) -> Profile.ID? {
+        guard let profile = profile(profileID) else { return nil }
+        let copyID = Profile.ID(UUID().uuidString)
+        // Semantic key: the suffix is a name fragment, not a command, and each language
+        // places it differently (see PROFILE_DEFAULT_NAME).
+        let name = String(localized: "PROFILE_COPY_NAME", defaultValue: "\(profile.name) Copy")
+        applyEdit { try $0.duplicateProfile(profileID, as: copyID, name: name) }
+        return copyID
+    }
+
     func renameProfile(_ profileID: Profile.ID, to name: String) {
         guard let profile = profile(profileID),
               let normalized = normalizedRenameName(name, currentName: profile.name) else { return }

--- a/Sources/Hostflip/WorkspaceStore.swift
+++ b/Sources/Hostflip/WorkspaceStore.swift
@@ -380,9 +380,8 @@ final class WorkspaceStore {
             guard let latest = model.profile(profileID) else {
                 throw ActivationModelError.unknownProfile(profileID)
             }
-            // Semantic key: the suffix is a name fragment, not a command, and each language
-            // places it differently (see PROFILE_DEFAULT_NAME).
-            let name = String(localized: "PROFILE_COPY_NAME", defaultValue: "\(latest.name) Copy")
+            // Not localized: like the default name, this becomes a file name on disk.
+            let name = "\(latest.name) Copy"
             try model.duplicateProfile(profileID, as: copyID, name: name)
         }
         return profile(copyID) == nil ? nil : copyID
@@ -454,14 +453,12 @@ final class WorkspaceStore {
     private func defaultProfileName() -> String {
         let existing = Set((model?.standaloneProfiles ?? []).map(\.name)
             + (model?.groups ?? []).flatMap { $0.profiles.map(\.name) })
-        // Semantic keys: the literal "New Profile" is already the menu command's
-        // key, and a command phrasing makes a poor default name in translation.
-        var candidate = String(localized: "PROFILE_DEFAULT_NAME", defaultValue: "New Profile")
+        // Not localized: the profile name doubles as its file name in the workspace, so
+        // generated names stay ASCII across languages (group names are display-only).
+        var candidate = "New Profile"
         var counter = 2
         while existing.contains(candidate) {
-            candidate = String(
-                localized: "PROFILE_DEFAULT_NAME_NUMBERED", defaultValue: "New Profile \(counter)"
-            )
+            candidate = "New Profile \(counter)"
             counter += 1
         }
         return candidate

--- a/Sources/HostflipCore/ActivationModel.swift
+++ b/Sources/HostflipCore/ActivationModel.swift
@@ -136,6 +136,28 @@ public struct ActivationModel: Sendable {
         standaloneProfiles.append(Profile(id: id, name: name, content: content))
     }
 
+    /// Inserts a copy of the profile right after it in the same container. The copy takes the
+    /// original's content as is — a Remote Header stays, so a Remote Profile's copy is remote
+    /// too — but starts inactive and with no refresh history of its own.
+    public mutating func duplicateProfile(_ profileID: Profile.ID, as newID: Profile.ID, name: String) throws {
+        guard !allProfiles.contains(where: { $0.id == newID }) else {
+            throw ActivationModelError.duplicateProfileID(newID)
+        }
+        if let index = standaloneProfiles.firstIndex(where: { $0.id == profileID }) {
+            let copy = Profile(id: newID, name: name, content: standaloneProfiles[index].content)
+            standaloneProfiles.insert(copy, at: index + 1)
+            return
+        }
+        for groupIndex in groups.indices {
+            if let index = groups[groupIndex].profiles.firstIndex(where: { $0.id == profileID }) {
+                let copy = Profile(id: newID, name: name, content: groups[groupIndex].profiles[index].content)
+                groups[groupIndex].profiles.insert(copy, at: index + 1)
+                return
+            }
+        }
+        throw ActivationModelError.unknownProfile(profileID)
+    }
+
     public mutating func renameProfile(_ profileID: Profile.ID, to name: String) throws {
         try mutateProfile(profileID) { $0.name = name }
     }

--- a/Tests/HostflipCoreTests/ActivationModelTests.swift
+++ b/Tests/HostflipCoreTests/ActivationModelTests.swift
@@ -201,6 +201,67 @@ final class ActivationModelTests: XCTestCase {
         XCTAssertEqual(model.standaloneProfiles, [existing])
     }
 
+    func testDuplicatingAStandaloneProfileInsertsAnInactiveCopyRightAfterIt() throws {
+        let first = makeProfile("first")
+        let second = makeProfile("second")
+        var model = try makeModel(standaloneProfiles: [first, second])
+        try model.toggleProfile(first.id)
+
+        try model.duplicateProfile(first.id, as: .init("copy"), name: "First Copy")
+
+        XCTAssertEqual(
+            model.standaloneProfiles,
+            [first, Profile(id: .init("copy"), name: "First Copy", content: first.content), second]
+        )
+        XCTAssertEqual(model.activeProfileIDs, [first.id])
+    }
+
+    func testDuplicatingAGroupedProfileKeepsTheGroupsActiveProfile() throws {
+        let first = makeProfile("first")
+        let second = makeProfile("second")
+        var model = try makeModel(groups: [makeGroup("group", profiles: [first, second])])
+        try model.toggleProfile(first.id)
+
+        try model.duplicateProfile(first.id, as: .init("copy"), name: "First Copy")
+
+        XCTAssertEqual(model.standaloneProfiles, [])
+        XCTAssertEqual(
+            model.groups.first?.profiles,
+            [first, Profile(id: .init("copy"), name: "First Copy", content: first.content), second]
+        )
+        XCTAssertEqual(model.activeProfileIDs, [first.id])
+    }
+
+    func testDuplicatingARemoteProfileCopiesTheHeaderButNotTheRefreshState() throws {
+        var remote = makeRemoteProfile("remote")
+        remote.remoteRefreshState = RemoteRefreshState(lastSuccessAt: Date(timeIntervalSince1970: 100))
+        var model = try makeModel(standaloneProfiles: [remote])
+
+        try model.duplicateProfile(remote.id, as: .init("copy"), name: "Remote Copy")
+
+        let copy = try XCTUnwrap(model.profile(.init("copy")))
+        XCTAssertEqual(copy.content, remote.content)
+        XCTAssertEqual(copy.remoteHeader, remote.remoteHeader)
+        XCTAssertNil(copy.remoteRefreshState)
+    }
+
+    func testDuplicatingRejectsUnknownSourcesAndDuplicateIDsWithoutChangingState() throws {
+        let existing = makeProfile("existing")
+        var model = try makeModel(standaloneProfiles: [existing])
+
+        XCTAssertThrowsError(
+            try model.duplicateProfile(.init("missing"), as: .init("copy"), name: "Copy")
+        ) { error in
+            XCTAssertEqual(error as? ActivationModelError, .unknownProfile(.init("missing")))
+        }
+        XCTAssertThrowsError(
+            try model.duplicateProfile(existing.id, as: existing.id, name: "Copy")
+        ) { error in
+            XCTAssertEqual(error as? ActivationModelError, .duplicateProfileID(existing.id))
+        }
+        XCTAssertEqual(model.standaloneProfiles, [existing])
+    }
+
     func testAProfileCanBeRenamedAndItsContentEdited() throws {
         let staging = makeProfile("staging")
         var model = try makeModel(groups: [makeGroup("environment", profiles: [staging])])

--- a/Tests/HostflipTests/LocalizationCatalogTests.swift
+++ b/Tests/HostflipTests/LocalizationCatalogTests.swift
@@ -70,6 +70,11 @@ final class LocalizationCatalogTests: XCTestCase {
                     value.contains("%lld"), expectsCounter,
                     "\(language): \(key) placeholder mismatch"
                 )
+                // The copy suffix wraps the original name; dropping %@ would swallow it.
+                XCTAssertEqual(
+                    value.contains("%@"), key == "PROFILE_COPY_NAME",
+                    "\(language): \(key) name placeholder mismatch"
+                )
             }
         }
     }

--- a/Tests/HostflipTests/LocalizationCatalogTests.swift
+++ b/Tests/HostflipTests/LocalizationCatalogTests.swift
@@ -10,6 +10,7 @@ final class LocalizationCatalogTests: XCTestCase {
     private static let semanticKeys: Set<String> = [
         "PROFILE_DEFAULT_NAME", "PROFILE_DEFAULT_NAME_NUMBERED",
         "GROUP_DEFAULT_NAME", "GROUP_DEFAULT_NAME_NUMBERED",
+        "PROFILE_COPY_NAME",
     ]
 
     private static var repoRoot: URL {

--- a/Tests/HostflipTests/LocalizationCatalogTests.swift
+++ b/Tests/HostflipTests/LocalizationCatalogTests.swift
@@ -7,10 +7,9 @@ import XCTest
 /// row in each catalog. SwiftUI literal keys are covered by release visual QA.
 final class LocalizationCatalogTests: XCTestCase {
     private static let languages = ["zh-Hans", "zh-Hant", "ja"]
+    /// Group default names only: profile names double as file names and are not localized.
     private static let semanticKeys: Set<String> = [
-        "PROFILE_DEFAULT_NAME", "PROFILE_DEFAULT_NAME_NUMBERED",
         "GROUP_DEFAULT_NAME", "GROUP_DEFAULT_NAME_NUMBERED",
-        "PROFILE_COPY_NAME",
     ]
 
     private static var repoRoot: URL {
@@ -69,11 +68,6 @@ final class LocalizationCatalogTests: XCTestCase {
                 XCTAssertEqual(
                     value.contains("%lld"), expectsCounter,
                     "\(language): \(key) placeholder mismatch"
-                )
-                // The copy suffix wraps the original name; dropping %@ would swallow it.
-                XCTAssertEqual(
-                    value.contains("%@"), key == "PROFILE_COPY_NAME",
-                    "\(language): \(key) name placeholder mismatch"
                 )
             }
         }

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -323,6 +323,29 @@ final class WorkspaceStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testDuplicateOfAForeignlyDeletedProfileIsDroppedAndReturnsNil() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        foreignlyModifyWorkspace { try $0.deleteProfile(profileID) }
+
+        XCTAssertNil(store.duplicateProfile(profileID))
+
+        XCTAssertEqual(store.standaloneProfiles, [])
+        XCTAssertNil(store.saveError)
+    }
+
+    @MainActor
+    func testDuplicateNamesTheCopyAfterAForeignRename() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+        foreignlyModifyWorkspace { try $0.renameProfile(profileID, to: "renamed") }
+
+        let copyID = try XCTUnwrap(store.duplicateProfile(profileID))
+
+        XCTAssertEqual(store.profile(copyID)?.name, "renamed Copy")
+    }
+
+    @MainActor
     func testDuplicateUnknownProfileIsIgnored() throws {
         let store = makeStore(coordinator: SwitchCoordinatingStub())
         let profileID = try XCTUnwrap(store.createStandaloneProfile())

--- a/Tests/HostflipTests/WorkspaceStoreTests.swift
+++ b/Tests/HostflipTests/WorkspaceStoreTests.swift
@@ -239,6 +239,100 @@ final class WorkspaceStoreTests: XCTestCase {
     }
 
     @MainActor
+    func testDuplicateProfilePlacesAnInactiveCopyRightAfterTheOriginalAndPersists() async throws {
+        let coordinator = SwitchCoordinatingStub()
+        let store = makeStore(coordinator: coordinator)
+        let originalID = try XCTUnwrap(store.createStandaloneProfile())
+        let trailingID = try XCTUnwrap(store.createStandaloneProfile())
+        store.renameProfile(originalID, to: "staging")
+        store.updateProfileContent(originalID, content: "1.2.3.4 staging.example.com\n")
+        store.setProfileActive(originalID, true)
+        await store.switchTask?.value
+        let switchesBefore = coordinator.performedSwitches.count
+
+        let copyID = try XCTUnwrap(store.duplicateProfile(originalID))
+
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [originalID, copyID, trailingID])
+        let copy = try XCTUnwrap(store.profile(copyID))
+        XCTAssertEqual(copy.name, "staging Copy")
+        XCTAssertEqual(copy.content, "1.2.3.4 staging.example.com\n")
+        XCTAssertFalse(store.isActive(copyID))
+        XCTAssertTrue(store.isActive(originalID))
+        // The copy is inactive, so no switch is performed.
+        XCTAssertEqual(coordinator.performedSwitches.count, switchesBefore)
+
+        let reloaded = try reloadModel()
+        XCTAssertEqual(reloaded.standaloneProfiles.map(\.id), [originalID, copyID, trailingID])
+        XCTAssertEqual(reloaded.profile(copyID), copy)
+        XCTAssertEqual(reloaded.activeProfileIDs, [originalID])
+    }
+
+    @MainActor
+    func testDuplicateProfileInGroupStaysInTheGroupAfterTheOriginal() async throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let groupID = try XCTUnwrap(store.createGroup())
+        let originalID = try XCTUnwrap(store.createProfile(in: groupID))
+        let trailingID = try XCTUnwrap(store.createProfile(in: groupID))
+        store.setProfileActive(originalID, true)
+        await store.switchTask?.value
+
+        let copyID = try XCTUnwrap(store.duplicateProfile(originalID))
+
+        XCTAssertEqual(store.standaloneProfiles, [])
+        XCTAssertEqual(store.groups.first?.profiles.map(\.id), [originalID, copyID, trailingID])
+        XCTAssertTrue(store.isActive(originalID))
+        XCTAssertFalse(store.isActive(copyID))
+        XCTAssertEqual(try reloadModel().groups.first?.profiles.map(\.id), [originalID, copyID, trailingID])
+    }
+
+    @MainActor
+    func testDuplicatingTwiceStacksTheNewestCopyRightAfterTheOriginal() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let originalID = try XCTUnwrap(store.createStandaloneProfile())
+
+        let firstCopyID = try XCTUnwrap(store.duplicateProfile(originalID))
+        let secondCopyID = try XCTUnwrap(store.duplicateProfile(originalID))
+
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [originalID, secondCopyID, firstCopyID])
+        // Names are not de-duplicated, matching the rename semantics.
+        XCTAssertEqual(store.standaloneProfiles.map(\.name), ["New Profile", "New Profile Copy", "New Profile Copy"])
+    }
+
+    @MainActor
+    func testDuplicateRemoteProfileKeepsTheHeaderWithoutRefreshHistory() async throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub(), fetchRemoteContent: { _ in
+            "9.9.9.9 fetched.example.com\n"
+        })
+        let originalID = try XCTUnwrap(store.createStandaloneProfile())
+        store.updateProfileContent(
+            originalID,
+            content: "#!hostflip-remote https://example.com/hosts.txt interval=6h\n"
+        )
+        _ = await store.confirmRemoteConversion()
+        let original = try XCTUnwrap(store.profile(originalID))
+        XCTAssertNotNil(original.remoteRefreshState)
+
+        let copyID = try XCTUnwrap(store.duplicateProfile(originalID))
+
+        let copy = try XCTUnwrap(store.profile(copyID))
+        XCTAssertTrue(copy.isRemote)
+        XCTAssertEqual(copy.remoteHeader, original.remoteHeader)
+        XCTAssertEqual(copy.content, original.content)
+        XCTAssertNil(copy.remoteRefreshState)
+        XCTAssertNil(try reloadModel().profile(copyID)?.remoteRefreshState)
+    }
+
+    @MainActor
+    func testDuplicateUnknownProfileIsIgnored() throws {
+        let store = makeStore(coordinator: SwitchCoordinatingStub())
+        let profileID = try XCTUnwrap(store.createStandaloneProfile())
+
+        XCTAssertNil(store.duplicateProfile(Profile.ID("missing")))
+
+        XCTAssertEqual(store.standaloneProfiles.map(\.id), [profileID])
+    }
+
+    @MainActor
     func testRenameAndEditPersistAcrossReload() throws {
         let store = makeStore(coordinator: SwitchCoordinatingStub())
         let profileID = try XCTUnwrap(store.createStandaloneProfile())


### PR DESCRIPTION
- Sidebar row context menu / ⋯ menu gain **Duplicate Profile**: the copy lands right after the original in the same group or the standalone area, inactive, content identical (a Remote Header stays, so a remote copy is still remote, with no refresh history); the copy is selected with its name in edit mode. Base Hosts offers no Duplicate.
- Name is `<name> Copy`, not de-duplicated (matching rename). Generated profile names (default name, copy suffix) are no longer localized because they double as workspace file names; the ja / zh-Hans / zh-Hant catalogs drop those rows. Group default names stay translated.
- A foreignly deleted original yields no copy instead of selecting a missing profile; the copy is named from the replayed model.
