### PR TITLE
feat: search every profile from the sidebar

### DIFF
--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -299,7 +299,7 @@
 "This line has a single field; every entry needs an IP address and at least one hostname." = "この行はフィールドが 1 つしかありません。各エントリには IP アドレスと 1 つ以上のホスト名が必要です。";
 
 /* Global search */
-"Search all profiles" = "すべてのプロファイルを検索";
+"Search" = "検索";
 "Find in All Profiles…" = "すべてのプロファイルから検索…";
 "No Matches" = "一致なし";
 "Line %lld" = "%lld 行目";

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -300,6 +300,6 @@
 
 /* Global search */
 "Search" = "検索";
-"Find in All Profiles…" = "すべてのプロファイルから検索…";
-"No Matches" = "一致なし";
+"Find in All Profiles…" = "すべてのプロファイル内を検索…";
+"No Matches" = "一致する項目はありません";
 "Line %lld" = "%lld 行目";

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -297,3 +297,9 @@
 /* Editor */
 "Toggle Comment" = "コメントを切り替え";
 "This line has a single field; every entry needs an IP address and at least one hostname." = "この行はフィールドが 1 つしかありません。各エントリには IP アドレスと 1 つ以上のホスト名が必要です。";
+
+/* Global search */
+"Search all profiles" = "すべてのプロファイルを検索";
+"Find in All Profiles…" = "すべてのプロファイルから検索…";
+"No Matches" = "一致なし";
+"Line %lld" = "%lld 行目";

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -303,3 +303,4 @@
 "Find in All Profiles…" = "すべてのプロファイル内を検索…";
 "No Matches" = "一致する項目はありません";
 "Line %lld" = "%lld 行目";
+"%lld more matches not shown" = "他 %lld 件は表示されていません";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -299,7 +299,7 @@
 "This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一个字段；每条记录都需要一个 IP 地址和至少一个主机名。";
 
 /* Global search */
-"Search all profiles" = "搜索所有方案";
+"Search" = "搜索";
 "Find in All Profiles…" = "在所有方案中查找…";
 "No Matches" = "无匹配";
 "Line %lld" = "第 %lld 行";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -303,3 +303,4 @@
 "Find in All Profiles…" = "在所有方案中查找…";
 "No Matches" = "无匹配项";
 "Line %lld" = "第 %lld 行";
+"%lld more matches not shown" = "还有 %lld 条匹配未显示";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -301,5 +301,5 @@
 /* Global search */
 "Search" = "搜索";
 "Find in All Profiles…" = "在所有方案中查找…";
-"No Matches" = "无匹配";
+"No Matches" = "无匹配项";
 "Line %lld" = "第 %lld 行";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -297,3 +297,9 @@
 /* Editor */
 "Toggle Comment" = "切换注释";
 "This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一个字段；每条记录都需要一个 IP 地址和至少一个主机名。";
+
+/* Global search */
+"Search all profiles" = "搜索所有方案";
+"Find in All Profiles…" = "在所有方案中查找…";
+"No Matches" = "无匹配";
+"Line %lld" = "第 %lld 行";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -297,3 +297,9 @@
 /* Editor */
 "Toggle Comment" = "切換註解";
 "This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一個欄位；每個項目都需要一個 IP 位址和至少一個主機名稱。";
+
+/* Global search */
+"Search all profiles" = "搜尋所有方案";
+"Find in All Profiles…" = "在所有方案中尋找…";
+"No Matches" = "沒有相符項目";
+"Line %lld" = "第 %lld 行";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -303,3 +303,4 @@
 "Find in All Profiles…" = "在所有方案中尋找…";
 "No Matches" = "沒有相符項目";
 "Line %lld" = "第 %lld 行";
+"%lld more matches not shown" = "還有 %lld 筆相符項目未顯示";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -299,7 +299,7 @@
 "This line has a single field; every entry needs an IP address and at least one hostname." = "此行只有一個欄位；每個項目都需要一個 IP 位址和至少一個主機名稱。";
 
 /* Global search */
-"Search all profiles" = "搜尋所有方案";
+"Search" = "搜尋";
 "Find in All Profiles…" = "在所有方案中尋找…";
 "No Matches" = "沒有相符項目";
 "Line %lld" = "第 %lld 行";

--- a/Sources/Hostflip/GlobalSearchResults.swift
+++ b/Sources/Hostflip/GlobalSearchResults.swift
@@ -40,9 +40,14 @@ struct GlobalSearchResults: Equatable {
 
     struct DocumentResult: Equatable, Identifiable {
         let document: Document
+        /// At most `matchLimit` rows: a one-letter query hits tens of thousands of lines in a
+        /// big Remote Profile, and diffing that many rows per keystroke froze typing.
         let matches: [Match]
+        let hiddenMatchCount: Int
         var id: MainWindowView.SidebarItem { document.item }
     }
+
+    static let matchLimit = 100
 
     /// The trimmed query these results answer.
     let query: String
@@ -56,14 +61,16 @@ struct GlobalSearchResults: Equatable {
             let hits = HostsSearch.matches(in: document.content, query: query)
             guard !hits.isEmpty else { return nil }
             let ns = document.content as NSString
-            return DocumentResult(document: document, matches: hits.map { hit in
+            let shown = hits.prefix(Self.matchLimit)
+            let matches = shown.map { hit -> Match in
                 let raw = ns.substring(with: hit.lineRange) as NSString
                 let firstNonBlank = raw.rangeOfCharacter(from: CharacterSet.whitespaces.inverted).location
                 let leading = firstNonBlank == NSNotFound ? 0 : firstNonBlank
                 let lineText = raw.trimmingCharacters(in: .whitespaces)
                 let matchOffset = hit.matchRange.location - hit.lineRange.location - leading
                 return Match(hit: hit, lineText: lineText, matchOffsetInLine: matchOffset)
-            })
+            }
+            return DocumentResult(document: document, matches: matches, hiddenMatchCount: hits.count - shown.count)
         }
     }
 }

--- a/Sources/Hostflip/GlobalSearchResults.swift
+++ b/Sources/Hostflip/GlobalSearchResults.swift
@@ -47,7 +47,6 @@ struct GlobalSearchResults: Equatable {
     /// The trimmed query these results answer.
     let query: String
     let results: [DocumentResult]
-    var matchCount: Int { results.reduce(0) { $0 + $1.matches.count } }
 
     static let empty = GlobalSearchResults(documents: [], query: "")
 

--- a/Sources/Hostflip/GlobalSearchResults.swift
+++ b/Sources/Hostflip/GlobalSearchResults.swift
@@ -28,7 +28,10 @@ struct GlobalSearchResults: Equatable {
             self.lineText = lineText
             var shown = lineText
             if matchOffsetInLine > Self.foldThreshold {
-                shown = "…" + (lineText as NSString).substring(from: max(0, matchOffsetInLine - Self.contextLength))
+                let ns = lineText as NSString
+                // Snap to a character boundary so the fold never splits a surrogate pair.
+                let start = ns.rangeOfComposedCharacterSequence(at: matchOffsetInLine - Self.contextLength).location
+                shown = "…" + ns.substring(from: start)
             }
             // Column alignment whitespace is noise in a one-line row.
             displayText = shown.split(whereSeparator: \.isWhitespace).joined(separator: " ")
@@ -41,10 +44,15 @@ struct GlobalSearchResults: Equatable {
         var id: MainWindowView.SidebarItem { document.item }
     }
 
+    /// The trimmed query these results answer.
+    let query: String
     let results: [DocumentResult]
     var matchCount: Int { results.reduce(0) { $0 + $1.matches.count } }
 
+    static let empty = GlobalSearchResults(documents: [], query: "")
+
     init(documents: [Document], query: String) {
+        self.query = query.trimmingCharacters(in: .whitespacesAndNewlines)
         results = documents.compactMap { document in
             let hits = HostsSearch.matches(in: document.content, query: query)
             guard !hits.isEmpty else { return nil }

--- a/Sources/Hostflip/GlobalSearchResults.swift
+++ b/Sources/Hostflip/GlobalSearchResults.swift
@@ -1,0 +1,62 @@
+import Foundation
+import HostflipCore
+
+/// Global search across the workspace (#88): every document with at least one matching line,
+/// in sidebar order — Base Hosts first, then standalone profiles, then each group's profiles.
+struct GlobalSearchResults: Equatable {
+    struct Document: Equatable {
+        let item: MainWindowView.SidebarItem
+        let name: String
+        let content: String
+        /// Nil for Base Hosts, which is always applied.
+        let isActive: Bool?
+    }
+
+    struct Match: Equatable, Identifiable {
+        let hit: HostsSearch.Hit
+        let lineText: String
+        /// The line as the narrow sidebar row shows it: matches usually sit in the hostname at
+        /// the end of a mapping, so a long prefix folds into "…" plus a little context.
+        let displayText: String
+        var id: Int { hit.line }
+
+        static let contextLength = 3
+        static let foldThreshold = 12
+
+        init(hit: HostsSearch.Hit, lineText: String, matchOffsetInLine: Int) {
+            self.hit = hit
+            self.lineText = lineText
+            var shown = lineText
+            if matchOffsetInLine > Self.foldThreshold {
+                shown = "…" + (lineText as NSString).substring(from: max(0, matchOffsetInLine - Self.contextLength))
+            }
+            // Column alignment whitespace is noise in a one-line row.
+            displayText = shown.split(whereSeparator: \.isWhitespace).joined(separator: " ")
+        }
+    }
+
+    struct DocumentResult: Equatable, Identifiable {
+        let document: Document
+        let matches: [Match]
+        var id: MainWindowView.SidebarItem { document.item }
+    }
+
+    let results: [DocumentResult]
+    var matchCount: Int { results.reduce(0) { $0 + $1.matches.count } }
+
+    init(documents: [Document], query: String) {
+        results = documents.compactMap { document in
+            let hits = HostsSearch.matches(in: document.content, query: query)
+            guard !hits.isEmpty else { return nil }
+            let ns = document.content as NSString
+            return DocumentResult(document: document, matches: hits.map { hit in
+                let raw = ns.substring(with: hit.lineRange) as NSString
+                let firstNonBlank = raw.rangeOfCharacter(from: CharacterSet.whitespaces.inverted).location
+                let leading = firstNonBlank == NSNotFound ? 0 : firstNonBlank
+                let lineText = raw.trimmingCharacters(in: .whitespaces)
+                let matchOffset = hit.matchRange.location - hit.lineRange.location - leading
+                return Match(hit: hit, lineText: lineText, matchOffsetInLine: matchOffset)
+            })
+        }
+    }
+}

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -89,6 +89,7 @@ struct HostflipApp: App {
             ImportExportCommands(store: store)
             RemoteRefreshCommands(store: store)
             EditorCommands()
+            SearchCommands()
         }
 
         Settings {

--- a/Sources/Hostflip/HostsEditor.swift
+++ b/Sources/Hostflip/HostsEditor.swift
@@ -15,6 +15,9 @@ struct HostsEditor: NSViewRepresentable {
     /// system, which would flash a zero-sized editor for a frame); a change of identity resets
     /// the per-document view state: undo stack, selection, scroll position, and the find bar.
     var documentID: AnyHashable = "single-document"
+    /// A one-shot request to select and show a range (global search, #88); a new `id` fires
+    /// it again even for the same range.
+    var reveal: EditorReveal?
 
     func makeNSView(context: Context) -> NSScrollView {
         let scrollView = HostsTextView.scrollableTextView()
@@ -80,6 +83,12 @@ struct HostsEditor: NSViewRepresentable {
             textView.setSelectedRange(NSRange(location: 0, length: 0))
             textView.scroll(.zero)
         }
+        if let reveal, reveal.id != context.coordinator.revealedID {
+            context.coordinator.revealedID = reveal.id
+            let range = NSIntersectionRange(reveal.range, NSRange(location: 0, length: (textView.string as NSString).length))
+            textView.setSelectedRange(range)
+            textView.scrollRangeToVisible(range)
+        }
     }
 
     func makeCoordinator() -> Coordinator {
@@ -90,6 +99,7 @@ struct HostsEditor: NSViewRepresentable {
     final class Coordinator: NSObject, NSTextViewDelegate {
         var text: Binding<String>
         var documentID: AnyHashable
+        var revealedID: UUID?
         /// Dedicated undo manager so clearing it on a document switch cannot touch
         /// undo state registered elsewhere in the window (e.g. the name field).
         let textUndoManager = UndoManager()
@@ -136,6 +146,11 @@ struct HostsEditor: NSViewRepresentable {
         case .hostname: .systemTeal
         }
     }
+}
+
+struct EditorReveal: Equatable {
+    let id: UUID
+    let range: NSRange
 }
 
 /// Whether an editable hosts editor currently holds keyboard focus (#86). The text view

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -396,6 +396,14 @@ struct MainWindowView: View {
         isSearching ? SearchRequest(query: searchQuery, documents: searchDocuments) : nil
     }
 
+    private static func findSearchField(in view: NSView) -> NSSearchField? {
+        if let field = view as? NSSearchField { return field }
+        for subview in view.subviews {
+            if let field = findSearchField(in: subview) { return field }
+        }
+        return nil
+    }
+
     /// Jumps to the matching line: the shared editor swaps the document, then reveals the range.
     private func showSearchMatch(_ result: GlobalSearchResults.DocumentResult, _ match: GlobalSearchResults.Match) {
         selection = result.document.item
@@ -514,7 +522,15 @@ struct MainWindowView: View {
             prompt: Text("Search")
         )
         .onReceive(NotificationCenter.default.publisher(for: .hostflipFindInAllProfiles)) { _ in
-            searchPresented = true
+            // A presented field can have lost focus, and re-presenting is a no-op for SwiftUI
+            // (macOS 15's searchFocused is out of reach), so focus the AppKit field directly.
+            guard searchPresented else {
+                searchPresented = true
+                return
+            }
+            if let window = NSApp.keyWindow, let field = window.contentView.flatMap(Self.findSearchField) {
+                window.makeFirstResponder(field)
+            }
         }
         .task(id: searchRequest) {
             guard let request = searchRequest else {

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -440,6 +440,11 @@ struct MainWindowView: View {
                     }
                     .buttonStyle(.plain)
                 }
+                if result.hiddenMatchCount > 0 {
+                    Text("\(result.hiddenMatchCount) more matches not shown")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
             } header: {
                 HStack(spacing: 6) {
                     Text(result.document.name)

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -182,6 +182,9 @@ struct MainWindowView: View {
     let store: WorkspaceStore
     let maintenanceStore: MaintenanceStore
     @State private var selection: SidebarItem? = .baseHosts
+    @State private var searchQuery = ""
+    @State private var searchPresented = false
+    @State private var editorReveal: EditorReveal?
     /// The profile pending deletion confirmation; a non-nil value shows the confirmation dialog.
     @State private var profilePendingDeletion: Profile?
     @State private var profilePendingNameFocus: Profile.ID?
@@ -364,8 +367,72 @@ struct MainWindowView: View {
         }
     }
 
-    private var sidebar: some View {
-        List(selection: $selection) {
+    private var isSearching: Bool {
+        !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var searchResults: GlobalSearchResults {
+        var documents = [GlobalSearchResults.Document(
+            item: .baseHosts, name: String(localized: "Base Hosts"), content: store.baseHostsContent, isActive: nil
+        )]
+        let profiles = store.standaloneProfiles + store.groups.flatMap(\.profiles)
+        documents += profiles.map {
+            GlobalSearchResults.Document(item: .profile($0.id), name: $0.name, content: $0.content, isActive: store.isActive($0.id))
+        }
+        return GlobalSearchResults(documents: documents, query: searchQuery)
+    }
+
+    /// Jumps to the matching line: the shared editor swaps the document, then reveals the range.
+    private func showSearchMatch(_ result: GlobalSearchResults.DocumentResult, _ match: GlobalSearchResults.Match) {
+        selection = result.document.item
+        editorReveal = EditorReveal(id: UUID(), range: match.hit.lineRange)
+    }
+
+    @ViewBuilder
+    private var searchResultRows: some View {
+        let results = searchResults
+        if results.results.isEmpty {
+            Text("No Matches")
+                .foregroundStyle(.secondary)
+                .frame(maxWidth: .infinity, alignment: .center)
+                .padding(.vertical, 12)
+        }
+        ForEach(results.results) { result in
+            Section {
+                ForEach(result.matches) { match in
+                    Button {
+                        showSearchMatch(result, match)
+                    } label: {
+                        HStack(alignment: .firstTextBaseline, spacing: 6) {
+                            Text(match.displayText)
+                                .font(.system(.body, design: .monospaced))
+                                .lineLimit(1)
+                                .truncationMode(.tail)
+                            Spacer(minLength: 4)
+                            Text("Line \(match.hit.line)")
+                                .font(.caption2.monospacedDigit())
+                                .foregroundStyle(.secondary)
+                                .layoutPriority(1)
+                        }
+                        .contentShape(Rectangle())
+                    }
+                    .buttonStyle(.plain)
+                }
+            } header: {
+                HStack(spacing: 6) {
+                    Text(result.document.name)
+                    if result.document.isActive == true {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundStyle(.blue)
+                            .accessibilityLabel(Text("Active"))
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var sidebarItems: some View {
             Label {
                 Text("System Hosts")
             } icon: {
@@ -417,14 +484,30 @@ struct MainWindowView: View {
                     groupHeader(group, index: groupIndex)
                 }
             }
+    }
+
+    private var sidebar: some View {
+        List(selection: $selection) {
+            if isSearching {
+                searchResultRows
+            } else {
+                sidebarItems
+            }
         }
         .listStyle(.sidebar)
+        .searchable(
+            text: $searchQuery, isPresented: $searchPresented, placement: .sidebar,
+            prompt: Text("Search all profiles")
+        )
+        .onReceive(NotificationCenter.default.publisher(for: .hostflipFindInAllProfiles)) { _ in
+            searchPresented = true
+        }
         .focused($sidebarHasFocus)
         .onKeyPress(.return) {
             toggleSelectedProfileActivation() ? .handled : .ignored
         }
         .overlay {
-            if presentation.showsEmptyState {
+            if presentation.showsEmptyState, !isSearching {
                 sidebarEmptyState
                     .offset(y: 24)
             }
@@ -1024,7 +1107,8 @@ struct MainWindowView: View {
             // Read-only for Base Hosts and for Remote Profiles alike: the former only changes
             // through drift reconciliation, the latter only through Refresh (ADR-0012).
             isEditable: profile?.isRemote == false,
-            documentID: profileID.map { AnyHashable($0) } ?? AnyHashable("base-hosts")
+            documentID: profileID.map { AnyHashable($0) } ?? AnyHashable("base-hosts"),
+            reveal: editorReveal
         )
         // Read here, in a View body, so the focus change re-renders and reaches the Edit menu (#86).
         .focusedSceneValue(\.isHostsEditorEditable, HostsEditorFocus.shared.isEditableEditorFocused)

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -185,6 +185,9 @@ struct MainWindowView: View {
     @State private var searchQuery = ""
     @State private var searchPresented = false
     @State private var editorReveal: EditorReveal?
+    /// Computed off the main thread per (query, documents): a keystroke must not rescan a
+    /// 90k-line Remote Profile synchronously (#94 scale).
+    @State private var searchResults = GlobalSearchResults.empty
     /// The profile pending deletion confirmation; a non-nil value shows the confirmation dialog.
     @State private var profilePendingDeletion: Profile?
     @State private var profilePendingNameFocus: Profile.ID?
@@ -371,7 +374,9 @@ struct MainWindowView: View {
         !searchQuery.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
     }
 
-    private var searchResults: GlobalSearchResults {
+    /// Every searchable document in sidebar order; System Hosts is the merge output, so its
+    /// hits are already attributable to one of these.
+    private var searchDocuments: [GlobalSearchResults.Document] {
         var documents = [GlobalSearchResults.Document(
             item: .baseHosts, name: String(localized: "Base Hosts"), content: store.baseHostsContent, isActive: nil
         )]
@@ -379,7 +384,16 @@ struct MainWindowView: View {
         documents += profiles.map {
             GlobalSearchResults.Document(item: .profile($0.id), name: $0.name, content: $0.content, isActive: store.isActive($0.id))
         }
-        return GlobalSearchResults(documents: documents, query: searchQuery)
+        return documents
+    }
+
+    private struct SearchRequest: Equatable {
+        let query: String
+        let documents: [GlobalSearchResults.Document]
+    }
+
+    private var searchRequest: SearchRequest? {
+        isSearching ? SearchRequest(query: searchQuery, documents: searchDocuments) : nil
     }
 
     /// Jumps to the matching line: the shared editor swaps the document, then reveals the range.
@@ -391,7 +405,7 @@ struct MainWindowView: View {
     @ViewBuilder
     private var searchResultRows: some View {
         let results = searchResults
-        if results.results.isEmpty {
+        if results.results.isEmpty, results.query == searchQuery.trimmingCharacters(in: .whitespacesAndNewlines) {
             Text("No Matches")
                 .foregroundStyle(.secondary)
                 .frame(maxWidth: .infinity, alignment: .center)
@@ -433,57 +447,57 @@ struct MainWindowView: View {
 
     @ViewBuilder
     private var sidebarItems: some View {
-            Label {
-                Text("System Hosts")
-            } icon: {
-                Image(systemName: "cpu")
-                    .foregroundStyle(.blue)
+        Label {
+            Text("System Hosts")
+        } icon: {
+            Image(systemName: "cpu")
+                .foregroundStyle(.blue)
+        }
+        .tag(SidebarItem.systemHosts)
+        Label("Base Hosts", systemImage: "lock.fill")
+            .tag(SidebarItem.baseHosts)
+        Section {
+            if !presentation.showsEmptyState {
+                ForEach(store.standaloneProfiles) { profile in
+                    sidebarProfileRow(
+                        profile,
+                        groupID: nil,
+                        index: store.standaloneProfiles.firstIndex(where: { $0.id == profile.id }) ?? 0
+                    )
+                }
             }
-            .tag(SidebarItem.systemHosts)
-            Label("Base Hosts", systemImage: "lock.fill")
-                .tag(SidebarItem.baseHosts)
+        } header: {
+            Text("Standalone Profiles")
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(Rectangle())
+                .modifier(sidebarDropTarget(.standaloneHeader))
+                .overlay {
+                    if sidebarDropFeedback == .profileContainer(nil) {
+                        containerDropIndicator
+                    }
+                }
+        }
+        ForEach(Array(store.groups.enumerated()), id: \.element.id) { groupIndex, group in
+            // Collapse is drawn by hand (conditional rows + own chevron): the native
+            // Section(isExpanded:) chevron fights the custom header's trailing
+            // controls and reflows them when collapsed.
             Section {
-                if !presentation.showsEmptyState {
-                    ForEach(store.standaloneProfiles) { profile in
+                if !collapsedGroups.contains(group.id) {
+                    ForEach(group.profiles) { profile in
                         sidebarProfileRow(
                             profile,
-                            groupID: nil,
-                            index: store.standaloneProfiles.firstIndex(where: { $0.id == profile.id }) ?? 0
+                            groupID: group.id,
+                            index: group.profiles.firstIndex(where: { $0.id == profile.id }) ?? 0
                         )
                     }
                 }
-            } header: {
-                Text("Standalone Profiles")
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .contentShape(Rectangle())
-                    .modifier(sidebarDropTarget(.standaloneHeader))
-                    .overlay {
-                        if sidebarDropFeedback == .profileContainer(nil) {
-                            containerDropIndicator
-                        }
-                    }
-            }
-            ForEach(Array(store.groups.enumerated()), id: \.element.id) { groupIndex, group in
-                // Collapse is drawn by hand (conditional rows + own chevron): the native
-                // Section(isExpanded:) chevron fights the custom header's trailing
-                // controls and reflows them when collapsed.
-                Section {
-                    if !collapsedGroups.contains(group.id) {
-                        ForEach(group.profiles) { profile in
-                            sidebarProfileRow(
-                                profile,
-                                groupID: group.id,
-                                index: group.profiles.firstIndex(where: { $0.id == profile.id }) ?? 0
-                            )
-                        }
-                    }
-                    if sidebarDropFeedback == .group(group.id, .after) {
-                        insertionDropIndicator
-                    }
-                } header: {
-                    groupHeader(group, index: groupIndex)
+                if sidebarDropFeedback == .group(group.id, .after) {
+                    insertionDropIndicator
                 }
+            } header: {
+                groupHeader(group, index: groupIndex)
             }
+        }
     }
 
     private var sidebar: some View {
@@ -502,9 +516,21 @@ struct MainWindowView: View {
         .onReceive(NotificationCenter.default.publisher(for: .hostflipFindInAllProfiles)) { _ in
             searchPresented = true
         }
+        .task(id: searchRequest) {
+            guard let request = searchRequest else {
+                searchResults = .empty
+                return
+            }
+            let results = await Task.detached(priority: .userInitiated) {
+                GlobalSearchResults(documents: request.documents, query: request.query)
+            }.value
+            guard !Task.isCancelled else { return }
+            searchResults = results
+        }
         .focused($sidebarHasFocus)
         .onKeyPress(.return) {
-            toggleSelectedProfileActivation() ? .handled : .ignored
+            // Result rows are buttons; Return must not toggle the profile selected underneath.
+            !isSearching && toggleSelectedProfileActivation() ? .handled : .ignored
         }
         .overlay {
             if presentation.showsEmptyState, !isSearching {

--- a/Sources/Hostflip/MainWindowView.swift
+++ b/Sources/Hostflip/MainWindowView.swift
@@ -511,7 +511,7 @@ struct MainWindowView: View {
         .listStyle(.sidebar)
         .searchable(
             text: $searchQuery, isPresented: $searchPresented, placement: .sidebar,
-            prompt: Text("Search all profiles")
+            prompt: Text("Search")
         )
         .onReceive(NotificationCenter.default.publisher(for: .hostflipFindInAllProfiles)) { _ in
             searchPresented = true

--- a/Sources/Hostflip/SearchCommands.swift
+++ b/Sources/Hostflip/SearchCommands.swift
@@ -1,0 +1,19 @@
+import SwiftUI
+
+extension Notification.Name {
+    /// Posted by the Edit menu to present the sidebar search field (#88).
+    static let hostflipFindInAllProfiles = Notification.Name("hostflip.findInAllProfiles")
+}
+
+/// Edit menu "Find in All Profiles…" (⌘⇧F, #88). ⌘F stays with the editor's own find bar;
+/// the global search lives in the sidebar, so the command only moves focus there.
+struct SearchCommands: Commands {
+    var body: some Commands {
+        CommandGroup(after: .textEditing) {
+            Button("Find in All Profiles…") {
+                NotificationCenter.default.post(name: .hostflipFindInAllProfiles, object: nil)
+            }
+            .keyboardShortcut("f", modifiers: [.command, .shift])
+        }
+    }
+}

--- a/Sources/HostflipCore/HostsSearch.swift
+++ b/Sources/HostflipCore/HostsSearch.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+/// Text search across hosts content (#88): case-insensitive substring, one hit per line so
+/// results read as "profile · line". Offsets are UTF-16 for the editor's text storage.
+public enum HostsSearch {
+    public struct Hit: Equatable, Sendable {
+        /// 1-based.
+        public let line: Int
+        /// The line without its terminator.
+        public let lineRange: NSRange
+        /// The first occurrence on the line.
+        public let matchRange: NSRange
+
+        public init(line: Int, lineRange: NSRange, matchRange: NSRange) {
+            self.line = line
+            self.lineRange = lineRange
+            self.matchRange = matchRange
+        }
+    }
+
+    public static func matches(in text: String, query: String) -> [Hit] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !needle.isEmpty else { return [] }
+        let ns = text as NSString
+        var hits: [Hit] = []
+        var lineNumber = 0
+        ns.enumerateSubstrings(
+            in: NSRange(location: 0, length: ns.length),
+            options: [.byLines, .substringNotRequired]
+        ) { _, lineRange, _, _ in
+            lineNumber += 1
+            let found = ns.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive], range: lineRange)
+            guard found.location != NSNotFound else { return }
+            hits.append(Hit(line: lineNumber, lineRange: lineRange, matchRange: found))
+        }
+        return hits
+    }
+}

--- a/Sources/HostflipCore/HostsSearch.swift
+++ b/Sources/HostflipCore/HostsSearch.swift
@@ -29,7 +29,7 @@ public enum HostsSearch {
             options: [.byLines, .substringNotRequired]
         ) { _, lineRange, _, _ in
             lineNumber += 1
-            let found = ns.range(of: needle, options: [.caseInsensitive, .diacriticInsensitive], range: lineRange)
+            let found = ns.range(of: needle, options: [.caseInsensitive], range: lineRange)
             guard found.location != NSNotFound else { return }
             hits.append(Hit(line: lineNumber, lineRange: lineRange, matchRange: found))
         }

--- a/Tests/HostflipCoreTests/HostsSearchTests.swift
+++ b/Tests/HostflipCoreTests/HostsSearchTests.swift
@@ -1,0 +1,28 @@
+import XCTest
+@testable import HostflipCore
+
+/// Global search (#88): case-insensitive substring matches, one hit per line.
+final class HostsSearchTests: XCTestCase {
+    func testReportsOneHitPerMatchingLineWithLineAndMatchRanges() {
+        let text = "127.0.0.1 api.example.com\n# api notes\n10.0.0.1 db.example.com api\n"
+        XCTAssertEqual(HostsSearch.matches(in: text, query: "api"), [
+            HostsSearch.Hit(line: 1, lineRange: NSRange(location: 0, length: 25), matchRange: NSRange(location: 10, length: 3)),
+            HostsSearch.Hit(line: 2, lineRange: NSRange(location: 26, length: 11), matchRange: NSRange(location: 28, length: 3)),
+            HostsSearch.Hit(line: 3, lineRange: NSRange(location: 38, length: 27), matchRange: NSRange(location: 62, length: 3)),
+        ])
+    }
+
+    func testMatchingIsCaseInsensitiveAndIgnoresSurroundingWhitespaceInTheQuery() {
+        XCTAssertEqual(HostsSearch.matches(in: "1.1.1.1 Example.COM", query: " example.com ").map(\.line), [1])
+    }
+
+    func testBlankQueryMatchesNothing() {
+        XCTAssertEqual(HostsSearch.matches(in: "1.1.1.1 a", query: ""), [])
+        XCTAssertEqual(HostsSearch.matches(in: "1.1.1.1 a", query: "   "), [])
+    }
+
+    func testLineRangeExcludesTheTerminator() {
+        let hits = HostsSearch.matches(in: "a\r\nb\n", query: "b")
+        XCTAssertEqual(hits, [HostsSearch.Hit(line: 2, lineRange: NSRange(location: 3, length: 1), matchRange: NSRange(location: 3, length: 1))])
+    }
+}

--- a/Tests/HostflipTests/GlobalSearchResultsTests.swift
+++ b/Tests/HostflipTests/GlobalSearchResultsTests.swift
@@ -49,6 +49,16 @@ final class GlobalSearchResultsTests: XCTestCase {
         XCTAssertEqual(match.lineText, "10.0.0.1\t\t  api.test   # dev")
     }
 
+    func testFoldingNeverSplitsASurrogatePair() {
+        let doc = GlobalSearchResults.Document(
+            item: .profile(Profile.ID("x")), name: "x", content: "# 🚀🚀🚀🚀🚀🚀🚀🚀 launch api.test", isActive: false
+        )
+        let match = GlobalSearchResults(documents: [doc], query: "api").results[0].matches[0]
+        XCTAssertTrue(match.displayText.hasPrefix("…"))
+        XCTAssertFalse(match.displayText.unicodeScalars.contains { $0.value == 0xFFFD })
+        XCTAssertTrue(match.displayText.hasSuffix("api.test"))
+    }
+
     func testBlankQueryYieldsNothing() {
         XCTAssertTrue(GlobalSearchResults(documents: [base, dev], query: "  ").results.isEmpty)
     }

--- a/Tests/HostflipTests/GlobalSearchResultsTests.swift
+++ b/Tests/HostflipTests/GlobalSearchResultsTests.swift
@@ -58,6 +58,15 @@ final class GlobalSearchResultsTests: XCTestCase {
         XCTAssertTrue(match.displayText.hasSuffix("api.test"))
     }
 
+    func testMatchesAreCappedPerDocumentWithTheRestCounted() {
+        let content = (1...250).map { "0.0.0.0 host\($0).example" }.joined(separator: "\n")
+        let doc = GlobalSearchResults.Document(item: .profile(Profile.ID("x")), name: "x", content: content, isActive: false)
+        let result = GlobalSearchResults(documents: [doc], query: "host").results[0]
+        XCTAssertEqual(result.matches.count, GlobalSearchResults.matchLimit)
+        XCTAssertEqual(result.matches.last?.hit.line, GlobalSearchResults.matchLimit)
+        XCTAssertEqual(result.hiddenMatchCount, 250 - GlobalSearchResults.matchLimit)
+    }
+
     func testBlankQueryYieldsNothing() {
         XCTAssertTrue(GlobalSearchResults(documents: [base, dev], query: "  ").results.isEmpty)
     }

--- a/Tests/HostflipTests/GlobalSearchResultsTests.swift
+++ b/Tests/HostflipTests/GlobalSearchResultsTests.swift
@@ -20,7 +20,6 @@ final class GlobalSearchResultsTests: XCTestCase {
         XCTAssertEqual(results.results.map(\.document.name), ["dev"])
         XCTAssertEqual(results.results[0].matches.map(\.lineText), ["10.0.0.1   api.test", "# api down"])
         XCTAssertEqual(results.results[0].matches.map(\.hit.line), [1, 2])
-        XCTAssertEqual(results.matchCount, 2)
     }
 
     func testBaseHostsTakesPartAndOrderFollowsTheSidebar() {

--- a/Tests/HostflipTests/GlobalSearchResultsTests.swift
+++ b/Tests/HostflipTests/GlobalSearchResultsTests.swift
@@ -1,0 +1,55 @@
+import HostflipCore
+import XCTest
+@testable import Hostflip
+
+/// Global search results (#88): documents in sidebar order, only those with matches, one row
+/// per matching line with the trimmed line text.
+final class GlobalSearchResultsTests: XCTestCase {
+    private let base = GlobalSearchResults.Document(
+        item: .baseHosts, name: "Base Hosts", content: "127.0.0.1 localhost\n", isActive: nil
+    )
+    private let dev = GlobalSearchResults.Document(
+        item: .profile(Profile.ID("dev")), name: "dev", content: "  10.0.0.1   api.test  \n# api down\n", isActive: true
+    )
+    private let prod = GlobalSearchResults.Document(
+        item: .profile(Profile.ID("prod")), name: "prod", content: "1.2.3.4 www.test", isActive: false
+    )
+
+    func testKeepsOnlyMatchingDocumentsInOrderWithTrimmedLines() {
+        let results = GlobalSearchResults(documents: [base, dev, prod], query: "api")
+        XCTAssertEqual(results.results.map(\.document.name), ["dev"])
+        XCTAssertEqual(results.results[0].matches.map(\.lineText), ["10.0.0.1   api.test", "# api down"])
+        XCTAssertEqual(results.results[0].matches.map(\.hit.line), [1, 2])
+        XCTAssertEqual(results.matchCount, 2)
+    }
+
+    func testBaseHostsTakesPartAndOrderFollowsTheSidebar() {
+        let results = GlobalSearchResults(documents: [base, dev, prod], query: "test")
+        XCTAssertEqual(results.results.map(\.document.name), ["dev", "prod"])
+        XCTAssertEqual(GlobalSearchResults(documents: [base, dev, prod], query: "localhost").results.map(\.document.name), ["Base Hosts"])
+    }
+
+    func testLongPrefixBeforeTheMatchFoldsIntoContext() {
+        let doc = GlobalSearchResults.Document(
+            item: .profile(Profile.ID("x")), name: "x",
+            content: "   185.199.109.133 avatars.githubusercontent.com\n0.0.0.0 github.com", isActive: false
+        )
+        let matches = GlobalSearchResults(documents: [doc], query: "github").results[0].matches
+        XCTAssertEqual(matches[0].lineText, "185.199.109.133 avatars.githubusercontent.com")
+        XCTAssertEqual(matches[0].displayText, "…rs.githubusercontent.com")
+        XCTAssertEqual(matches[1].displayText, "0.0.0.0 github.com")
+    }
+
+    func testDisplayTextCollapsesAlignmentWhitespace() {
+        let doc = GlobalSearchResults.Document(
+            item: .profile(Profile.ID("x")), name: "x", content: "10.0.0.1\t\t  api.test   # dev", isActive: false
+        )
+        let match = GlobalSearchResults(documents: [doc], query: "api").results[0].matches[0]
+        XCTAssertEqual(match.displayText, "10.0.0.1 api.test # dev")
+        XCTAssertEqual(match.lineText, "10.0.0.1\t\t  api.test   # dev")
+    }
+
+    func testBlankQueryYieldsNothing() {
+        XCTAssertTrue(GlobalSearchResults(documents: [base, dev], query: "  ").results.isEmpty)
+    }
+}


### PR DESCRIPTION
"Which profile has api.example.com, and is it active?" had no answer in the app once profiles piled up: the editor's find bar only covers the current document. This adds a global search.

- A search field at the top of the sidebar (Edit › Find in All Profiles…, ⌘⇧F) matches any text — hostname, IP, comment — across Base Hosts and every profile, case-insensitively, one result per line. Results are grouped by document in sidebar order with active profiles marked; picking a result switches the editor to that document and selects the line. ⌘F stays with the editor's own find bar.
- Matching runs off the main thread per (query, documents), and each document lists its first 100 matches with the rest counted, so a one-letter query over a 90k-line Remote Profile keeps typing smooth.
- Result rows fold a long prefix into "…" plus a little context so the match itself stays visible in the narrow sidebar.
- New copy is localized (ja / zh-Hans / zh-Hant).

Verified on device: grouping and active marks, jump-and-select, clearing the field restores the sidebar, repeated ⌘⇧F refocuses the field with the query kept, Return while searching leaves activation alone, and typing stays smooth with a 90k-line Remote Profile loaded.
