### PR TITLE
feat: flag incomplete hosts lines in the editor gutter

### DIFF
--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -296,3 +296,4 @@
 
 /* Editor */
 "Toggle Comment" = "コメントを切り替え";
+"This line has a single field; every entry needs an IP address and at least one hostname." = "この行はフィールドが 1 つしかありません。各エントリには IP アドレスと 1 つ以上のホスト名が必要です。";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -296,3 +296,4 @@
 
 /* Editor */
 "Toggle Comment" = "切换注释";
+"This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一个字段；每条记录都需要一个 IP 地址和至少一个主机名。";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -296,3 +296,4 @@
 
 /* Editor */
 "Toggle Comment" = "切換註解";
+"This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一個欄位；每筆項目都需要一個 IP 位址和至少一個主機名稱。";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -296,4 +296,4 @@
 
 /* Editor */
 "Toggle Comment" = "切換註解";
-"This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一個欄位；每筆項目都需要一個 IP 位址和至少一個主機名稱。";
+"This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一個欄位；每個項目都需要一個 IP 位址和至少一個主機名稱。";

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -220,6 +220,13 @@ final class HostsLineNumberRulerView: NSRulerView {
     /// storage from there.
     private(set) var lineStarts: [Int] = [0]
     var lineCount: Int { lineStarts.count }
+    /// 1-based numbers of structurally incomplete lines (#87), rebuilt with `lineStarts`.
+    /// The gutter only warns — saving and merging are untouched; the CLI's `write` is the
+    /// one that refuses such content.
+    private(set) var incompleteLines: Set<Int> = []
+    static let incompleteLineTooltip = String(
+        localized: "This line has a single field; every entry needs an IP address and at least one hostname."
+    )
 
     init(scrollView: NSScrollView, textView: NSTextView) {
         self.textView = textView
@@ -227,6 +234,7 @@ final class HostsLineNumberRulerView: NSRulerView {
         clientView = textView
         ruleThickness = 40
         rebuildLineStarts()
+        addToolTip(bounds, owner: self, userData: nil)
 
         let center = NotificationCenter.default
         center.addObserver(
@@ -274,6 +282,7 @@ final class HostsLineNumberRulerView: NSRulerView {
             )
         }
         lineStarts = starts
+        incompleteLines = Set(HostsSyntax.incompleteLines(in: string as String))
 
         // Sized here, not in draw: changing the thickness re-tiles the scroll view, and doing
         // that mid-draw left the clip view scrolled sideways by the width difference.
@@ -295,6 +304,24 @@ final class HostsLineNumberRulerView: NSRulerView {
             if lineStarts[mid] <= offset { low = mid } else { high = mid - 1 }
         }
         return low + 1
+    }
+
+    override func setFrameSize(_ newSize: NSSize) {
+        super.setFrameSize(newSize)
+        removeAllToolTips()
+        addToolTip(bounds, owner: self, userData: nil)
+    }
+
+    /// NSViewToolTipOwner: the tooltip is served per row, only markers explain themselves.
+    @objc func view(
+        _ view: NSView, stringForToolTip tag: NSView.ToolTipTag, point: NSPoint, userData: UnsafeMutableRawPointer?
+    ) -> String {
+        guard let textView, let labels = labels(in: textView.visibleRect) else { return "" }
+        let y = convert(point, to: textView).y
+        guard let label = labels.first(where: { $0.y <= y && y < $0.y + $0.height }),
+              incompleteLines.contains(label.line)
+        else { return "" }
+        return Self.incompleteLineTooltip
     }
 
     override func draw(_ dirtyRect: NSRect) {
@@ -380,10 +407,25 @@ final class HostsLineNumberRulerView: NSRulerView {
             .foregroundColor: NSColor.tertiaryLabelColor,
             .paragraphStyle: paragraphStyle,
         ]
+        let marker = NSImage(systemSymbolName: "exclamationmark.triangle.fill", accessibilityDescription: nil)?
+            .withSymbolConfiguration(
+                NSImage.SymbolConfiguration(pointSize: 9, weight: .bold)
+                    .applying(.init(paletteColors: [.systemYellow]))
+            )
         for label in labels {
             let point = convert(NSPoint(x: 0, y: label.y), from: textView)
             let labelRect = NSRect(x: 4, y: point.y, width: bounds.width - 10, height: label.height)
             String(label.line).draw(in: labelRect, withAttributes: attributes)
+            if incompleteLines.contains(label.line), let marker {
+                let size = marker.size
+                let markerRect = NSRect(
+                    x: 3, y: point.y + (label.height - size.height) / 2, width: size.width, height: size.height
+                )
+                marker.draw(
+                    in: markerRect, from: .zero, operation: .sourceOver, fraction: 1,
+                    respectFlipped: true, hints: nil
+                )
+            }
         }
     }
 }

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -282,12 +282,15 @@ final class HostsLineNumberRulerView: NSRulerView {
             )
         }
         lineStarts = starts
+        // Bridges the document once per character edit — the same order of work as the
+        // highlighting pass, and large Remote Profiles are read-only, so this runs on load only.
         incompleteLines = Set(HostsSyntax.incompleteLines(in: string as String))
 
         // Sized here, not in draw: changing the thickness re-tiles the scroll view, and doing
         // that mid-draw left the clip view scrolled sideways by the width difference.
+        // Digits right-aligned, plus a marker column on the left (#87).
         let digits = max(2, String(lineCount).count)
-        let desiredThickness = max(40, CGFloat(digits * 8 + 16))
+        let desiredThickness = max(40, CGFloat(digits * 7 + 24))
         if ruleThickness != desiredThickness {
             ruleThickness = desiredThickness
             if let clipView = scrollView?.contentView {

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -266,20 +266,21 @@ final class HostsLineNumberRulerView: NSRulerView {
         needsDisplay = true
     }
 
-    /// Finds newlines on the storage's mutable string proxy — UTF-16 search, no String bridge.
+    /// Walks the storage's mutable string proxy with NSString's line API — UTF-16, no String
+    /// bridge, and the same line breaks as HostsSyntax (.byLines) and TextKit 2 paragraphs,
+    /// so a bare CR counts as a line here too.
     private func rebuildLineStarts() {
         guard let storage = textView?.textStorage else { return }
         let string = storage.mutableString
         var starts = [0]
-        var searchRange = NSRange(location: 0, length: string.length)
-        while true {
-            let found = string.range(of: "\n", options: [.literal], range: searchRange)
-            if found.location == NSNotFound { break }
-            starts.append(NSMaxRange(found))
-            searchRange = NSRange(
-                location: NSMaxRange(found),
-                length: string.length - NSMaxRange(found)
-            )
+        var position = 0
+        while position < string.length {
+            var end = 0, contentsEnd = 0
+            string.getLineStart(nil, end: &end, contentsEnd: &contentsEnd, for: NSRange(location: position, length: 0))
+            if contentsEnd < end { // a terminator opens the next line, even an empty trailing one
+                starts.append(end)
+            }
+            position = end
         }
         lineStarts = starts
         // Bridges the document once per character edit — the same order of work as the

--- a/Sources/HostflipCLI/WriteCommand.swift
+++ b/Sources/HostflipCLI/WriteCommand.swift
@@ -47,6 +47,8 @@ enum WriteCommand {
             )
         }
         let content = try readContent(filePath: filePath, readStandardInput: readStandardInput)
+        // Deliberate GUI/CLI asymmetry (#87): the editor only flags incomplete lines in its
+        // gutter and keeps saving, while a script should fail loudly. Do not align the two.
         if let line = HostsSyntax.firstIncompleteLine(in: content) {
             throw CLIError(
                 code: "invalid-hosts-syntax",

--- a/Sources/HostflipCore/HostsSyntax.swift
+++ b/Sources/HostflipCore/HostsSyntax.swift
@@ -62,9 +62,24 @@ public enum HostsSyntax {
     /// values stay unvalidated, matching the tokenizer. Returns the 1-based number of the first
     /// incomplete line; nil when every line is blank, comment-only, or a full entry.
     public static func firstIncompleteLine(in text: String) -> Int? {
+        var first: Int?
+        enumerateIncompleteLines(in: text) { line, stop in
+            first = line
+            stop = true
+        }
+        return first
+    }
+
+    /// Every incomplete line, 1-based, on the rule of `firstIncompleteLine` (#87).
+    public static func incompleteLines(in text: String) -> [Int] {
+        var lines: [Int] = []
+        enumerateIncompleteLines(in: text) { line, _ in lines.append(line) }
+        return lines
+    }
+
+    private static func enumerateIncompleteLines(in text: String, _ body: @escaping (Int, inout Bool) -> Void) {
         let ns = text as NSString
         var lineNumber = 0
-        var incompleteLine: Int?
         ns.enumerateSubstrings(
             in: NSRange(location: 0, length: ns.length),
             options: [.byLines, .substringNotRequired]
@@ -76,11 +91,11 @@ public enum HostsSyntax {
                 codeRange.length = hash.location - lineRange.location
             }
             if fieldPattern.numberOfMatches(in: text, options: [], range: codeRange) == 1 {
-                incompleteLine = lineNumber
-                stop.pointee = true
+                var shouldStop = false
+                body(lineNumber, &shouldStop)
+                if shouldStop { stop.pointee = true }
             }
         }
-        return incompleteLine
     }
 }
 

--- a/Tests/HostflipCoreTests/HostsSyntaxTests.swift
+++ b/Tests/HostflipCoreTests/HostsSyntaxTests.swift
@@ -108,3 +108,26 @@ final class HostsSyntaxTests: XCTestCase {
         XCTAssertNil(HostsSyntax.firstIncompleteLine(in: "not-an-ip some-host"))
     }
 }
+
+/// Every incomplete line (#87): the editor gutter flags all of them on the rule
+/// `firstIncompleteLine` enforces for the CLI.
+extension HostsSyntaxTests {
+    func testIncompleteLinesListsEveryOffendingLine() {
+        XCTAssertEqual(
+            HostsSyntax.incompleteLines(in: "stray\n1.1.1.1 a\n\n# note\n127.0.0.1 # tbd\nstray-again"),
+            [1, 5, 6]
+        )
+    }
+
+    func testIncompleteLinesIsEmptyForBlankCommentOnlyAndCompleteContent() {
+        XCTAssertEqual(HostsSyntax.incompleteLines(in: ""), [])
+        XCTAssertEqual(HostsSyntax.incompleteLines(in: "\n\n# only comments\n"), [])
+        XCTAssertEqual(HostsSyntax.incompleteLines(in: "0.0.0.0 a b\n::1 c # d"), [])
+    }
+
+    func testIncompleteLinesAgreesWithFirstIncompleteLine() {
+        for text in ["stray\n1.1.1.1 a\nstray again\n", "1.1.1.1 a", "", "127.0.0.1"] {
+            XCTAssertEqual(HostsSyntax.incompleteLines(in: text).first, HostsSyntax.firstIncompleteLine(in: text), text)
+        }
+    }
+}

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -26,6 +26,9 @@ final class HostsLineNumberRulerViewTests: XCTestCase {
         XCTAssertEqual(makeRuler("").2.lineCount, 1)
         XCTAssertEqual(makeRuler("a\nb").2.lineCount, 2)
         XCTAssertEqual(makeRuler("a\nb\n").2.lineCount, 3)
+        // Every terminator TextKit 2 and HostsSyntax split on counts, not only LF.
+        XCTAssertEqual(makeRuler("a\rb\r\nc\u{2028}d").2.lineStarts, [0, 2, 5, 7])
+        XCTAssertEqual(makeRuler("a\r").2.lineStarts, [0, 2])
     }
 
     /// The bounds observer only marks the ruler dirty; it never touches the storage.

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -120,3 +120,30 @@ extension HostsLineNumberRulerViewTests {
         XCTAssertEqual(labels.map(\.line), [1])
     }
 }
+
+extension HostsLineNumberRulerViewTests {
+    func testIncompleteLinesFollowEdits() {
+        let (_, textView, ruler) = makeRuler("127.0.0.1\n# note\n1.1.1.1 a")
+        XCTAssertEqual(ruler.incompleteLines, [1])
+        textView.insertText(" app.test", replacementRange: NSRange(location: 9, length: 0))
+        XCTAssertEqual(ruler.incompleteLines, [])
+        textView.insertText("\nstray", replacementRange: NSRange(location: (textView.string as NSString).length, length: 0))
+        XCTAssertEqual(ruler.incompleteLines, [4])
+        textView.string = "fresh document"
+        XCTAssertEqual(ruler.incompleteLines, [])
+    }
+
+    func testTooltipIsServedOnlyOnFlaggedRows() throws {
+        let ruler = makeLaidOutRuler("1.1.1.1 a\n127.0.0.1\n", width: 300)
+        let textView = try XCTUnwrap(ruler.clientView as? NSTextView)
+        let labels = try XCTUnwrap(ruler.labels(in: textView.visibleRect))
+        func tooltip(onLine line: Int) -> String {
+            let label = labels.first { $0.line == line }!
+            let point = ruler.convert(NSPoint(x: 0, y: label.y + label.height / 2), from: textView)
+            return ruler.view(ruler, stringForToolTip: 0, point: point, userData: nil)
+        }
+        XCTAssertEqual(tooltip(onLine: 1), "")
+        XCTAssertEqual(tooltip(onLine: 2), HostsLineNumberRulerView.incompleteLineTooltip)
+        XCTAssertEqual(tooltip(onLine: 3), "")
+    }
+}

--- a/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
+++ b/Tests/HostflipTests/HostsLineNumberRulerViewTests.swift
@@ -129,6 +129,8 @@ extension HostsLineNumberRulerViewTests {
         XCTAssertEqual(ruler.incompleteLines, [])
         textView.insertText("\nstray", replacementRange: NSRange(location: (textView.string as NSString).length, length: 0))
         XCTAssertEqual(ruler.incompleteLines, [4])
+        textView.insertText("# ", replacementRange: NSRange(location: (textView.string as NSString).length - 5, length: 0))
+        XCTAssertEqual(ruler.incompleteLines, [])
         textView.string = "fresh document"
         XCTAssertEqual(ruler.incompleteLines, [])
     }


### PR DESCRIPTION
A non-comment hosts line with a single field — an IP without a hostname, or a lone word — cannot be a complete entry. The CLI's `write` already refuses such content; the editor now flags it instead of staying silent.

- Every incomplete line gets a warning marker in the line-number gutter, with a tooltip explaining the rule (localized: ja / zh-Hans / zh-Hant).
- Markers update as the text changes, including undo and document switches, and show for read-only documents too (Base Hosts, Remote Profiles) — a remote source can ship broken lines.
- Saving and merging are untouched: the GUI warns while a script fails loudly, on purpose (noted where the CLI refusal lives).
- Diagnostics are structural only: no IP/hostname validation, no duplicate detection.
- The gutter now splits lines on every terminator NSString recognizes (CR, CRLF, Unicode separators), matching the syntax rules and TextKit 2 paragraphs, and reserves a column for the marker so three-digit line numbers stay clear of it.

Verified on device: marker appears for a lone `127.0.0.1`, clears on completing or commenting the line, tooltip follows the system language, no stale markers across profile switches, saving/merging unchanged.
