### PR TITLE
feat: toggle line comments from the Edit menu

### DIFF
--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -293,3 +293,6 @@
 "Save" = "保存";
 "The profile was changed outside this dialog." = "このダイアログの外でプロファイルが変更されました。";
 "The profile is no longer a remote profile." = "このプロファイルはリモートプロファイルではなくなっています。";
+
+/* Editor */
+"Toggle Comment" = "コメントを切り替え";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -293,3 +293,6 @@
 "Save" = "保存";
 "The profile was changed outside this dialog." = "方案已在此对话框之外被更改。";
 "The profile is no longer a remote profile." = "该方案已不再是远程方案。";
+
+/* Editor */
+"Toggle Comment" = "切换注释";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -293,3 +293,6 @@
 "Save" = "儲存";
 "The profile was changed outside this dialog." = "方案已在此對話框之外被更改。";
 "The profile is no longer a remote profile." = "此方案已不再是遠端方案。";
+
+/* Editor */
+"Toggle Comment" = "切換註解";

--- a/Sources/Hostflip/EditorCommands.swift
+++ b/Sources/Hostflip/EditorCommands.swift
@@ -1,0 +1,20 @@
+import AppKit
+import SwiftUI
+
+/// Edit menu "Toggle Comment" (#86): dispatched down the responder chain to the focused
+/// `HostsTextView`. SwiftUI's Commands cannot validate through the responder chain, so the
+/// item follows the focus state the text view publishes.
+struct EditorCommands: Commands {
+    var focus = HostsEditorFocus.shared
+
+    var body: some Commands {
+        CommandGroup(after: .pasteboard) {
+            Divider()
+            Button("Toggle Comment") {
+                NSApp.sendAction(#selector(HostsTextView.toggleComment(_:)), to: nil, from: nil)
+            }
+            .keyboardShortcut("/", modifiers: .command)
+            .disabled(!focus.isEditableEditorFocused)
+        }
+    }
+}

--- a/Sources/Hostflip/EditorCommands.swift
+++ b/Sources/Hostflip/EditorCommands.swift
@@ -3,9 +3,9 @@ import SwiftUI
 
 /// Edit menu "Toggle Comment" (#86): dispatched down the responder chain to the focused
 /// `HostsTextView`. SwiftUI's Commands cannot validate through the responder chain, so the
-/// item follows the focus state the text view publishes.
+/// item follows the focused scene value the detail pane derives from the editor's focus.
 struct EditorCommands: Commands {
-    private let focus = HostsEditorFocus.shared
+    @FocusedValue(\.isHostsEditorEditable) private var isEditorEditable
 
     var body: some Commands {
         CommandGroup(after: .pasteboard) {
@@ -14,7 +14,7 @@ struct EditorCommands: Commands {
                 NSApp.sendAction(#selector(HostsTextView.toggleComment(_:)), to: nil, from: nil)
             }
             .keyboardShortcut("/", modifiers: .command)
-            .disabled(!focus.isEditableEditorFocused)
+            .disabled(isEditorEditable != true)
         }
     }
 }

--- a/Sources/Hostflip/EditorCommands.swift
+++ b/Sources/Hostflip/EditorCommands.swift
@@ -5,7 +5,7 @@ import SwiftUI
 /// `HostsTextView`. SwiftUI's Commands cannot validate through the responder chain, so the
 /// item follows the focus state the text view publishes.
 struct EditorCommands: Commands {
-    var focus = HostsEditorFocus.shared
+    private let focus = HostsEditorFocus.shared
 
     var body: some Commands {
         CommandGroup(after: .pasteboard) {

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -88,6 +88,7 @@ struct HostflipApp: App {
         .commands {
             ImportExportCommands(store: store)
             RemoteRefreshCommands(store: store)
+            EditorCommands()
         }
 
         Settings {

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -17,8 +17,8 @@ struct HostsEditor: NSViewRepresentable {
     var documentID: AnyHashable = "single-document"
 
     func makeNSView(context: Context) -> NSScrollView {
-        let scrollView = NSTextView.scrollableTextView()
-        let textView = scrollView.documentView as! NSTextView
+        let scrollView = HostsTextView.scrollableTextView()
+        let textView = scrollView.documentView as! HostsTextView
         textView.font = .monospacedSystemFont(ofSize: NSFont.systemFontSize, weight: .regular)
         textView.isEditable = isEditable
         textView.isSelectable = true
@@ -137,6 +137,70 @@ struct HostsEditor: NSViewRepresentable {
         case .ipAddress: .systemBlue
         case .hostname: .systemTeal
         }
+    }
+}
+
+/// Whether an editable hosts editor currently holds keyboard focus — what the Edit-menu
+/// "Toggle Comment" item keys its enabled state on (#86). SwiftUI's Commands cannot
+/// consult NSUserInterfaceValidations, so the text view publishes its state here instead.
+@Observable
+@MainActor
+final class HostsEditorFocus {
+    static let shared = HostsEditorFocus()
+    private(set) var isEditableEditorFocused = false
+
+    fileprivate func set(_ focused: Bool) {
+        if isEditableEditorFocused != focused {
+            isEditableEditorFocused = focused
+        }
+    }
+}
+
+/// The hosts editor's text view: carries the editor-level actions that the Edit menu
+/// dispatches down the responder chain (#86).
+final class HostsTextView: NSTextView {
+    override var isEditable: Bool {
+        didSet {
+            if window?.firstResponder === self {
+                HostsEditorFocus.shared.set(isEditable)
+            }
+        }
+    }
+
+    override func becomeFirstResponder() -> Bool {
+        let accepted = super.becomeFirstResponder()
+        if accepted {
+            HostsEditorFocus.shared.set(isEditable)
+        }
+        return accepted
+    }
+
+    override func resignFirstResponder() -> Bool {
+        let resigned = super.resignFirstResponder()
+        if resigned {
+            HostsEditorFocus.shared.set(false)
+        }
+        return resigned
+    }
+
+    /// Comments or uncomments the selected lines (the caret's line for an empty selection)
+    /// as one undoable edit that goes through the regular text-change path, so the profile
+    /// saves and merges exactly like a typed edit — including the held Remote Header
+    /// conversion (ADR-0012).
+    @objc func toggleComment(_ sender: Any?) {
+        guard isEditable,
+              let edit = HostsSyntax.toggleComment(in: string, range: selectedRange()),
+              shouldChangeText(in: edit.editedRange, replacementString: edit.replacement)
+        else { return }
+        textStorage?.replaceCharacters(in: edit.editedRange, with: edit.replacement)
+        didChangeText()
+        setSelectedRange(edit.selection)
+        scrollRangeToVisible(edit.selection)
+    }
+
+    override func validateUserInterfaceItem(_ item: any NSValidatedUserInterfaceItem) -> Bool {
+        if item.action == #selector(toggleComment(_:)) { return isEditable }
+        return super.validateUserInterfaceItem(item)
     }
 }
 

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -161,9 +161,11 @@ final class HostsEditorFocus {
 final class HostsTextView: NSTextView {
     override var isEditable: Bool {
         didSet {
-            if window?.firstResponder === self {
-                HostsEditorFocus.shared.set(isEditable)
-            }
+            // Flipped from updateNSView on an in-place document switch; publish outside the
+            // SwiftUI update pass.
+            guard window?.firstResponder === self else { return }
+            let editable = isEditable
+            DispatchQueue.main.async { HostsEditorFocus.shared.set(editable) }
         }
     }
 
@@ -196,11 +198,6 @@ final class HostsTextView: NSTextView {
         didChangeText()
         setSelectedRange(edit.selection)
         scrollRangeToVisible(edit.selection)
-    }
-
-    override func validateUserInterfaceItem(_ item: any NSValidatedUserInterfaceItem) -> Bool {
-        if item.action == #selector(toggleComment(_:)) { return isEditable }
-        return super.validateUserInterfaceItem(item)
     }
 }
 

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -140,20 +140,25 @@ struct HostsEditor: NSViewRepresentable {
     }
 }
 
-/// Whether an editable hosts editor currently holds keyboard focus — what the Edit-menu
-/// "Toggle Comment" item keys its enabled state on (#86). SwiftUI's Commands cannot
-/// consult NSUserInterfaceValidations, so the text view publishes its state here instead.
+/// Whether an editable hosts editor currently holds keyboard focus (#86). The text view
+/// publishes it here; the detail pane forwards it as a focused scene value, which is what
+/// the Edit-menu "Toggle Comment" item keys its enabled state on — a `Commands` body does
+/// not track `@Observable` reads, and a scene value also goes away with the key window.
 @Observable
 @MainActor
 final class HostsEditorFocus {
     static let shared = HostsEditorFocus()
     private(set) var isEditableEditorFocused = false
 
-    fileprivate func set(_ focused: Bool) {
+    fileprivate func setEditableEditorFocused(_ focused: Bool) {
         if isEditableEditorFocused != focused {
             isEditableEditorFocused = focused
         }
     }
+}
+
+extension FocusedValues {
+    @Entry var isHostsEditorEditable: Bool?
 }
 
 /// The hosts editor's text view: carries the editor-level actions that the Edit menu
@@ -162,17 +167,19 @@ final class HostsTextView: NSTextView {
     override var isEditable: Bool {
         didSet {
             // Flipped from updateNSView on an in-place document switch; publish outside the
-            // SwiftUI update pass.
+            // SwiftUI update pass, and only if focus has not moved on in the meantime.
             guard window?.firstResponder === self else { return }
-            let editable = isEditable
-            DispatchQueue.main.async { HostsEditorFocus.shared.set(editable) }
+            DispatchQueue.main.async { [weak self] in
+                guard let self, window?.firstResponder === self else { return }
+                HostsEditorFocus.shared.setEditableEditorFocused(isEditable)
+            }
         }
     }
 
     override func becomeFirstResponder() -> Bool {
         let accepted = super.becomeFirstResponder()
         if accepted {
-            HostsEditorFocus.shared.set(isEditable)
+            HostsEditorFocus.shared.setEditableEditorFocused(isEditable)
         }
         return accepted
     }
@@ -180,7 +187,7 @@ final class HostsTextView: NSTextView {
     override func resignFirstResponder() -> Bool {
         let resigned = super.resignFirstResponder()
         if resigned {
-            HostsEditorFocus.shared.set(false)
+            HostsEditorFocus.shared.setEditableEditorFocused(false)
         }
         return resigned
     }

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -1026,6 +1026,8 @@ struct MainWindowView: View {
             isEditable: profile?.isRemote == false,
             documentID: profileID.map { AnyHashable($0) } ?? AnyHashable("base-hosts")
         )
+        // Read here, in a View body, so the focus change re-renders and reaches the Edit menu (#86).
+        .focusedSceneValue(\.isHostsEditorEditable, HostsEditorFocus.shared.isEditableEditorFocused)
     }
 }
 

--- a/Sources/HostflipCore/HostsSyntax.swift
+++ b/Sources/HostflipCore/HostsSyntax.swift
@@ -83,3 +83,101 @@ public enum HostsSyntax {
         return incompleteLine
     }
 }
+
+/// Result of a Toggle Comment (#86): `editedRange` (in the old text) replaced by `replacement`
+/// yields `text`; `selection` is the range to select afterwards, in the new text.
+public struct HostsCommentToggle: Equatable, Sendable {
+    public let editedRange: NSRange
+    public let replacement: String
+    public let selection: NSRange
+    public let text: String
+}
+
+extension HostsSyntax {
+    /// Toggles line comments on every line intersecting `range` (the caret's line when empty);
+    /// a selection ending at the start of a line leaves that line out. When every non-blank
+    /// target line is commented they are all uncommented, otherwise every non-blank line is
+    /// commented — mixed selections end up fully commented. Blank lines are skipped, and a
+    /// target of blank lines only is a no-op (nil). Commenting inserts `# ` after the leading
+    /// whitespace; uncommenting removes the first `#` and at most one following space.
+    /// Offsets are UTF-16 to match the editor's text storage.
+    public static func toggleComment(in text: String, range: NSRange) -> HostsCommentToggle? {
+        let ns = text as NSString
+        var target = range
+        if target.length > 0, isNewline(ns.character(at: NSMaxRange(target) - 1)) {
+            target.length -= 1
+        }
+        let editedRange = ns.lineRange(for: target)
+
+        var lines: [(content: NSRange, terminator: NSRange, indentEnd: Int)] = []
+        ns.enumerateSubstrings(
+            in: editedRange,
+            options: [.byLines, .substringNotRequired]
+        ) { _, content, enclosing, _ in
+            var indentEnd = content.location
+            while indentEnd < NSMaxRange(content), isIndentation(ns.character(at: indentEnd)) {
+                indentEnd += 1
+            }
+            lines.append((
+                content,
+                NSRange(location: NSMaxRange(content), length: NSMaxRange(enclosing) - NSMaxRange(content)),
+                indentEnd
+            ))
+        }
+        let nonBlank = lines.filter { $0.indentEnd < NSMaxRange($0.content) }
+        guard !nonBlank.isEmpty else { return nil }
+        let uncomment = nonBlank.allSatisfy { ns.character(at: $0.indentEnd) == hash }
+
+        var replacement = ""
+        var caret = range.location
+        var lastContentEnd = editedRange.location
+        for line in lines {
+            let isBlank = line.indentEnd == NSMaxRange(line.content)
+            let indent = ns.substring(with: NSRange(location: line.content.location, length: line.indentEnd - line.content.location))
+            var body = ns.substring(with: NSRange(location: line.indentEnd, length: NSMaxRange(line.content) - line.indentEnd))
+            var delta = 0
+            if !isBlank {
+                if uncomment {
+                    body.removeFirst()
+                    delta = -1
+                    if body.utf16.first == space {
+                        body.removeFirst()
+                        delta = -2
+                    }
+                } else {
+                    body = "# " + body
+                    delta = 2
+                }
+            }
+            if range.length == 0, caret > line.indentEnd {
+                caret = max(line.indentEnd, caret + delta)
+            }
+            let start = editedRange.location + (replacement as NSString).length
+            replacement += indent + body
+            lastContentEnd = start + (indent as NSString).length + (body as NSString).length
+            replacement += ns.substring(with: line.terminator)
+        }
+
+        let selection = range.length == 0
+            ? NSRange(location: caret, length: 0)
+            : NSRange(location: editedRange.location, length: lastContentEnd - editedRange.location)
+        return HostsCommentToggle(
+            editedRange: editedRange,
+            replacement: replacement,
+            selection: selection,
+            text: ns.replacingCharacters(in: editedRange, with: replacement)
+        )
+    }
+
+    private static let hash: unichar = 0x23
+    private static let space: unichar = 0x20
+
+    private static func isIndentation(_ character: unichar) -> Bool {
+        character == space || character == 0x09
+    }
+
+    private static func isNewline(_ character: unichar) -> Bool {
+        guard let scalar = Unicode.Scalar(character) else { return false }
+        return CharacterSet.newlines.contains(scalar)
+    }
+}

--- a/Sources/HostflipCore/HostsSyntax.swift
+++ b/Sources/HostflipCore/HostsSyntax.swift
@@ -134,16 +134,15 @@ extension HostsSyntax {
         for line in lines {
             let isBlank = line.indentEnd == NSMaxRange(line.content)
             let indent = ns.substring(with: NSRange(location: line.content.location, length: line.indentEnd - line.content.location))
-            var body = ns.substring(with: NSRange(location: line.indentEnd, length: NSMaxRange(line.content) - line.indentEnd))
+            let bodyRange = NSRange(location: line.indentEnd, length: NSMaxRange(line.content) - line.indentEnd)
+            var body = ns.substring(with: bodyRange)
             var delta = 0
             if !isBlank {
                 if uncomment {
-                    body.removeFirst()
-                    delta = -1
-                    if body.utf16.first == space {
-                        body.removeFirst()
-                        delta = -2
-                    }
+                    // UTF-16 slicing, not Character removal: a combining mark after `#` must not go with it.
+                    let dropped = bodyRange.length > 1 && ns.character(at: line.indentEnd + 1) == space ? 2 : 1
+                    body = ns.substring(with: NSRange(location: line.indentEnd + dropped, length: bodyRange.length - dropped))
+                    delta = -dropped
                 } else {
                     body = "# " + body
                     delta = 2

--- a/Sources/HostflipCore/HostsSyntax.swift
+++ b/Sources/HostflipCore/HostsSyntax.swift
@@ -100,29 +100,37 @@ extension HostsSyntax {
     /// commented — mixed selections end up fully commented. Blank lines are skipped, and a
     /// target of blank lines only is a no-op (nil). Commenting inserts `# ` after the leading
     /// whitespace; uncommenting removes the first `#` and at most one following space.
-    /// Offsets are UTF-16 to match the editor's text storage.
+    /// Offsets are UTF-16 to match the editor's text storage; lines split where NSString's line APIs do.
     public static func toggleComment(in text: String, range: NSRange) -> HostsCommentToggle? {
         let ns = text as NSString
-        var target = range
-        if target.length > 0, isNewline(ns.character(at: NSMaxRange(target) - 1)) {
-            target.length -= 1
-        }
-        let editedRange = ns.lineRange(for: target)
+        let firstLine = ns.lineRange(for: NSRange(location: range.location, length: 0))
+        // The last target line is the one holding the selection's last character, so a
+        // selection ending at a line start leaves that line out.
+        let lastLine = range.length > 0
+            ? ns.lineRange(for: NSRange(location: NSMaxRange(range) - 1, length: 0))
+            : firstLine
+        let editedRange = NSRange(
+            location: firstLine.location,
+            length: NSMaxRange(lastLine) - firstLine.location
+        )
 
+        // Walked by hand: enumerateSubstrings(.byLines) skips an empty line at the end of the range,
+        // which must still count for the returned selection.
         var lines: [(content: NSRange, terminator: NSRange, indentEnd: Int)] = []
-        ns.enumerateSubstrings(
-            in: editedRange,
-            options: [.byLines, .substringNotRequired]
-        ) { _, content, enclosing, _ in
-            var indentEnd = content.location
-            while indentEnd < NSMaxRange(content), isIndentation(ns.character(at: indentEnd)) {
+        var position = editedRange.location
+        while position < NSMaxRange(editedRange) {
+            var start = 0, end = 0, contentsEnd = 0
+            ns.getLineStart(&start, end: &end, contentsEnd: &contentsEnd, for: NSRange(location: position, length: 0))
+            var indentEnd = start
+            while indentEnd < contentsEnd, isIndentation(ns.character(at: indentEnd)) {
                 indentEnd += 1
             }
             lines.append((
-                content,
-                NSRange(location: NSMaxRange(content), length: NSMaxRange(enclosing) - NSMaxRange(content)),
+                NSRange(location: start, length: contentsEnd - start),
+                NSRange(location: contentsEnd, length: end - contentsEnd),
                 indentEnd
             ))
+            position = end
         }
         let nonBlank = lines.filter { $0.indentEnd < NSMaxRange($0.content) }
         guard !nonBlank.isEmpty else { return nil }
@@ -172,11 +180,7 @@ extension HostsSyntax {
     private static let space: unichar = 0x20
 
     private static func isIndentation(_ character: unichar) -> Bool {
-        character == space || character == 0x09
-    }
-
-    private static func isNewline(_ character: unichar) -> Bool {
         guard let scalar = Unicode.Scalar(character) else { return false }
-        return CharacterSet.newlines.contains(scalar)
+        return CharacterSet.whitespaces.contains(scalar)
     }
 }

--- a/Tests/HostflipCoreTests/HostsCommentToggleTests.swift
+++ b/Tests/HostflipCoreTests/HostsCommentToggleTests.swift
@@ -25,6 +25,8 @@ final class HostsCommentToggleTests: XCTestCase {
         XCTAssertEqual(toggle("#foo", 0)?.text, "foo")
         XCTAssertEqual(toggle("# foo", 0)?.text, "foo")
         XCTAssertEqual(toggle("#  foo", 0)?.text, " foo")
+        // The marker alone goes; a combining mark right after it stays with the text.
+        XCTAssertEqual(toggle("#\u{301}foo", 0)?.text, "\u{301}foo")
     }
 
     func testIndentationIsPreservedBothWays() throws {

--- a/Tests/HostflipCoreTests/HostsCommentToggleTests.swift
+++ b/Tests/HostflipCoreTests/HostsCommentToggleTests.swift
@@ -85,3 +85,23 @@ final class HostsCommentToggleTests: XCTestCase {
         XCTAssertEqual(edit.text, "x\n# a\n# b\ny")
     }
 }
+
+extension HostsCommentToggleTests {
+    func testSelectionKeepsAFullySelectedTrailingBlankLine() throws {
+        let edit = try XCTUnwrap(toggle("a\n\nb", 0, 3))
+        XCTAssertEqual(edit.text, "# a\n\nb")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 4))
+    }
+
+    func testUnicodeWhitespaceCountsAsBlankAndIndentation() throws {
+        XCTAssertNil(toggle("\u{00A0}\u{3000}", 0))
+        XCTAssertEqual(toggle("\u{3000}a", 0)?.text, "\u{3000}# a")
+        XCTAssertEqual(toggle("\u{3000}# a", 0)?.text, "\u{3000}a")
+    }
+
+    func testVerticalTabIsNotALineBreak() throws {
+        let edit = try XCTUnwrap(toggle("a\u{000B}b\nc", 0, 2))
+        XCTAssertEqual(edit.text, "# a\u{000B}b\nc")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 5))
+    }
+}

--- a/Tests/HostflipCoreTests/HostsCommentToggleTests.swift
+++ b/Tests/HostflipCoreTests/HostsCommentToggleTests.swift
@@ -1,0 +1,85 @@
+import XCTest
+@testable import HostflipCore
+
+/// Toggle Comment (#86): line-wise comment/uncomment over the lines intersecting a UTF-16
+/// selection. All non-blank target lines commented → uncomment them all; otherwise comment
+/// every non-blank line (mixed selections become fully commented). Blank lines are skipped.
+final class HostsCommentToggleTests: XCTestCase {
+    private func toggle(_ text: String, _ location: Int, _ length: Int = 0) -> HostsCommentToggle? {
+        HostsSyntax.toggleComment(in: text, range: NSRange(location: location, length: length))
+    }
+
+    func testCommentsTheCaretLineAndKeepsTheCaretOnIt() throws {
+        let edit = try XCTUnwrap(toggle("127.0.0.1 local.dev\n1.2.3.4 b", 5))
+        XCTAssertEqual(edit.text, "# 127.0.0.1 local.dev\n1.2.3.4 b")
+        XCTAssertEqual(edit.selection, NSRange(location: 7, length: 0))
+    }
+
+    func testUncommentsTheCaretLineRemovingHashAndOneSpace() throws {
+        let edit = try XCTUnwrap(toggle("# 127.0.0.1 local.dev", 7))
+        XCTAssertEqual(edit.text, "127.0.0.1 local.dev")
+        XCTAssertEqual(edit.selection, NSRange(location: 5, length: 0))
+    }
+
+    func testHashWithoutSpaceUncommentsToo() throws {
+        XCTAssertEqual(toggle("#foo", 0)?.text, "foo")
+        XCTAssertEqual(toggle("# foo", 0)?.text, "foo")
+        XCTAssertEqual(toggle("#  foo", 0)?.text, " foo")
+    }
+
+    func testIndentationIsPreservedBothWays() throws {
+        XCTAssertEqual(toggle("  1.2.3.4 a", 0)?.text, "  # 1.2.3.4 a")
+        XCTAssertEqual(toggle("\t# foo", 0)?.text, "\tfoo")
+    }
+
+    func testTrailingCommentIsNotTouched() throws {
+        XCTAssertEqual(toggle("1.2.3.4 a # dev", 0)?.text, "# 1.2.3.4 a # dev")
+        XCTAssertEqual(toggle("# 1.2.3.4 a # dev", 0)?.text, "1.2.3.4 a # dev")
+    }
+
+    func testAllCommentedSelectionUncommentsEveryLine() throws {
+        let text = "# a\n#b\n\n  # c\n"
+        let edit = try XCTUnwrap(toggle(text, 0, (text as NSString).length))
+        XCTAssertEqual(edit.text, "a\nb\n\n  c\n")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 8))
+    }
+
+    func testMixedSelectionCommentsEveryNonBlankLine() throws {
+        let text = "# a\nb\n   \nc"
+        let edit = try XCTUnwrap(toggle(text, 0, (text as NSString).length))
+        XCTAssertEqual(edit.text, "# # a\n# b\n   \n# c")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 17))
+    }
+
+    func testPartialSelectionCoversEveryIntersectingLine() throws {
+        // "a\nb\nc": selecting from inside line 1 to inside line 2 targets both, not line 3.
+        let edit = try XCTUnwrap(toggle("a\nb\nc", 1, 2))
+        XCTAssertEqual(edit.text, "# a\n# b\nc")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 7))
+    }
+
+    func testSelectionEndingAtLineStartExcludesThatLine() throws {
+        let edit = try XCTUnwrap(toggle("a\nb\nc", 0, 2))
+        XCTAssertEqual(edit.text, "# a\nb\nc")
+        XCTAssertEqual(edit.selection, NSRange(location: 0, length: 3))
+    }
+
+    func testBlankOnlyTargetsAreANoOp() {
+        XCTAssertNil(toggle("", 0))
+        XCTAssertNil(toggle("   \n\t\n", 0, 6))
+        XCTAssertNil(toggle("a\n\nb", 2))
+    }
+
+    func testCaretBeforeTheInsertionPointStaysPut() throws {
+        let edit = try XCTUnwrap(toggle("  a", 1))
+        XCTAssertEqual(edit.text, "  # a")
+        XCTAssertEqual(edit.selection, NSRange(location: 1, length: 0))
+    }
+
+    func testEditedRangeAndReplacementDescribeTheTouchedLines() throws {
+        let edit = try XCTUnwrap(toggle("x\na\nb\ny", 2, 3))
+        XCTAssertEqual(edit.editedRange, NSRange(location: 2, length: 4))
+        XCTAssertEqual(edit.replacement, "# a\n# b\n")
+        XCTAssertEqual(edit.text, "x\n# a\n# b\ny")
+    }
+}

--- a/Tests/HostflipTests/HostsTextViewTests.swift
+++ b/Tests/HostflipTests/HostsTextViewTests.swift
@@ -1,0 +1,50 @@
+import AppKit
+import XCTest
+@testable import Hostflip
+
+/// Toggle Comment on the editor's text view (#86): one undoable step through the regular
+/// text-change path.
+@MainActor
+final class HostsTextViewTests: XCTestCase {
+    @MainActor
+    private final class Delegate: NSObject, NSTextViewDelegate {
+        let undoManager = UndoManager()
+        var changes = 0
+
+        func undoManager(for view: NSTextView) -> UndoManager? { undoManager }
+        func textDidChange(_ notification: Notification) { changes += 1 }
+    }
+
+    private func makeTextView(_ text: String, delegate: Delegate) -> HostsTextView {
+        let textView = HostsTextView.scrollableTextView().documentView as! HostsTextView
+        textView.allowsUndo = true
+        textView.delegate = delegate
+        textView.string = text
+        return textView
+    }
+
+    func testToggleIsOneUndoStepAndNotifiesTheDelegate() {
+        let delegate = Delegate()
+        let textView = makeTextView("a\nb\nc", delegate: delegate)
+        textView.setSelectedRange(NSRange(location: 0, length: 3))
+
+        textView.toggleComment(nil)
+        XCTAssertEqual(textView.string, "# a\n# b\nc")
+        XCTAssertEqual(textView.selectedRange(), NSRange(location: 0, length: 7))
+        XCTAssertEqual(delegate.changes, 1)
+
+        delegate.undoManager.undo()
+        XCTAssertEqual(textView.string, "a\nb\nc")
+        delegate.undoManager.redo()
+        XCTAssertEqual(textView.string, "# a\n# b\nc")
+    }
+
+    func testReadOnlyViewIgnoresTheAction() {
+        let delegate = Delegate()
+        let textView = makeTextView("a", delegate: delegate)
+        textView.isEditable = false
+        textView.toggleComment(nil)
+        XCTAssertEqual(textView.string, "a")
+        XCTAssertEqual(delegate.changes, 0)
+    }
+}


### PR DESCRIPTION
Adds a **Toggle Comment** item (⌘/) to the Edit menu that comments or uncomments the caret line, or every line of the selection, in an editable profile.

- Rules live in `HostflipCore` next to `HostsSyntax` (`HostsSyntax.toggleComment(in:range:)`): all non-blank target lines commented → uncomment; otherwise comment every non-blank line. Blank lines are skipped, indentation is preserved, `#foo` / `# foo` both uncomment to `foo`, trailing comments are untouched.
- Applied on the editor's text view as one undoable edit through the regular text-change path, so saving, merging, and the held Remote Header conversion behave exactly like typed edits.
- The menu item follows the editor's focus via a focused scene value: disabled for Base Hosts, Remote Profiles, other focused views, and when another window is key.
- ja / zh-Hans / zh-Hant catalogs gain the one new string.

Verified on device: menu enabling across focus/document/window changes, single and multi-line toggles, one-step undo/redo, persistence across profile switches, merge into `/etc/hosts`, Remote Header conversion cancel, and all three localizations.
