### PR TITLE
perf: keep the editor responsive on very large profiles

### DIFF
--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -307,49 +307,37 @@ final class HostsLineNumberRulerView: NSRulerView {
         drawHashMarksAndLabels(in: bounds)
     }
 
-    override func drawHashMarksAndLabels(in rect: NSRect) {
+    /// One gutter label: a file line number and the text-view-space row it sits on.
+    struct Label: Equatable {
+        let line: Int
+        let y: CGFloat
+        let height: CGFloat
+    }
+
+    /// The labels for the rows intersecting `visibleRect` (text view coordinates), walking
+    /// only what the viewport controller has already laid out: asking for layout from here
+    /// (ensuresLayout / textLayoutFragment(for:)) cancels TextKit 2's idle estimation of the
+    /// document height, and the view then cannot scroll past the first screen. Returns nil
+    /// when nothing is laid out yet (first frame, or a document just swapped in).
+    func labels(in visibleRect: NSRect) -> [Label]? {
         guard let textView,
               let layoutManager = textView.textLayoutManager,
-              let contentManager = layoutManager.textContentManager
-        else { return }
-
-        let paragraphStyle = NSMutableParagraphStyle()
-        paragraphStyle.alignment = .right
-        let attributes: [NSAttributedString.Key: Any] = [
-            .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .regular),
-            .foregroundColor: NSColor.tertiaryLabelColor,
-            .paragraphStyle: paragraphStyle,
-        ]
+              let contentManager = layoutManager.textContentManager,
+              let storage = textView.textStorage
+        else { return [] }
         let origin = textView.textContainerOrigin
-        let visibleRect = textView.visibleRect
-        let documentStart = contentManager.documentRange.location
 
-        // Row geometry is in text container coordinates; the ruler draws in its own.
-        func draw(_ number: Int, rowY: CGFloat, rowHeight: CGFloat) {
-            let point = convert(NSPoint(x: 0, y: rowY + origin.y), from: textView)
-            let labelRect = NSRect(x: 4, y: point.y, width: bounds.width - 10, height: rowHeight)
-            String(number).draw(in: labelRect, withAttributes: attributes)
-        }
-
-        guard let storage = textView.textStorage, storage.length > 0 else {
+        guard storage.length > 0 else {
             // An empty document has no fragments to walk, but still one line.
-            if let font = textView.font {
-                draw(1, rowY: 0, rowHeight: ceil(font.ascender - font.descender + font.leading))
-            }
-            return
+            guard let font = textView.font else { return [] }
+            return [Label(line: 1, y: origin.y, height: ceil(font.ascender - font.descender + font.leading))]
         }
-
-        // Walk only what the viewport controller has already laid out: asking for layout from
-        // here (ensuresLayout / textLayoutFragment(for:)) cancels TextKit 2's idle estimation
-        // of the document height, and the view then cannot scroll past the first screen.
         guard let viewport = layoutManager.textViewportLayoutController.viewportRange,
               viewport.location.compare(layoutManager.documentRange.endLocation) == .orderedAscending
-        else {
-            // Nothing laid out yet (first frame, or a document just swapped in): come back
-            // once the viewport has been laid out, since no bounds change may follow.
-            DispatchQueue.main.async { [weak self] in self?.needsDisplay = true }
-            return
-        }
+        else { return nil }
+
+        let documentStart = contentManager.documentRange.location
+        var labels: [Label] = []
         var lastFragment: NSTextLayoutFragment?
         layoutManager.enumerateTextLayoutFragments(from: viewport.location, options: []) { fragment in
             let frame = fragment.layoutFragmentFrame
@@ -360,7 +348,7 @@ final class HostsLineNumberRulerView: NSRulerView {
             let offset = contentManager.offset(from: documentStart, to: fragment.rangeInElement.location)
             // Only the first row of a wrapped line carries the number.
             let firstRowHeight = fragment.textLineFragments.first?.typographicBounds.height ?? frame.height
-            draw(lineNumber(at: offset), rowY: frame.minY, rowHeight: firstRowHeight)
+            labels.append(Label(line: lineNumber(at: offset), y: frame.minY + origin.y, height: firstRowHeight))
             lastFragment = fragment
             return true
         }
@@ -370,10 +358,32 @@ final class HostsLineNumberRulerView: NSRulerView {
         if let lastFragment, storage.mutableString.hasSuffix("\n"),
            contentManager.offset(from: documentStart, to: lastFragment.rangeInElement.endLocation) == storage.length,
            let emptyRow = lastFragment.textLineFragments.last?.typographicBounds {
-            let rowY = lastFragment.layoutFragmentFrame.minY + emptyRow.minY
-            if rowY + origin.y < visibleRect.maxY {
-                draw(lineCount, rowY: rowY, rowHeight: emptyRow.height)
+            let y = lastFragment.layoutFragmentFrame.minY + emptyRow.minY + origin.y
+            if y < visibleRect.maxY {
+                labels.append(Label(line: lineCount, y: y, height: emptyRow.height))
             }
+        }
+        return labels
+    }
+
+    override func drawHashMarksAndLabels(in rect: NSRect) {
+        guard let textView else { return }
+        guard let labels = labels(in: textView.visibleRect) else {
+            // Come back once the viewport has been laid out; no bounds change may follow.
+            DispatchQueue.main.async { [weak self] in self?.needsDisplay = true }
+            return
+        }
+        let paragraphStyle = NSMutableParagraphStyle()
+        paragraphStyle.alignment = .right
+        let attributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.monospacedDigitSystemFont(ofSize: 10, weight: .regular),
+            .foregroundColor: NSColor.tertiaryLabelColor,
+            .paragraphStyle: paragraphStyle,
+        ]
+        for label in labels {
+            let point = convert(NSPoint(x: 0, y: label.y), from: textView)
+            let labelRect = NSRect(x: 4, y: point.y, width: bounds.width - 10, height: label.height)
+            String(label.line).draw(in: labelRect, withAttributes: attributes)
         }
     }
 }

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -73,10 +73,13 @@ struct HostsEditor: NSViewRepresentable {
                 scrollView.isFindBarVisible = false
             }
         }
-        if textView.string != text { // guard against the delegate write-back loop
+        // Guard against the delegate write-back loop. Compared through the storage's mutable
+        // string proxy: `textView.string` would bridge the whole document into a fresh String
+        // on every SwiftUI update, which at 200k lines is a few milliseconds each (#94).
+        if let storage = textView.textStorage, !storage.mutableString.isEqual(to: text) {
             textView.string = text
             Self.highlight(textView)
-            scrollView.verticalRulerView?.needsDisplay = true
+            (scrollView.verticalRulerView as? HostsLineNumberRulerView)?.textDidReplace()
         }
         if documentChanged {
             textView.setSelectedRange(NSRange(location: 0, length: 0))
@@ -211,19 +214,23 @@ final class HostsTextView: NSTextView {
 /// Never reads NSTextView.layoutManager, to avoid downgrading the main editor from TextKit 2.
 /// The editor does not soft-wrap, so a fixed line-height font can locate visible logical lines directly.
 @MainActor
-private final class HostsLineNumberRulerView: NSRulerView {
+final class HostsLineNumberRulerView: NSRulerView {
     private weak var textView: NSTextView?
+    /// Cached: the draw runs on every scroll tick, and deriving the count there would copy and
+    /// scan the whole document per frame (#94). Recomputed only when the text changes.
+    private(set) var lineCount = 1
 
     init(scrollView: NSScrollView, textView: NSTextView) {
         self.textView = textView
         super.init(scrollView: scrollView, orientation: .verticalRuler)
         clientView = textView
         ruleThickness = 40
+        recountLines()
 
         let center = NotificationCenter.default
         center.addObserver(
             self,
-            selector: #selector(invalidateRuler(_:)),
+            selector: #selector(textDidChange(_:)),
             name: NSText.didChangeNotification,
             object: textView
         )
@@ -239,8 +246,37 @@ private final class HostsLineNumberRulerView: NSRulerView {
         fatalError("init(coder:) has not been implemented")
     }
 
+    /// For text swapped in without an edit notification (a document switch).
+    func textDidReplace() {
+        recountLines()
+        needsDisplay = true
+    }
+
+    @objc private func textDidChange(_ notification: Notification) {
+        recountLines()
+        needsDisplay = true
+    }
+
     @objc private func invalidateRuler(_ notification: Notification) {
         needsDisplay = true
+    }
+
+    /// Counts newlines on the storage's mutable string proxy — UTF-16 search, no String bridge.
+    private func recountLines() {
+        guard let storage = textView?.textStorage else { return }
+        let string = storage.mutableString
+        var count = 1
+        var searchRange = NSRange(location: 0, length: string.length)
+        while true {
+            let found = string.range(of: "\n", options: [.literal], range: searchRange)
+            if found.location == NSNotFound { break }
+            count += 1
+            searchRange = NSRange(
+                location: NSMaxRange(found),
+                length: string.length - NSMaxRange(found)
+            )
+        }
+        lineCount = count
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -256,9 +292,6 @@ private final class HostsLineNumberRulerView: NSRulerView {
     override func drawHashMarksAndLabels(in rect: NSRect) {
         guard let textView, let font = textView.font else { return }
 
-        let lineCount = textView.string.reduce(into: 1) { count, character in
-            if character == "\n" { count += 1 }
-        }
         let digits = max(2, String(lineCount).count)
         let desiredThickness = max(40, CGFloat(digits * 8 + 16))
         if ruleThickness != desiredThickness {

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -36,17 +36,13 @@ struct HostsEditor: NSViewRepresentable {
         textView.isAutomaticLinkDetectionEnabled = false
         textView.smartInsertDeleteEnabled = false
         textView.textContainerInset = NSSize(width: 4, height: 8)
-        // hosts is a line-oriented format; with soft wrapping off, gutter line numbers always match file lines.
-        textView.isHorizontallyResizable = true
-        textView.textContainer?.widthTracksTextView = false
-        textView.textContainer?.containerSize = NSSize(
-            width: CGFloat.greatestFiniteMagnitude,
-            height: CGFloat.greatestFiniteMagnitude
-        )
+        // Soft wrapping stays on (the scrollableTextView default): with widthTracksTextView off,
+        // TextKit 2 lays out the whole document up front instead of the viewport — seconds and a
+        // 4x per-scroll cost on a 90k-line Remote Profile (#94). The gutter maps wrapped rows
+        // back to file lines through the layout fragments.
         textView.delegate = context.coordinator
         textView.string = text
         Self.highlight(textView)
-        scrollView.hasHorizontalScroller = true
         scrollView.contentView.postsBoundsChangedNotifications = true
         scrollView.verticalRulerView = HostsLineNumberRulerView(
             scrollView: scrollView,
@@ -210,17 +206,20 @@ final class HostsTextView: NSTextView {
     }
 }
 
-/// Never reads NSTextView.layoutManager, to avoid downgrading the main editor from TextKit 2.
-/// The editor does not soft-wrap, so a fixed line-height font can locate visible logical lines directly.
+/// Never reads NSTextView.layoutManager, to avoid downgrading the main editor from TextKit 2;
+/// it walks the TextKit 2 layout fragments of the visible rows instead. A fragment is one
+/// paragraph, i.e. one file line, so a wrapped line gets its number on its first row only.
 @MainActor
 final class HostsLineNumberRulerView: NSRulerView {
     private weak var textView: NSTextView?
-    /// Cached: the draw runs on every scroll tick, and deriving the count there would copy and
-    /// scan the whole document per frame (#94). Recomputed only when characters change — observed
-    /// on the storage rather than through NSText.didChangeNotification, which undo does not post.
-    /// Read-only in didProcessEditing: the attribute-merging hazard noted at the top of the file
-    /// only concerns mutating the storage from there.
-    private(set) var lineCount = 1
+    /// UTF-16 offsets at which each file line starts. Cached: the draw runs on every scroll
+    /// tick, and deriving this there would copy and scan the whole document per frame (#94).
+    /// Recomputed only when characters change — observed on the storage rather than through
+    /// NSText.didChangeNotification, which undo does not post. Read-only in didProcessEditing:
+    /// the attribute-merging hazard noted at the top of the file only concerns mutating the
+    /// storage from there.
+    private(set) var lineStarts: [Int] = [0]
+    var lineCount: Int { lineStarts.count }
 
     init(scrollView: NSScrollView, textView: NSTextView) {
         self.textView = textView
@@ -259,22 +258,32 @@ final class HostsLineNumberRulerView: NSRulerView {
         needsDisplay = true
     }
 
-    /// Counts newlines on the storage's mutable string proxy — UTF-16 search, no String bridge.
+    /// Finds newlines on the storage's mutable string proxy — UTF-16 search, no String bridge.
     private func recountLines() {
         guard let storage = textView?.textStorage else { return }
         let string = storage.mutableString
-        var count = 1
+        var starts = [0]
         var searchRange = NSRange(location: 0, length: string.length)
         while true {
             let found = string.range(of: "\n", options: [.literal], range: searchRange)
             if found.location == NSNotFound { break }
-            count += 1
+            starts.append(NSMaxRange(found))
             searchRange = NSRange(
                 location: NSMaxRange(found),
                 length: string.length - NSMaxRange(found)
             )
         }
-        lineCount = count
+        lineStarts = starts
+    }
+
+    /// 1-based number of the file line containing the UTF-16 offset.
+    func lineNumber(at offset: Int) -> Int {
+        var low = 0, high = lineStarts.count - 1
+        while low < high {
+            let mid = (low + high + 1) / 2
+            if lineStarts[mid] <= offset { low = mid } else { high = mid - 1 }
+        }
+        return low + 1
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -288,23 +297,16 @@ final class HostsLineNumberRulerView: NSRulerView {
     }
 
     override func drawHashMarksAndLabels(in rect: NSRect) {
-        guard let textView, let font = textView.font else { return }
+        guard let textView,
+              let layoutManager = textView.textLayoutManager,
+              let contentManager = layoutManager.textContentManager
+        else { return }
 
         let digits = max(2, String(lineCount).count)
         let desiredThickness = max(40, CGFloat(digits * 8 + 16))
         if ruleThickness != desiredThickness {
             ruleThickness = desiredThickness
         }
-
-        let lineHeight = ceil(font.ascender - font.descender + font.leading)
-        let inset = textView.textContainerInset.height
-        let visibleRect = textView.visibleRect
-        let firstLine = max(0, Int(floor((visibleRect.minY - inset) / lineHeight)))
-        let lastLine = min(
-            lineCount - 1,
-            Int(ceil((visibleRect.maxY - inset) / lineHeight))
-        )
-        guard firstLine <= lastLine else { return }
 
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .right
@@ -313,20 +315,47 @@ final class HostsLineNumberRulerView: NSRulerView {
             .foregroundColor: NSColor.tertiaryLabelColor,
             .paragraphStyle: paragraphStyle,
         ]
+        let origin = textView.textContainerOrigin
+        let visibleRect = textView.visibleRect
+        let documentStart = contentManager.documentRange.location
 
-        for lineIndex in firstLine...lastLine {
-            let point = convert(
-                NSPoint(x: 0, y: inset + CGFloat(lineIndex) * lineHeight),
-                from: textView
-            )
-            let labelRect = NSRect(
-                x: 4,
-                y: point.y,
-                width: bounds.width - 10,
-                height: lineHeight
-            )
-            String(lineIndex + 1).draw(in: labelRect, withAttributes: attributes)
+        // Fragment frames are in text container coordinates; the ruler draws in its own.
+        func draw(_ number: Int, rowFrame: NSRect) {
+            let point = convert(NSPoint(x: 0, y: rowFrame.minY + origin.y), from: textView)
+            let labelRect = NSRect(x: 4, y: point.y, width: bounds.width - 10, height: rowFrame.height)
+            String(number).draw(in: labelRect, withAttributes: attributes)
         }
 
+        // Walk only what the viewport controller has already laid out: asking for layout from
+        // here (ensuresLayout / textLayoutFragment(for:)) cancels TextKit 2's idle estimation
+        // of the document height, and the view then cannot scroll past the first screen.
+        guard let viewport = layoutManager.textViewportLayoutController.viewportRange else { return }
+        var lastFragment: NSTextLayoutFragment?
+        layoutManager.enumerateTextLayoutFragments(from: viewport.location, options: []) { fragment in
+            let frame = fragment.layoutFragmentFrame
+            guard frame.minY + origin.y < visibleRect.maxY,
+                  fragment.rangeInElement.location.compare(viewport.endLocation) == .orderedAscending
+            else { return false }
+            guard frame.maxY + origin.y > visibleRect.minY else { return true }
+            let offset = contentManager.offset(from: documentStart, to: fragment.rangeInElement.location)
+            // Only the first row of a wrapped line carries the number.
+            let firstRow = fragment.textLineFragments.first?.typographicBounds
+                ?? NSRect(origin: .zero, size: frame.size)
+            draw(lineNumber(at: offset), rowFrame: NSRect(x: 0, y: frame.minY, width: 0, height: firstRow.height))
+            lastFragment = fragment
+            return true
+        }
+
+        // A trailing newline opens an empty last line; TextKit 2 renders it as an extra line
+        // fragment inside the last layout fragment rather than as a fragment of its own.
+        if let lastFragment, let storage = textView.textStorage,
+           storage.length > 0, storage.mutableString.hasSuffix("\n"),
+           contentManager.offset(from: documentStart, to: lastFragment.rangeInElement.endLocation) == storage.length,
+           let emptyRow = lastFragment.textLineFragments.last?.typographicBounds {
+            let frame = lastFragment.layoutFragmentFrame
+            if frame.minY + emptyRow.minY + origin.y < visibleRect.maxY {
+                draw(lineCount, rowFrame: NSRect(x: 0, y: frame.minY + emptyRow.minY, width: 0, height: emptyRow.height))
+            }
+        }
     }
 }

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -79,7 +79,6 @@ struct HostsEditor: NSViewRepresentable {
         if let storage = textView.textStorage, !storage.mutableString.isEqual(to: text) {
             textView.string = text
             Self.highlight(textView)
-            (scrollView.verticalRulerView as? HostsLineNumberRulerView)?.textDidReplace()
         }
         if documentChanged {
             textView.setSelectedRange(NSRange(location: 0, length: 0))
@@ -217,7 +216,10 @@ final class HostsTextView: NSTextView {
 final class HostsLineNumberRulerView: NSRulerView {
     private weak var textView: NSTextView?
     /// Cached: the draw runs on every scroll tick, and deriving the count there would copy and
-    /// scan the whole document per frame (#94). Recomputed only when the text changes.
+    /// scan the whole document per frame (#94). Recomputed only when characters change — observed
+    /// on the storage rather than through NSText.didChangeNotification, which undo does not post.
+    /// Read-only in didProcessEditing: the attribute-merging hazard noted at the top of the file
+    /// only concerns mutating the storage from there.
     private(set) var lineCount = 1
 
     init(scrollView: NSScrollView, textView: NSTextView) {
@@ -230,9 +232,9 @@ final class HostsLineNumberRulerView: NSRulerView {
         let center = NotificationCenter.default
         center.addObserver(
             self,
-            selector: #selector(textDidChange(_:)),
-            name: NSText.didChangeNotification,
-            object: textView
+            selector: #selector(storageDidProcessEditing(_:)),
+            name: NSTextStorage.didProcessEditingNotification,
+            object: textView.textStorage
         )
         center.addObserver(
             self,
@@ -246,13 +248,9 @@ final class HostsLineNumberRulerView: NSRulerView {
         fatalError("init(coder:) has not been implemented")
     }
 
-    /// For text swapped in without an edit notification (a document switch).
-    func textDidReplace() {
-        recountLines()
-        needsDisplay = true
-    }
-
-    @objc private func textDidChange(_ notification: Notification) {
+    @objc private func storageDidProcessEditing(_ notification: Notification) {
+        guard let storage = notification.object as? NSTextStorage,
+              storage.editedMask.contains(.editedCharacters) else { return } // highlighting only
         recountLines()
         needsDisplay = true
     }

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -226,7 +226,7 @@ final class HostsLineNumberRulerView: NSRulerView {
         super.init(scrollView: scrollView, orientation: .verticalRuler)
         clientView = textView
         ruleThickness = 40
-        recountLines()
+        rebuildLineStarts()
 
         let center = NotificationCenter.default
         center.addObserver(
@@ -250,7 +250,7 @@ final class HostsLineNumberRulerView: NSRulerView {
     @objc private func storageDidProcessEditing(_ notification: Notification) {
         guard let storage = notification.object as? NSTextStorage,
               storage.editedMask.contains(.editedCharacters) else { return } // highlighting only
-        recountLines()
+        rebuildLineStarts()
         needsDisplay = true
     }
 
@@ -259,7 +259,7 @@ final class HostsLineNumberRulerView: NSRulerView {
     }
 
     /// Finds newlines on the storage's mutable string proxy — UTF-16 search, no String bridge.
-    private func recountLines() {
+    private func rebuildLineStarts() {
         guard let storage = textView?.textStorage else { return }
         let string = storage.mutableString
         var starts = [0]
@@ -274,6 +274,17 @@ final class HostsLineNumberRulerView: NSRulerView {
             )
         }
         lineStarts = starts
+
+        // Sized here, not in draw: changing the thickness re-tiles the scroll view, and doing
+        // that mid-draw left the clip view scrolled sideways by the width difference.
+        let digits = max(2, String(lineCount).count)
+        let desiredThickness = max(40, CGFloat(digits * 8 + 16))
+        if ruleThickness != desiredThickness {
+            ruleThickness = desiredThickness
+            if let clipView = scrollView?.contentView {
+                clipView.scroll(to: NSPoint(x: 0, y: clipView.bounds.origin.y))
+            }
+        }
     }
 
     /// 1-based number of the file line containing the UTF-16 offset.
@@ -302,12 +313,6 @@ final class HostsLineNumberRulerView: NSRulerView {
               let contentManager = layoutManager.textContentManager
         else { return }
 
-        let digits = max(2, String(lineCount).count)
-        let desiredThickness = max(40, CGFloat(digits * 8 + 16))
-        if ruleThickness != desiredThickness {
-            ruleThickness = desiredThickness
-        }
-
         let paragraphStyle = NSMutableParagraphStyle()
         paragraphStyle.alignment = .right
         let attributes: [NSAttributedString.Key: Any] = [
@@ -319,17 +324,32 @@ final class HostsLineNumberRulerView: NSRulerView {
         let visibleRect = textView.visibleRect
         let documentStart = contentManager.documentRange.location
 
-        // Fragment frames are in text container coordinates; the ruler draws in its own.
-        func draw(_ number: Int, rowFrame: NSRect) {
-            let point = convert(NSPoint(x: 0, y: rowFrame.minY + origin.y), from: textView)
-            let labelRect = NSRect(x: 4, y: point.y, width: bounds.width - 10, height: rowFrame.height)
+        // Row geometry is in text container coordinates; the ruler draws in its own.
+        func draw(_ number: Int, rowY: CGFloat, rowHeight: CGFloat) {
+            let point = convert(NSPoint(x: 0, y: rowY + origin.y), from: textView)
+            let labelRect = NSRect(x: 4, y: point.y, width: bounds.width - 10, height: rowHeight)
             String(number).draw(in: labelRect, withAttributes: attributes)
+        }
+
+        guard let storage = textView.textStorage, storage.length > 0 else {
+            // An empty document has no fragments to walk, but still one line.
+            if let font = textView.font {
+                draw(1, rowY: 0, rowHeight: ceil(font.ascender - font.descender + font.leading))
+            }
+            return
         }
 
         // Walk only what the viewport controller has already laid out: asking for layout from
         // here (ensuresLayout / textLayoutFragment(for:)) cancels TextKit 2's idle estimation
         // of the document height, and the view then cannot scroll past the first screen.
-        guard let viewport = layoutManager.textViewportLayoutController.viewportRange else { return }
+        guard let viewport = layoutManager.textViewportLayoutController.viewportRange,
+              viewport.location.compare(layoutManager.documentRange.endLocation) == .orderedAscending
+        else {
+            // Nothing laid out yet (first frame, or a document just swapped in): come back
+            // once the viewport has been laid out, since no bounds change may follow.
+            DispatchQueue.main.async { [weak self] in self?.needsDisplay = true }
+            return
+        }
         var lastFragment: NSTextLayoutFragment?
         layoutManager.enumerateTextLayoutFragments(from: viewport.location, options: []) { fragment in
             let frame = fragment.layoutFragmentFrame
@@ -339,22 +359,20 @@ final class HostsLineNumberRulerView: NSRulerView {
             guard frame.maxY + origin.y > visibleRect.minY else { return true }
             let offset = contentManager.offset(from: documentStart, to: fragment.rangeInElement.location)
             // Only the first row of a wrapped line carries the number.
-            let firstRow = fragment.textLineFragments.first?.typographicBounds
-                ?? NSRect(origin: .zero, size: frame.size)
-            draw(lineNumber(at: offset), rowFrame: NSRect(x: 0, y: frame.minY, width: 0, height: firstRow.height))
+            let firstRowHeight = fragment.textLineFragments.first?.typographicBounds.height ?? frame.height
+            draw(lineNumber(at: offset), rowY: frame.minY, rowHeight: firstRowHeight)
             lastFragment = fragment
             return true
         }
 
         // A trailing newline opens an empty last line; TextKit 2 renders it as an extra line
         // fragment inside the last layout fragment rather than as a fragment of its own.
-        if let lastFragment, let storage = textView.textStorage,
-           storage.length > 0, storage.mutableString.hasSuffix("\n"),
+        if let lastFragment, storage.mutableString.hasSuffix("\n"),
            contentManager.offset(from: documentStart, to: lastFragment.rangeInElement.endLocation) == storage.length,
            let emptyRow = lastFragment.textLineFragments.last?.typographicBounds {
-            let frame = lastFragment.layoutFragmentFrame
-            if frame.minY + emptyRow.minY + origin.y < visibleRect.maxY {
-                draw(lineCount, rowFrame: NSRect(x: 0, y: frame.minY + emptyRow.minY, width: 0, height: emptyRow.height))
+            let rowY = lastFragment.layoutFragmentFrame.minY + emptyRow.minY
+            if rowY + origin.y < visibleRect.maxY {
+                draw(lineCount, rowY: rowY, rowHeight: emptyRow.height)
             }
         }
     }

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -80,3 +80,43 @@ extension HostsLineNumberRulerViewTests {
         XCTAssertEqual(ruler.lineNumber(at: 9), 4)
     }
 }
+
+extension HostsLineNumberRulerViewTests {
+    /// Lays the editor out in a window so the viewport controller has run.
+    private func makeLaidOutRuler(_ text: String, width: CGFloat) -> HostsLineNumberRulerView {
+        let (scrollView, textView, ruler) = makeRuler("")
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: width, height: 300),
+            styleMask: [.titled], backing: .buffered, defer: false
+        )
+        window.contentView = scrollView
+        scrollView.hasVerticalRuler = true
+        scrollView.rulersVisible = true
+        textView.string = text
+        window.contentView?.layoutSubtreeIfNeeded()
+        textView.display()
+        return ruler
+    }
+
+    func testLabelsNumberOnlyTheFirstRowOfAWrappedLine() throws {
+        let long = String(repeating: "x", count: 400)
+        let ruler = makeLaidOutRuler("a\n\(long)\nb", width: 300)
+        let labels = try XCTUnwrap(ruler.labels(in: NSRect(x: 0, y: 0, width: 300, height: 300)))
+        XCTAssertEqual(labels.map(\.line), [1, 2, 3])
+        // Line 3 sits below every wrapped row of line 2, more than one row further down.
+        XCTAssertGreaterThan(labels[2].y - labels[1].y, labels[1].height * 1.5)
+    }
+
+    func testLabelsIncludeTheTrailingEmptyLine() throws {
+        let ruler = makeLaidOutRuler("a\nb\n", width: 300)
+        let labels = try XCTUnwrap(ruler.labels(in: NSRect(x: 0, y: 0, width: 300, height: 300)))
+        XCTAssertEqual(labels.map(\.line), [1, 2, 3])
+        XCTAssertEqual(labels[2].y - labels[1].y, labels[1].height, accuracy: 0.5)
+    }
+
+    func testEmptyDocumentStillShowsLineOne() throws {
+        let ruler = makeLaidOutRuler("", width: 300)
+        let labels = try XCTUnwrap(ruler.labels(in: NSRect(x: 0, y: 0, width: 300, height: 300)))
+        XCTAssertEqual(labels.map(\.line), [1])
+    }
+}

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -67,3 +67,16 @@ final class HostsLineNumberRulerViewTests: XCTestCase {
         XCTAssertEqual(ruler.lineCount, 1)
     }
 }
+
+extension HostsLineNumberRulerViewTests {
+    func testLineNumberAtOffsetFollowsLineStarts() {
+        let (_, _, ruler) = makeRuler("ab\ncd\n\nef")
+        XCTAssertEqual(ruler.lineStarts, [0, 3, 6, 7])
+        XCTAssertEqual(ruler.lineNumber(at: 0), 1)
+        XCTAssertEqual(ruler.lineNumber(at: 2), 1)
+        XCTAssertEqual(ruler.lineNumber(at: 3), 2)
+        XCTAssertEqual(ruler.lineNumber(at: 6), 3)
+        XCTAssertEqual(ruler.lineNumber(at: 7), 4)
+        XCTAssertEqual(ruler.lineNumber(at: 9), 4)
+    }
+}

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -1,0 +1,43 @@
+import AppKit
+import XCTest
+@testable import Hostflip
+
+/// The line-number ruler caches its line count (#94): scrolling must never rescan the document.
+@MainActor
+final class HostsLineNumberRulerViewTests: XCTestCase {
+    private func makeRuler(_ text: String) -> (NSScrollView, HostsTextView, HostsLineNumberRulerView) {
+        let scrollView = HostsTextView.scrollableTextView()
+        let textView = scrollView.documentView as! HostsTextView
+        textView.string = text
+        let ruler = HostsLineNumberRulerView(scrollView: scrollView, textView: textView)
+        scrollView.verticalRulerView = ruler
+        scrollView.contentView.postsBoundsChangedNotifications = true
+        return (scrollView, textView, ruler)
+    }
+
+    func testCountsLinesLikeTheEditorDisplaysThem() {
+        XCTAssertEqual(makeRuler("").2.lineCount, 1)
+        XCTAssertEqual(makeRuler("a\nb").2.lineCount, 2)
+        XCTAssertEqual(makeRuler("a\nb\n").2.lineCount, 3)
+    }
+
+    func testBoundsChangeDoesNotRecount() {
+        let (scrollView, textView, ruler) = makeRuler("a\nb")
+        // Mutate the storage behind the ruler's back: a recount on scroll would see 4 lines.
+        textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 0), with: "x\ny\n")
+        NotificationCenter.default.post(
+            name: NSView.boundsDidChangeNotification, object: scrollView.contentView
+        )
+        XCTAssertEqual(ruler.lineCount, 2)
+    }
+
+    func testEditsAndDocumentSwapsRecount() {
+        let (_, textView, ruler) = makeRuler("a\nb")
+        textView.insertText("c\n", replacementRange: NSRange(location: 0, length: 0))
+        XCTAssertEqual(ruler.lineCount, 3)
+
+        textView.string = "one"
+        ruler.textDidReplace()
+        XCTAssertEqual(ruler.lineCount, 1)
+    }
+}

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -5,6 +5,13 @@ import XCTest
 /// The line-number ruler caches its line count (#94): scrolling must never rescan the document.
 @MainActor
 final class HostsLineNumberRulerViewTests: XCTestCase {
+    @MainActor
+    private final class UndoDelegate: NSObject, NSTextViewDelegate {
+        let undoManager: UndoManager
+        init(undoManager: UndoManager) { self.undoManager = undoManager }
+        func undoManager(for view: NSTextView) -> UndoManager? { undoManager }
+    }
+
     private func makeRuler(_ text: String) -> (NSScrollView, HostsTextView, HostsLineNumberRulerView) {
         let scrollView = HostsTextView.scrollableTextView()
         let textView = scrollView.documentView as! HostsTextView
@@ -21,23 +28,42 @@ final class HostsLineNumberRulerViewTests: XCTestCase {
         XCTAssertEqual(makeRuler("a\nb\n").2.lineCount, 3)
     }
 
-    func testBoundsChangeDoesNotRecount() {
+    /// The bounds observer only marks the ruler dirty; it never touches the storage.
+    func testBoundsChangeObserverDoesNotRecount() {
         let (scrollView, textView, ruler) = makeRuler("a\nb")
-        // Mutate the storage behind the ruler's back: a recount on scroll would see 4 lines.
-        textView.textStorage?.replaceCharacters(in: NSRange(location: 0, length: 0), with: "x\ny\n")
+        // Deafen the ruler to edits, then mutate: a recount on the scroll path would see 4 lines.
+        NotificationCenter.default.removeObserver(
+            ruler, name: NSTextStorage.didProcessEditingNotification, object: nil
+        )
+        textView.textStorage?.mutableString.setString("x\ny\na\nb")
         NotificationCenter.default.post(
             name: NSView.boundsDidChangeNotification, object: scrollView.contentView
         )
         XCTAssertEqual(ruler.lineCount, 2)
     }
 
-    func testEditsAndDocumentSwapsRecount() {
+    func testEditsUndoToggleCommentAndDocumentSwapsRecount() {
         let (_, textView, ruler) = makeRuler("a\nb")
+        let undoManager = UndoManager()
+        let delegate = UndoDelegate(undoManager: undoManager)
+        textView.delegate = delegate
+        textView.allowsUndo = true
+
         textView.insertText("c\n", replacementRange: NSRange(location: 0, length: 0))
         XCTAssertEqual(ruler.lineCount, 3)
+        textView.breakUndoCoalescing()
+        undoManager.undo()
+        XCTAssertEqual(textView.string, "a\nb")
+        XCTAssertEqual(ruler.lineCount, 2)
 
-        textView.string = "one"
-        ruler.textDidReplace()
+        textView.setSelectedRange(NSRange(location: 0, length: 3))
+        textView.toggleComment(nil)
+        XCTAssertEqual(textView.string, "# a\n# b")
+        XCTAssertEqual(ruler.lineCount, 2)
+        textView.insertText("\n", replacementRange: NSRange(location: 0, length: 0))
+        XCTAssertEqual(ruler.lineCount, 3)
+
+        textView.string = "one" // a document switch assigns the string without an edit notification
         XCTAssertEqual(ruler.lineCount, 1)
     }
 }


### PR DESCRIPTION
Switching to and scrolling a very large Remote Profile (e.g. the StevenBlack unified hosts, ~90k lines) stalled for seconds and stuttered on every scroll tick.

**Root cause.** The editor turned soft wrapping off (`widthTracksTextView = false`) to get a horizontal scroller; in that configuration TextKit 2 lays out the whole document up front instead of the viewport. Measured on a 90k-line file: 2.3 s to switch in and ~12 ms per scroll step, versus 0.2 s and ~1 ms with viewport layout.

**Fix.**
- Soft wrapping stays on, so TextKit 2 keeps to viewport layout. Long lines now wrap instead of scrolling horizontally — hosts lines are short, so this rarely shows.
- The line-number gutter walks the laid-out viewport fragments and maps wrapped rows back to file lines through cached UTF-16 line starts; only the first row of a wrapped line is numbered, and the trailing empty line still gets its number. It never asks TextKit for layout from the draw path, which would cancel the idle height estimation and leave the view unable to scroll.
- The gutter's line starts are cached and rebuilt on storage edits (including undo and in-place document switches) rather than on every scroll tick, and its width is adjusted outside the draw pass.
- The SwiftUI write-back guard compares through the storage's string proxy instead of bridging the whole document on every update.

Verified on device with the StevenBlack list: instant switch-in, smooth scrolling to the end, correct numbering after edits, undo, Toggle Comment, and large ↔ small profile switches.
