### PR TITLE
feat: report an issue from the app with a diagnostic report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,33 @@
+name: Bug report
+description: Something in hostflip did not behave as expected.
+labels: [bug]
+body:
+  - type: textarea
+    id: environment
+    attributes:
+      label: Environment
+      description: Prefilled by Help › Report an Issue… in the app; otherwise app version, macOS version, and how you installed.
+      render: text
+    validations:
+      required: true
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What you did, what you expected, and what happened instead.
+    validations:
+      required: true
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      placeholder: |
+        1.
+        2.
+        3.
+  - type: textarea
+    id: diagnostic-report
+    attributes:
+      label: Diagnostic report
+      description: Help › Copy Diagnostic Report in the app, then paste here. It contains versions, helper state, and counts only — no hosts content, profile names, or URLs.
+      render: text

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,23 @@
+name: Feature request
+description: Suggest an improvement or a new capability.
+labels: [enhancement]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: What are you trying to do
+      description: The situation or workflow this would help with.
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed change
+      description: How hostflip could support it. Rough is fine.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Workarounds you use today, or other ways this could be solved.

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -308,7 +308,5 @@
 /* Problem reporting */
 "Report an Issue…" = "問題を報告…";
 "Copy Diagnostic Report" = "診断レポートをコピー";
-"Copied" = "コピーしました";
 "Diagnostic report copied" = "診断レポートをコピーしました";
-"Paste it into the issue's Diagnostic report field." = "Issue の「Diagnostic report」欄に貼り付けてください。";
 "Support" = "サポート";

--- a/Packaging/Localization/ja.lproj/Localizable.strings
+++ b/Packaging/Localization/ja.lproj/Localizable.strings
@@ -304,3 +304,11 @@
 "No Matches" = "一致する項目はありません";
 "Line %lld" = "%lld 行目";
 "%lld more matches not shown" = "他 %lld 件は表示されていません";
+
+/* Problem reporting */
+"Report an Issue…" = "問題を報告…";
+"Copy Diagnostic Report" = "診断レポートをコピー";
+"Copied" = "コピーしました";
+"Diagnostic report copied" = "診断レポートをコピーしました";
+"Paste it into the issue's Diagnostic report field." = "Issue の「Diagnostic report」欄に貼り付けてください。";
+"Support" = "サポート";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -308,7 +308,5 @@
 /* Problem reporting */
 "Report an Issue…" = "报告问题…";
 "Copy Diagnostic Report" = "拷贝诊断报告";
-"Copied" = "已拷贝";
 "Diagnostic report copied" = "诊断报告已拷贝";
-"Paste it into the issue's Diagnostic report field." = "请将其粘贴到 issue 的“Diagnostic report”栏中。";
 "Support" = "支持";

--- a/Packaging/Localization/zh-Hans.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hans.lproj/Localizable.strings
@@ -304,3 +304,11 @@
 "No Matches" = "无匹配项";
 "Line %lld" = "第 %lld 行";
 "%lld more matches not shown" = "还有 %lld 条匹配未显示";
+
+/* Problem reporting */
+"Report an Issue…" = "报告问题…";
+"Copy Diagnostic Report" = "拷贝诊断报告";
+"Copied" = "已拷贝";
+"Diagnostic report copied" = "诊断报告已拷贝";
+"Paste it into the issue's Diagnostic report field." = "请将其粘贴到 issue 的“Diagnostic report”栏中。";
+"Support" = "支持";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -308,7 +308,5 @@
 /* Problem reporting */
 "Report an Issue…" = "回報問題…";
 "Copy Diagnostic Report" = "拷貝診斷報告";
-"Copied" = "已拷貝";
 "Diagnostic report copied" = "已拷貝診斷報告";
-"Paste it into the issue's Diagnostic report field." = "請將其貼到 issue 的「Diagnostic report」欄位中。";
 "Support" = "支援";

--- a/Packaging/Localization/zh-Hant.lproj/Localizable.strings
+++ b/Packaging/Localization/zh-Hant.lproj/Localizable.strings
@@ -304,3 +304,11 @@
 "No Matches" = "沒有相符項目";
 "Line %lld" = "第 %lld 行";
 "%lld more matches not shown" = "還有 %lld 筆相符項目未顯示";
+
+/* Problem reporting */
+"Report an Issue…" = "回報問題…";
+"Copy Diagnostic Report" = "拷貝診斷報告";
+"Copied" = "已拷貝";
+"Diagnostic report copied" = "已拷貝診斷報告";
+"Paste it into the issue's Diagnostic report field." = "請將其貼到 issue 的「Diagnostic report」欄位中。";
+"Support" = "支援";

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -44,8 +44,8 @@ struct ApplicationSettingsView: View {
                     Label("Command Line", systemImage: "terminal")
                 }
 
-            UpdatesSettingsView(updater: updater)
-                .frame(width: 500, height: 150, alignment: .top)
+            UpdatesSettingsView(updater: updater, store: store, maintenanceStore: maintenanceStore)
+                .frame(width: 500, height: 230, alignment: .top)
                 .tabItem {
                     Label("Updates", systemImage: "arrow.triangle.2.circlepath")
                 }
@@ -190,10 +190,15 @@ private struct GeneralSettingsView: View {
 /// automatic-check preference, this view only mirrors it.
 private struct UpdatesSettingsView: View {
     let updater: SPUUpdater
+    let store: WorkspaceStore
+    let maintenanceStore: MaintenanceStore
     @State private var automaticallyChecksForUpdates: Bool
+    @State private var reportCopiedAt: Date?
 
-    init(updater: SPUUpdater) {
+    init(updater: SPUUpdater, store: WorkspaceStore, maintenanceStore: MaintenanceStore) {
         self.updater = updater
+        self.store = store
+        self.maintenanceStore = maintenanceStore
         automaticallyChecksForUpdates = updater.automaticallyChecksForUpdates
     }
 
@@ -210,6 +215,31 @@ private struct UpdatesSettingsView: View {
                 }
 
             CheckForUpdatesButton(updater: updater)
+
+            // Problem reporting (#90) sits with updates: both are "something is off" entries.
+            LabeledContent("Support") {
+                VStack(alignment: .leading, spacing: 8) {
+                    Button("Report an Issue…") {
+                        ProblemReporting.openNewIssue(store: store, maintenanceStore: maintenanceStore)
+                    }
+                    HStack(spacing: 8) {
+                        Button("Copy Diagnostic Report") {
+                            ProblemReporting.copyReport(store: store, maintenanceStore: maintenanceStore)
+                            reportCopiedAt = .now
+                        }
+                        if reportCopiedAt != nil {
+                            Text("Copied")
+                                .foregroundStyle(.secondary)
+                                .transition(.opacity)
+                        }
+                    }
+                }
+            }
+            .task(id: reportCopiedAt) {
+                guard reportCopiedAt != nil else { return }
+                try? await Task.sleep(for: .seconds(2))
+                reportCopiedAt = nil
+            }
         }
         .padding(20)
     }

--- a/Sources/Hostflip/ApplicationSettingsView.swift
+++ b/Sources/Hostflip/ApplicationSettingsView.swift
@@ -193,7 +193,7 @@ private struct UpdatesSettingsView: View {
     let store: WorkspaceStore
     let maintenanceStore: MaintenanceStore
     @State private var automaticallyChecksForUpdates: Bool
-    @State private var reportCopiedAt: Date?
+    @State private var isShowingReportCopied = false
 
     init(updater: SPUUpdater, store: WorkspaceStore, maintenanceStore: MaintenanceStore) {
         self.updater = updater
@@ -222,23 +222,16 @@ private struct UpdatesSettingsView: View {
                     Button("Report an Issue…") {
                         ProblemReporting.openNewIssue(store: store, maintenanceStore: maintenanceStore)
                     }
-                    HStack(spacing: 8) {
-                        Button("Copy Diagnostic Report") {
-                            ProblemReporting.copyReport(store: store, maintenanceStore: maintenanceStore)
-                            reportCopiedAt = .now
-                        }
-                        if reportCopiedAt != nil {
-                            Text("Copied")
-                                .foregroundStyle(.secondary)
-                                .transition(.opacity)
+                    Button(isShowingReportCopied ? "Copied" : "Copy Diagnostic Report") {
+                        ProblemReporting.copyReport(store: store, maintenanceStore: maintenanceStore)
+                        isShowingReportCopied = true
+                        Task {
+                            try? await Task.sleep(for: .seconds(1.5))
+                            isShowingReportCopied = false
                         }
                     }
+                    .disabled(isShowingReportCopied)
                 }
-            }
-            .task(id: reportCopiedAt) {
-                guard reportCopiedAt != nil else { return }
-                try? await Task.sleep(for: .seconds(2))
-                reportCopiedAt = nil
             }
         }
         .padding(20)

--- a/Sources/Hostflip/DiagnosticReport.swift
+++ b/Sources/Hostflip/DiagnosticReport.swift
@@ -1,0 +1,104 @@
+import Foundation
+import HostflipXPC
+
+/// What a problem report needs and nothing more (#90): versions, environment, helper state,
+/// and counts. No profile names, Source URLs, hosts lines, or paths beyond the app's own
+/// can enter — the type has no fields for them.
+struct DiagnosticSnapshot: Equatable {
+    enum InstallSource: Equatable {
+        case homebrewCask
+        case direct
+    }
+
+    struct RemoteFreshness: Equatable {
+        /// Seconds since the last successful refresh; nil when it never succeeded.
+        var lastSuccessAge: TimeInterval?
+        var lastAttemptFailed: Bool
+    }
+
+    var appVersion: String
+    var build: String
+    var macOSVersion: String
+    var architecture: String
+    var installSource: InstallSource
+    var helperStatus: DaemonRegistrationStatus?
+    var isPaused: Bool
+    var hasHostsDrift: Bool
+    var groupCount: Int
+    var profileCount: Int
+    var activeProfileCount: Int
+    var remoteFreshness: [RemoteFreshness]
+}
+
+/// Renders the snapshot as plain text for the clipboard and as the prefilled new-issue URL.
+/// The text is English only on purpose: it is pasted into an English issue tracker, and a
+/// localized report would have to be translated back by whoever reads it.
+enum DiagnosticReport {
+    static let newIssueURL = URL(string: "https://github.com/heronapp/hostflip/issues/new")!
+    static let bugTemplate = "bug_report.yml"
+
+    /// The lines the bug form's Environment field asks for; also the head of the full report.
+    static func environment(for snapshot: DiagnosticSnapshot) -> String {
+        """
+        hostflip \(snapshot.appVersion) (\(snapshot.build))
+        macOS: \(snapshot.macOSVersion) (\(snapshot.architecture))
+        Install source: \(label(snapshot.installSource))
+        Helper: \(snapshot.helperStatus?.rawValue ?? "unknown")
+        """
+    }
+
+    static func text(for snapshot: DiagnosticSnapshot) -> String {
+        var lines = [
+            "hostflip \(snapshot.appVersion) (\(snapshot.build)) diagnostic report",
+            "macOS: \(snapshot.macOSVersion) (\(snapshot.architecture))",
+            "Install source: \(label(snapshot.installSource))",
+            "Helper: \(snapshot.helperStatus?.rawValue ?? "unknown")",
+            "Paused: \(yesNo(snapshot.isPaused))",
+            "Hosts drift detected: \(yesNo(snapshot.hasHostsDrift))",
+            "Groups: \(snapshot.groupCount)",
+            "Profiles: \(snapshot.profileCount) (active: \(snapshot.activeProfileCount), remote: \(snapshot.remoteFreshness.count))",
+        ]
+        for (index, remote) in snapshot.remoteFreshness.enumerated() {
+            let success = remote.lastSuccessAge.map { "last success \(age($0)) ago" } ?? "never refreshed"
+            lines.append("Remote profile \(index + 1): \(success), last attempt failed: \(yesNo(remote.lastAttemptFailed))")
+        }
+        return lines.joined(separator: "\n")
+    }
+
+    static func issueURL(for snapshot: DiagnosticSnapshot) -> URL {
+        var components = URLComponents(url: newIssueURL, resolvingAgainstBaseURL: false)!
+        components.queryItems = [
+            URLQueryItem(name: "template", value: bugTemplate),
+            URLQueryItem(name: "environment", value: environment(for: snapshot)),
+        ]
+        // URLComponents leaves "+" and newlines' neighbours alone; GitHub reads a fully
+        // percent-encoded query, so encode everything outside the unreserved set.
+        components.percentEncodedQuery = components.queryItems!.map { item in
+            "\(item.name)=\(item.value!.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed)!)"
+        }.joined(separator: "&")
+        return components.url!
+    }
+
+    private static func label(_ source: DiagnosticSnapshot.InstallSource) -> String {
+        switch source {
+        case .homebrewCask: "Homebrew cask"
+        case .direct: "direct download"
+        }
+    }
+
+    private static func yesNo(_ value: Bool) -> String { value ? "yes" : "no" }
+
+    /// Coarse "1h 30m" style; a report needs the order of magnitude, not the second.
+    private static func age(_ seconds: TimeInterval) -> String {
+        let total = Int(seconds)
+        let days = total / 86_400, hours = total % 86_400 / 3_600, minutes = total % 3_600 / 60
+        if days > 0 { return "\(days)d \(hours)h" }
+        if hours > 0 { return "\(hours)h \(minutes)m" }
+        return "\(minutes)m"
+    }
+}
+
+private extension CharacterSet {
+    /// RFC 3986 unreserved characters: everything else is percent-encoded in query values.
+    static let urlQueryValueAllowed = CharacterSet(charactersIn: "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-._~")
+}

--- a/Sources/Hostflip/DiagnosticReport.swift
+++ b/Sources/Hostflip/DiagnosticReport.swift
@@ -13,6 +13,8 @@ struct DiagnosticSnapshot: Equatable {
     struct RemoteFreshness: Equatable {
         /// Seconds since the last successful refresh; nil when it never succeeded.
         var lastSuccessAge: TimeInterval?
+        /// The workspace only records that the latest attempt failed, not why (the reason is
+        /// shown live, never persisted), and the report must not add persisted data.
         var lastAttemptFailed: Bool
     }
 
@@ -71,10 +73,11 @@ enum DiagnosticReport {
             URLQueryItem(name: "template", value: bugTemplate),
             URLQueryItem(name: "environment", value: environment(for: snapshot)),
         ]
-        // URLComponents leaves "+" and newlines' neighbours alone; GitHub reads a fully
-        // percent-encoded query, so encode everything outside the unreserved set.
+        // URLComponents keeps "+", "&", and "=" literal inside values; encode everything
+        // outside the unreserved set so the multi-line block survives GitHub's query parsing.
         components.percentEncodedQuery = components.queryItems!.map { item in
-            "\(item.name)=\(item.value!.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed)!)"
+            let value = item.value ?? ""
+            return "\(item.name)=\(value.addingPercentEncoding(withAllowedCharacters: .urlQueryValueAllowed) ?? "")"
         }.joined(separator: "&")
         return components.url!
     }

--- a/Sources/Hostflip/DiagnosticReport.swift
+++ b/Sources/Hostflip/DiagnosticReport.swift
@@ -41,20 +41,22 @@ enum DiagnosticReport {
 
     /// The lines the bug form's Environment field asks for; also the head of the full report.
     static func environment(for snapshot: DiagnosticSnapshot) -> String {
-        """
-        hostflip \(snapshot.appVersion) (\(snapshot.build))
-        macOS: \(snapshot.macOSVersion) (\(snapshot.architecture))
-        Install source: \(label(snapshot.installSource))
-        Helper: \(snapshot.helperStatus?.rawValue ?? "unknown")
-        """
+        environmentLines(for: snapshot).joined(separator: "\n")
     }
 
-    static func text(for snapshot: DiagnosticSnapshot) -> String {
-        var lines = [
-            "hostflip \(snapshot.appVersion) (\(snapshot.build)) diagnostic report",
+    private static func environmentLines(for snapshot: DiagnosticSnapshot) -> [String] {
+        [
+            "hostflip \(snapshot.appVersion) (\(snapshot.build))",
             "macOS: \(snapshot.macOSVersion) (\(snapshot.architecture))",
             "Install source: \(label(snapshot.installSource))",
             "Helper: \(snapshot.helperStatus?.rawValue ?? "unknown")",
+        ]
+    }
+
+    static func text(for snapshot: DiagnosticSnapshot) -> String {
+        var lines = environmentLines(for: snapshot)
+        lines[0] += " diagnostic report" // the heading line makes a pasted block recognisable
+        lines += [
             "Paused: \(yesNo(snapshot.isPaused))",
             "Hosts drift detected: \(yesNo(snapshot.hasHostsDrift))",
             "Groups: \(snapshot.groupCount)",

--- a/Sources/Hostflip/DiagnosticSnapshot+Current.swift
+++ b/Sources/Hostflip/DiagnosticSnapshot+Current.swift
@@ -17,7 +17,7 @@ extension DiagnosticSnapshot {
             build: info["CFBundleVersion"] as? String ?? "unknown",
             macOSVersion: "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)",
             architecture: architecture,
-            installSource: installSource(bundleURL: Bundle.main.bundleURL),
+            installSource: installSource(),
             helperStatus: maintenanceStore.helperStatus,
             isPaused: store.isPaused,
             hasHostsDrift: store.hasHostsDrift,
@@ -41,17 +41,14 @@ extension DiagnosticSnapshot {
         #endif
     }
 
-    /// Best effort: the cask installs into /Applications and leaves its Caskroom entry behind;
-    /// anything else counts as a direct download.
+    /// Best effort: the cask leaves its Caskroom entry behind (Apple silicon and Intel
+    /// prefixes). The app's own location is not consulted — `brew --appdir` can put it
+    /// anywhere — so anything without an entry counts as a direct download.
     static let caskrooms = ["/opt/homebrew/Caskroom/hostflip", "/usr/local/Caskroom/hostflip"]
 
     static func installSource(
-        bundleURL: URL, caskrooms: [String] = caskrooms, fileManager: FileManager = .default
+        caskrooms: [String] = caskrooms, fileManager: FileManager = .default
     ) -> InstallSource {
-        let inApplications = bundleURL.deletingLastPathComponent().path == "/Applications"
-        if inApplications, caskrooms.contains(where: { fileManager.fileExists(atPath: $0) }) {
-            return .homebrewCask
-        }
-        return .direct
+        caskrooms.contains(where: { fileManager.fileExists(atPath: $0) }) ? .homebrewCask : .direct
     }
 }

--- a/Sources/Hostflip/DiagnosticSnapshot+Current.swift
+++ b/Sources/Hostflip/DiagnosticSnapshot+Current.swift
@@ -1,0 +1,54 @@
+import AppKit
+import Foundation
+import HostflipCore
+
+extension DiagnosticSnapshot {
+    /// The live snapshot from state the app already holds — read-only, no workspace access,
+    /// and usable while the helper is unapproved or the app is paused (#90).
+    @MainActor
+    static func current(store: WorkspaceStore, maintenanceStore: MaintenanceStore, now: Date = .now) -> DiagnosticSnapshot {
+        let info = Bundle.main.infoDictionary ?? [:]
+        let os = ProcessInfo.processInfo.operatingSystemVersion
+        let profiles = store.standaloneProfiles + store.groups.flatMap(\.profiles)
+        return DiagnosticSnapshot(
+            appVersion: info["CFBundleShortVersionString"] as? String ?? "unknown",
+            build: info["CFBundleVersion"] as? String ?? "unknown",
+            macOSVersion: "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)",
+            architecture: architecture,
+            installSource: installSource(bundleURL: Bundle.main.bundleURL),
+            helperStatus: maintenanceStore.helperStatus,
+            isPaused: store.isPaused,
+            hasHostsDrift: store.hasHostsDrift,
+            groupCount: store.groups.count,
+            profileCount: profiles.count,
+            activeProfileCount: profiles.filter { store.isActive($0.id) }.count,
+            remoteFreshness: store.remoteProfiles.map { profile in
+                RemoteFreshness(
+                    lastSuccessAge: profile.remoteRefreshState?.lastSuccessAt.map { now.timeIntervalSince($0) },
+                    lastAttemptFailed: profile.remoteRefreshState?.lastAttemptFailed ?? false
+                )
+            }
+        )
+    }
+
+    private static var architecture: String {
+        #if arch(arm64)
+        "arm64"
+        #else
+        "x86_64"
+        #endif
+    }
+
+    /// Best effort: the cask installs into /Applications and leaves its Caskroom entry behind;
+    /// anything else counts as a direct download.
+    static func installSource(
+        bundleURL: URL, fileManager: FileManager = .default
+    ) -> InstallSource {
+        let caskrooms = ["/opt/homebrew/Caskroom/hostflip", "/usr/local/Caskroom/hostflip"]
+        let inApplications = bundleURL.deletingLastPathComponent().path == "/Applications"
+        if inApplications, caskrooms.contains(where: { fileManager.fileExists(atPath: $0) }) {
+            return .homebrewCask
+        }
+        return .direct
+    }
+}

--- a/Sources/Hostflip/DiagnosticSnapshot+Current.swift
+++ b/Sources/Hostflip/DiagnosticSnapshot+Current.swift
@@ -1,6 +1,7 @@
 import AppKit
 import Foundation
 import HostflipCore
+import HostflipXPC
 
 extension DiagnosticSnapshot {
     /// The live snapshot from state the app already holds — read-only, no workspace access,
@@ -11,7 +12,8 @@ extension DiagnosticSnapshot {
         let os = ProcessInfo.processInfo.operatingSystemVersion
         let profiles = store.standaloneProfiles + store.groups.flatMap(\.profiles)
         return DiagnosticSnapshot(
-            appVersion: info["CFBundleShortVersionString"] as? String ?? "unknown",
+            // A bare `swift run` binary has no Info.plist; the compiled-in version still applies.
+            appVersion: info["CFBundleShortVersionString"] as? String ?? HostflipBuild.version,
             build: info["CFBundleVersion"] as? String ?? "unknown",
             macOSVersion: "\(os.majorVersion).\(os.minorVersion).\(os.patchVersion)",
             architecture: architecture,
@@ -41,10 +43,11 @@ extension DiagnosticSnapshot {
 
     /// Best effort: the cask installs into /Applications and leaves its Caskroom entry behind;
     /// anything else counts as a direct download.
+    static let caskrooms = ["/opt/homebrew/Caskroom/hostflip", "/usr/local/Caskroom/hostflip"]
+
     static func installSource(
-        bundleURL: URL, fileManager: FileManager = .default
+        bundleURL: URL, caskrooms: [String] = caskrooms, fileManager: FileManager = .default
     ) -> InstallSource {
-        let caskrooms = ["/opt/homebrew/Caskroom/hostflip", "/usr/local/Caskroom/hostflip"]
         let inApplications = bundleURL.deletingLastPathComponent().path == "/Applications"
         if inApplications, caskrooms.contains(where: { fileManager.fileExists(atPath: $0) }) {
             return .homebrewCask

--- a/Sources/Hostflip/HostflipApp.swift
+++ b/Sources/Hostflip/HostflipApp.swift
@@ -90,6 +90,7 @@ struct HostflipApp: App {
             RemoteRefreshCommands(store: store)
             EditorCommands()
             SearchCommands()
+            ReportIssueCommands(store: store, maintenanceStore: maintenanceStore)
         }
 
         Settings {

--- a/Sources/Hostflip/ReportIssueCommands.swift
+++ b/Sources/Hostflip/ReportIssueCommands.swift
@@ -16,12 +16,9 @@ struct ReportIssueCommands: Commands {
             }
             Button("Copy Diagnostic Report") {
                 ProblemReporting.copyReport(store: store, maintenanceStore: maintenanceStore)
-                // A menu action has no surface of its own for feedback; the settings pane
-                // shows its confirmation inline instead.
-                let alert = NSAlert()
-                alert.messageText = String(localized: "Diagnostic report copied")
-                alert.informativeText = String(localized: "Paste it into the issue's Diagnostic report field.")
-                alert.runModal()
+                // A menu action has no surface of its own; a short floating notice beats a
+                // modal alert for a clipboard write.
+                TransientNotice.show(String(localized: "Diagnostic report copied"))
             }
         }
     }
@@ -39,5 +36,63 @@ enum ProblemReporting {
         let pasteboard = NSPasteboard.general
         pasteboard.clearContents()
         pasteboard.setString(DiagnosticReport.text(for: snapshot), forType: .string)
+    }
+}
+
+/// A small non-activating panel that fades out on its own — feedback for actions fired from
+/// the menu bar, where there may not even be a key window to attach a sheet to.
+@MainActor
+enum TransientNotice {
+    private static var panel: NSPanel?
+
+    static func show(_ message: String, for duration: Duration = .seconds(1.5)) {
+        panel?.close()
+        let label = NSTextField(labelWithString: message)
+        label.font = .systemFont(ofSize: NSFont.systemFontSize, weight: .medium)
+        label.alignment = .center
+        let content = NSVisualEffectView()
+        content.material = .hudWindow
+        content.blendingMode = .behindWindow
+        content.state = .active
+        content.wantsLayer = true
+        content.layer?.cornerRadius = 10
+        content.addSubview(label)
+        label.translatesAutoresizingMaskIntoConstraints = false
+        NSLayoutConstraint.activate([
+            label.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 18),
+            label.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -18),
+            label.topAnchor.constraint(equalTo: content.topAnchor, constant: 12),
+            label.bottomAnchor.constraint(equalTo: content.bottomAnchor, constant: -12),
+        ])
+        let panel = NSPanel(
+            contentRect: .zero, styleMask: [.borderless, .nonactivatingPanel], backing: .buffered, defer: false
+        )
+        panel.isFloatingPanel = true
+        panel.level = .statusBar
+        panel.isOpaque = false
+        panel.backgroundColor = .clear
+        panel.hasShadow = true
+        panel.contentView = content
+        panel.setContentSize(content.fittingSize)
+        if let screen = NSScreen.main {
+            let frame = screen.visibleFrame
+            panel.setFrameOrigin(NSPoint(
+                x: frame.midX - panel.frame.width / 2,
+                y: frame.maxY - panel.frame.height - 40
+            ))
+        }
+        panel.orderFrontRegardless()
+        self.panel = panel
+        Task {
+            try? await Task.sleep(for: duration)
+            guard self.panel === panel else { return }
+            NSAnimationContext.runAnimationGroup { context in
+                context.duration = 0.25
+                panel.animator().alphaValue = 0
+            } completionHandler: {
+                panel.close()
+                if self.panel === panel { self.panel = nil }
+            }
+        }
     }
 }

--- a/Sources/Hostflip/ReportIssueCommands.swift
+++ b/Sources/Hostflip/ReportIssueCommands.swift
@@ -1,0 +1,43 @@
+import AppKit
+import SwiftUI
+
+/// Help menu "Report an Issue…" and "Copy Diagnostic Report" (#90). Both are read-only and
+/// need neither the helper nor an unpaused app; the report never leaves the machine unless
+/// the user pastes it.
+struct ReportIssueCommands: Commands {
+    let store: WorkspaceStore
+    let maintenanceStore: MaintenanceStore
+
+    var body: some Commands {
+        CommandGroup(after: .help) {
+            Divider()
+            Button("Report an Issue…") {
+                ProblemReporting.openNewIssue(store: store, maintenanceStore: maintenanceStore)
+            }
+            Button("Copy Diagnostic Report") {
+                ProblemReporting.copyReport(store: store, maintenanceStore: maintenanceStore)
+                // A menu action has no surface of its own for feedback; the settings pane
+                // shows its confirmation inline instead.
+                let alert = NSAlert()
+                alert.messageText = String(localized: "Diagnostic report copied")
+                alert.informativeText = String(localized: "Paste it into the issue's Diagnostic report field.")
+                alert.runModal()
+            }
+        }
+    }
+}
+
+@MainActor
+enum ProblemReporting {
+    static func openNewIssue(store: WorkspaceStore, maintenanceStore: MaintenanceStore) {
+        let snapshot = DiagnosticSnapshot.current(store: store, maintenanceStore: maintenanceStore)
+        NSWorkspace.shared.open(DiagnosticReport.issueURL(for: snapshot))
+    }
+
+    static func copyReport(store: WorkspaceStore, maintenanceStore: MaintenanceStore) {
+        let snapshot = DiagnosticSnapshot.current(store: store, maintenanceStore: maintenanceStore)
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(DiagnosticReport.text(for: snapshot), forType: .string)
+    }
+}

--- a/Tests/HostflipTests/DiagnosticReportTests.swift
+++ b/Tests/HostflipTests/DiagnosticReportTests.swift
@@ -70,14 +70,11 @@ final class DiagnosticReportTests: XCTestCase {
         XCTAssertTrue(DiagnosticReport.text(for: unknown).contains("Install source: direct download"))
     }
 
-    func testInstallSourceNeedsBothTheApplicationsFolderAndACaskroomEntry() throws {
+    func testInstallSourceFollowsTheCaskroomEntry() throws {
         let caskroom = FileManager.default.temporaryDirectory.appendingPathComponent("Caskroom-\(UUID().uuidString)")
         try FileManager.default.createDirectory(at: caskroom, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: caskroom) }
-        let inApplications = URL(fileURLWithPath: "/Applications/Hostflip.app")
-        XCTAssertEqual(DiagnosticSnapshot.installSource(bundleURL: inApplications, caskrooms: [caskroom.path]), .homebrewCask)
-        XCTAssertEqual(DiagnosticSnapshot.installSource(bundleURL: inApplications, caskrooms: ["/nonexistent/Caskroom"]), .direct)
-        let elsewhere = URL(fileURLWithPath: "/Users/someone/Downloads/Hostflip.app")
-        XCTAssertEqual(DiagnosticSnapshot.installSource(bundleURL: elsewhere, caskrooms: [caskroom.path]), .direct)
+        XCTAssertEqual(DiagnosticSnapshot.installSource(caskrooms: [caskroom.path]), .homebrewCask)
+        XCTAssertEqual(DiagnosticSnapshot.installSource(caskrooms: ["/nonexistent/Caskroom"]), .direct)
     }
 }

--- a/Tests/HostflipTests/DiagnosticReportTests.swift
+++ b/Tests/HostflipTests/DiagnosticReportTests.swift
@@ -1,0 +1,72 @@
+import HostflipXPC
+import XCTest
+@testable import Hostflip
+
+/// The report and the prefilled issue URL (#90) from a fixed snapshot: exact text, exact
+/// encoding, and nothing user-identifying — the snapshot deliberately has no room for
+/// profile names, Source URLs, or hosts lines.
+final class DiagnosticReportTests: XCTestCase {
+    private let snapshot = DiagnosticSnapshot(
+        appVersion: "0.4.0",
+        build: "13",
+        macOSVersion: "15.6.1",
+        architecture: "arm64",
+        installSource: .homebrewCask,
+        helperStatus: .requiresApproval,
+        isPaused: true,
+        hasHostsDrift: false,
+        groupCount: 2,
+        profileCount: 7,
+        activeProfileCount: 3,
+        remoteFreshness: [
+            .init(lastSuccessAge: 5_400, lastAttemptFailed: false),
+            .init(lastSuccessAge: nil, lastAttemptFailed: true),
+        ]
+    )
+
+    func testReportTextMatchesTheFixture() {
+        XCTAssertEqual(DiagnosticReport.text(for: snapshot), """
+            hostflip 0.4.0 (13) diagnostic report
+            macOS: 15.6.1 (arm64)
+            Install source: Homebrew cask
+            Helper: requiresApproval
+            Paused: yes
+            Hosts drift detected: no
+            Groups: 2
+            Profiles: 7 (active: 3, remote: 2)
+            Remote profile 1: last success 1h 30m ago, last attempt failed: no
+            Remote profile 2: never refreshed, last attempt failed: yes
+            """)
+    }
+
+    func testEnvironmentBlockIsTheHeadOfTheReport() {
+        XCTAssertEqual(DiagnosticReport.environment(for: snapshot), """
+            hostflip 0.4.0 (13)
+            macOS: 15.6.1 (arm64)
+            Install source: Homebrew cask
+            Helper: requiresApproval
+            """)
+    }
+
+    func testIssueURLTargetsTheBugFormWithThePercentEncodedEnvironment() throws {
+        let url = DiagnosticReport.issueURL(for: snapshot)
+        let components = try XCTUnwrap(URLComponents(url: url, resolvingAgainstBaseURL: false))
+        XCTAssertEqual(components.scheme, "https")
+        XCTAssertEqual(components.host, "github.com")
+        XCTAssertEqual(components.path, "/heronapp/hostflip/issues/new")
+        let items = Dictionary(uniqueKeysWithValues: (components.queryItems ?? []).map { ($0.name, $0.value) })
+        XCTAssertEqual(items["template"], "bug_report.yml")
+        XCTAssertEqual(items["environment"], DiagnosticReport.environment(for: snapshot))
+        // Query strings must not carry raw newlines or spaces.
+        XCTAssertFalse(url.absoluteString.contains("\n"))
+        XCTAssertFalse(url.absoluteString.contains(" "))
+    }
+
+    func testUnknownStatesReadAsSuch() {
+        var unknown = snapshot
+        unknown.helperStatus = nil
+        unknown.installSource = .direct
+        XCTAssertTrue(DiagnosticReport.text(for: unknown).contains("Helper: unknown"))
+        XCTAssertTrue(DiagnosticReport.text(for: unknown).contains("Install source: direct download"))
+    }
+}

--- a/Tests/HostflipTests/DiagnosticReportTests.swift
+++ b/Tests/HostflipTests/DiagnosticReportTests.swift
@@ -69,4 +69,15 @@ final class DiagnosticReportTests: XCTestCase {
         XCTAssertTrue(DiagnosticReport.text(for: unknown).contains("Helper: unknown"))
         XCTAssertTrue(DiagnosticReport.text(for: unknown).contains("Install source: direct download"))
     }
+
+    func testInstallSourceNeedsBothTheApplicationsFolderAndACaskroomEntry() throws {
+        let caskroom = FileManager.default.temporaryDirectory.appendingPathComponent("Caskroom-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: caskroom, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: caskroom) }
+        let inApplications = URL(fileURLWithPath: "/Applications/Hostflip.app")
+        XCTAssertEqual(DiagnosticSnapshot.installSource(bundleURL: inApplications, caskrooms: [caskroom.path]), .homebrewCask)
+        XCTAssertEqual(DiagnosticSnapshot.installSource(bundleURL: inApplications, caskrooms: ["/nonexistent/Caskroom"]), .direct)
+        let elsewhere = URL(fileURLWithPath: "/Users/someone/Downloads/Hostflip.app")
+        XCTAssertEqual(DiagnosticSnapshot.installSource(bundleURL: elsewhere, caskrooms: [caskroom.path]), .direct)
+    }
 }


### PR DESCRIPTION
There was no in-app way to reach the issue tracker, and nothing exposed the version, helper state, or workspace shape in a form a user could paste. This adds both, without telemetry.

- **Report an Issue…** (Help menu, and the Updates settings pane) opens this repository's bug form with the Environment field prefilled: app version and build, macOS version and chip, install source (Homebrew cask vs. direct, by the Caskroom entry), helper status.
- **Copy Diagnostic Report** puts a plain-text block on the clipboard: the environment lines plus paused / drift flags, group and profile counts (active, remote), and per-Remote-Profile freshness (last success age, whether the last attempt failed). The snapshot type has no fields for profile names, Source URLs, hosts lines, or paths, so none can leak; the report is English only because it lands in an English tracker.
- Both actions are read-only, work while the helper is unapproved or the app is paused, and make no network call beyond opening the browser. The menu action confirms with a short floating notice; the settings button flips its title to "Copied".
- `.github/ISSUE_TEMPLATE/` gains a bug report form (Environment, What happened, Steps to reproduce, Diagnostic report) and a feature request form.

Verified on device: menu and settings entries, the copied report's content, the floating confirmation, and both actions while paused and with the helper unapproved.
