### PR TITLE
build: bump version to 0.5.0

### DIFF
--- a/Packaging/HostflipApp-Info.plist
+++ b/Packaging/HostflipApp-Info.plist
@@ -24,9 +24,9 @@
 	<key>CFBundlePackageType</key>
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
-	<string>0.4.0</string>
+	<string>0.5.0</string>
 	<key>CFBundleVersion</key>
-	<string>13</string>
+	<string>14</string>
 	<key>LSMinimumSystemVersion</key>
 	<string>14.0</string>
 	<key>LSUIElement</key>

--- a/Packaging/ReleaseNotes/0.5.0.html
+++ b/Packaging/ReleaseNotes/0.5.0.html
@@ -1,0 +1,8 @@
+<h2>What's New</h2>
+<ul>
+  <li><b>Search every profile.</b> A search field at the top of the sidebar (Edit › Find in All Profiles…, ⌘⇧F) finds a hostname, IP, or any text across Base Hosts and all your profiles, grouped by profile with the active ones marked. Pick a result to jump straight to that line.</li>
+  <li><b>Toggle Comment.</b> ⌘/ comments or uncomments the current line or every selected line, as one undoable step — no more typing <code>#</code> by hand to switch a mapping off.</li>
+  <li><b>Incomplete lines are flagged.</b> A line with an IP but no hostname (or a lone word) gets a warning marker in the line-number gutter with an explanation on hover. Saving is never blocked; the marker just tells you the entry will not take effect.</li>
+  <li><b>Smooth with very large profiles.</b> Remote Profiles with tens of thousands of lines now open instantly and scroll without stutter. Long lines wrap in the editor instead of scrolling sideways.</li>
+  <li><b>Report an issue from the app.</b> Help › Report an Issue… opens a prefilled bug report, and Copy Diagnostic Report puts your versions, helper state, and profile counts on the clipboard — never your hosts content, profile names, or URLs.</li>
+</ul>

--- a/Sources/HostflipXPC/ChannelIdentity.swift
+++ b/Sources/HostflipXPC/ChannelIdentity.swift
@@ -16,5 +16,5 @@ public enum ChannelIdentity {
 
 public enum HostflipBuild {
     /// Kept in sync with CFBundleShortVersionString in Packaging/HostflipApp-Info.plist.
-    public static let version = "0.4.0"
+    public static let version = "0.5.0"
 }


### PR DESCRIPTION
Release notes for 0.5.0 (global search, Toggle Comment, incomplete-line markers, large-profile performance with soft wrapping, in-app issue reporting) and the version bump to 0.5.0 / build 14.